### PR TITLE
docs: update readme with go install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,21 @@ Test with these commands; in the project dir run:
 1. `go build`
 2. `./world create myproject`
 
-## Install Pre-compiled Binaries
+## Installation
 
-The simplest, cross-platform way to get started is to download `world-cli` from [GitHub Releases](https://github.com/Argus-Labs/world-cli/releases) and place the executable file in your PATH, or using installer script below:
+## Go Install
 
-- Install latest with `go install`
+- Install latest available release:
 ```
 go install pkg.world.dev/world-cli@latest
 ```
 
-- Install specific release tag with `go install`
+- Install specific release tag:
 ```
 go install pkg.world.dev/world-cli@<release tag>
 ```
+
+## Curl
 
 - Install latest available release:
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # world-engine-cli
-world-engine-cli
 
 temporary testing notes:
 
@@ -23,6 +22,16 @@ Test with these commands; in the project dir run:
 ## Install Pre-compiled Binaries
 
 The simplest, cross-platform way to get started is to download `world-cli` from [GitHub Releases](https://github.com/Argus-Labs/world-cli/releases) and place the executable file in your PATH, or using installer script below:
+
+- Install latest with `go install`
+```
+go install pkg.world.dev/world-cli@latest
+```
+
+- Install specific release tag with `go install`
+```
+go install pkg.world.dev/world-cli@<release tag>
+```
 
 - Install latest available release:
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Test with these commands; in the project dir run:
 1. `go build`
 2. `./world create myproject`
 
-## Installation
+# Installation
 
 ## Go Install
 


### PR DESCRIPTION
## What is the purpose of the change
  
go-users are quite familiar with installing tools via `go install`. adding the option to the readme here.

## Testing and Verifying
  