### PR TITLE
feat: `world cardinal dev` graceful shutdown

### DIFF
--- a/cmd/cardinal/dev.go
+++ b/cmd/cardinal/dev.go
@@ -2,13 +2,14 @@ package cardinal
 
 import (
 	"fmt"
-	"github.com/magefile/mage/sh"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"os/signal"
-	"pkg.world.dev/world-cli/tea/style"
 	"syscall"
+
+	"github.com/magefile/mage/sh"
+	"github.com/spf13/cobra"
+	"pkg.world.dev/world-cli/tea/style"
 )
 
 const (
@@ -46,7 +47,7 @@ var devCmd = &cobra.Command{
 		}
 
 		// Run Cardinal
-		execCmd, err := runCardinal()
+		cardinalExecCmd, err := runCardinal()
 		if err != nil {
 			return err
 		}
@@ -59,7 +60,7 @@ var devCmd = &cobra.Command{
 		cmdErr := make(chan error, 1)
 
 		go func() {
-			err := execCmd.Wait()
+			err := cardinalExecCmd.Wait()
 			cmdErr <- err
 		}()
 
@@ -71,9 +72,11 @@ var devCmd = &cobra.Command{
 				return errCleanup
 			}
 
-			err = execCmd.Process.Signal(syscall.SIGTERM)
-			if err != nil {
-				return err
+			if cardinalExecCmd.ProcessState == nil && cardinalExecCmd.Process != nil {
+				err = cardinalExecCmd.Process.Signal(syscall.SIGTERM)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/cmd/cardinal/dev.go
+++ b/cmd/cardinal/dev.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/magefile/mage/sh"
 	"github.com/spf13/cobra"
@@ -72,7 +73,19 @@ var devCmd = &cobra.Command{
 				return errCleanup
 			}
 
-			if cardinalExecCmd.ProcessState == nil && cardinalExecCmd.Process != nil {
+			isProcessRunning := func(cmd *exec.Cmd) bool {
+				return cardinalExecCmd.ProcessState == nil && cardinalExecCmd.Process != nil
+			}
+
+			//wait up to 10 seconds for it to quit.
+			for i := 0; i < 10; i++ {
+				if isProcessRunning(cardinalExecCmd) {
+					time.Sleep(1 * time.Second)
+				} else {
+					break
+				}
+			}
+			if isProcessRunning(cardinalExecCmd) {
 				err = cardinalExecCmd.Process.Signal(syscall.SIGTERM)
 				if err != nil {
 					return err


### PR DESCRIPTION
Closes: #496 
## What is the purpose of the change
 
 When you run `world-cli cardinal dev` then ctrl+C to quit you'll see a wierd error message about how the process already quit then the cli will display the help message. 
 
 this occurs because when scott was messing with the cli he used a version of cardinal that hung during shutdown. So he used a force quit to kill it. 
 
 Now that cardinal handles shutdown properly and doesn't hang forever during start game the mechanism is now changed to wait 10 seconds and see if the cardinal shutsdown by itself. If it doesn't then force quit. 