### PR TITLE
feat(world-cli): Add commands for running evm and da layer

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -1,11 +1,8 @@
 package cardinal
 
 import (
-	"errors"
-
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/dependency"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -13,7 +10,6 @@ import (
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
 	BaseCmd.AddCommand(createCmd, startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
-	BaseCmd.Flags().String("config", "", "a toml encoded config file")
 }
 
 // BaseCmd is the base command for the cardinal subcommand
@@ -37,21 +33,4 @@ var BaseCmd = &cobra.Command{
 			log.Fatal().Err(err).Msg("Failed to execute cardinal command")
 		}
 	},
-}
-
-func getConfig(cmd *cobra.Command) (cfg config.Config, err error) {
-	if !cmd.Flags().Changed("config") {
-		// The config flag was not set. Attempt to find the config via environment variables or in the local directory
-		return config.LoadConfig("")
-	}
-	// The config flag was explicitly set
-	configFile, err := cmd.Flags().GetString("config")
-	if err != nil {
-		return cfg, err
-	}
-	if configFile == "" {
-		return cfg, errors.New("config cannot be empty")
-	}
-	return config.LoadConfig(configFile)
-
 }

--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"github.com/spf13/cobra"
+	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/tea_cmd"
 )
 
@@ -20,7 +21,7 @@ This will restart the following Docker services:
 - Cardinal (Core game logic)
 - Nakama (Relay)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := getConfig(cmd)
+		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/tea_cmd"
 )
 
@@ -36,7 +37,7 @@ This will start the following Docker services and its dependencies:
 - Redis (Cardinal dependency)
 - Postgres (Nakama dependency)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := getConfig(cmd)
+		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/evm/evm.go
+++ b/cmd/world/evm/evm.go
@@ -1,0 +1,187 @@
+package evm
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+	"pkg.world.dev/world-cli/common/config"
+	"pkg.world.dev/world-cli/common/tea_cmd"
+)
+
+func EVMCmds() *cobra.Command {
+	evmRootCmd := &cobra.Command{
+		Use:   "evm",
+		Short: "EVM base shard commands.",
+		Long:  "Commands for provisioning the EVM Base Shard.",
+	}
+	evmRootCmd.AddGroup(&cobra.Group{
+		ID:    "EVM",
+		Title: "EVM Base Shard Commands",
+	})
+	evmRootCmd.AddCommand(
+		StartEVM(),
+		StartDA(),
+		StopAll(),
+	)
+	return evmRootCmd
+}
+
+const (
+	FlagDAAuthToken = "da-auth-token"
+	EnvDAAuthToken  = "DA_AUTH_TOKEN"
+)
+
+func services(s ...tea_cmd.DockerService) []tea_cmd.DockerService {
+	return s
+}
+
+func StartDA() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start-da",
+		Short: "Start the data availability layer client.",
+		Long:  fmt.Sprintf("Start the data availability layer client."),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.GetConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Has the DA_AUTH_TOKEN parameter been set in the config?
+			isDAAuthTokenSet := len(cfg.DockerEnv[EnvDAAuthToken]) > 0
+
+			cfg.Build = true
+			cfg.Debug = false
+			cfg.Detach = true
+			cfg.Timeout = -1
+			daService := tea_cmd.DockerServiceDA
+			fmt.Println("starting DA docker service...")
+			err = tea_cmd.DockerStart(cfg, services(daService))
+			if err != nil {
+				fmt.Errorf("error starting %s docker container: %w", daService, err)
+			}
+			// TODO: Can this be replaced with a health check in the docker-compose file?
+			time.Sleep(3 * time.Second)
+			fmt.Println("started DA service...")
+
+			if !isDAAuthTokenSet {
+				fmt.Println("DA token has not been set in the config file.")
+				fmt.Println("attempting to get the DA token...")
+				authTokenLog, daToken, err := getDAToken()
+				if err != nil {
+					return err
+				}
+				fmt.Println(authTokenLog)
+				fmt.Println("To skip this check in the future, add the following line to the [evm] section of your config file:")
+				fmt.Printf("%s=%q\n", EnvDAAuthToken, daToken)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func StartEVM() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the EVM base shard. Use --da-auth-token to pass in an auth token directly.",
+		Long:  "Start the EVM base shard. Requires connection to celestia DA.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.GetConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			daToken, err := cmd.Flags().GetString(FlagDAAuthToken)
+			if err != nil {
+				return err
+			}
+			fmt.Println("start", cfg.DockerEnv[EnvDAAuthToken])
+			if daToken != "" {
+				cfg.DockerEnv[EnvDAAuthToken] = daToken
+			}
+			fmt.Println("after", cfg.DockerEnv[EnvDAAuthToken])
+
+			if cfg.DockerEnv[EnvDAAuthToken] == "" {
+				return fmt.Errorf("the DA auth token was not found in the config at a[evm].%s, nor set via the"+
+					"--%s flag. please add the token to the config file or use the flag", EnvDAAuthToken, FlagDAAuthToken)
+			}
+
+			cfg.Build = true
+			cfg.Debug = false
+			cfg.Detach = false
+			cfg.Timeout = 0
+
+			err = tea_cmd.DockerStart(cfg, services(tea_cmd.DockerServiceEVM))
+			if err != nil {
+				fmt.Errorf("error starting %s docker container: %w", tea_cmd.DockerServiceEVM, err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String(FlagDAAuthToken, "", "DA Auth Token that allows the rollup to communicate with the Celestia client.")
+	return cmd
+}
+
+func StopAll() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the EVM base shard and DA layer client.",
+		Long:  "Stop the EVM base shard and data availability layer client if they are running.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return tea_cmd.DockerStop(services(tea_cmd.DockerServiceEVM, tea_cmd.DockerServiceDA))
+		},
+	}
+	return cmd
+}
+
+func getDAToken() (authTokenLog, token string, err error) {
+	// Create a new command
+	cmd := exec.Command("docker", "logs", "celestia_devnet")
+	retry := 0
+	for ; retry < 10; func() {
+		time.Sleep(2 * time.Second)
+		retry++
+	}() {
+		fmt.Println("attempting to get DA token...")
+
+		output, err := cmd.Output()
+		if err != nil {
+			fmt.Println("error running command docker logs: ", err)
+			continue
+		}
+
+		// Find the line containing CELESTIA_NODE_AUTH_TOKEN
+		lines := bytes.Split(output, []byte("\n"))
+		for i, line := range lines {
+			if bytes.Contains(line, []byte("CELESTIA_NODE_AUTH_TOKEN")) {
+				// Get the next 5 lines after the match
+				endIndex := i + 6
+				if endIndex > len(lines) {
+					endIndex = len(lines)
+				}
+				authTokenLines := lines[i:endIndex]
+				fmt.Println("I have some lines", len(authTokenLines))
+				for _, X := range authTokenLines {
+					fmt.Println("->", string(X))
+				}
+
+				// Concatenate the lines to get the final output
+				authTokenLog = string(bytes.Join(authTokenLines, []byte("\n")))
+				// The last line is the actual token
+				token = string(authTokenLines[len(authTokenLines)-1])
+				break
+			}
+		}
+
+		// Print the final output
+		if authTokenLog != "" {
+			fmt.Println("token found")
+			return authTokenLog, token, nil
+		}
+		fmt.Println("failed... trying again")
+	}
+	return "", "", fmt.Errorf("timed out while getting DA token")
+}

--- a/cmd/world/evm/evm.go
+++ b/cmd/world/evm/evm.go
@@ -163,10 +163,6 @@ func getDAToken() (authTokenLog, token string, err error) {
 					endIndex = len(lines)
 				}
 				authTokenLines := lines[i:endIndex]
-				fmt.Println("I have some lines", len(authTokenLines))
-				for _, X := range authTokenLines {
-					fmt.Println("->", string(X))
-				}
 
 				// Concatenate the lines to get the final output
 				authTokenLog = string(bytes.Join(authTokenLines, []byte("\n")))

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -1,11 +1,14 @@
 package root
 
 import (
+	"os"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"os"
 	"pkg.world.dev/world-cli/cmd/world/cardinal"
+	"pkg.world.dev/world-cli/cmd/world/evm"
+	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/tea/style"
 )
 
@@ -21,6 +24,10 @@ func init() {
 
 	// Register subcommands
 	rootCmd.AddCommand(cardinal.BaseCmd)
+
+	rootCmd.AddCommand(evm.EVMCmds())
+
+	config.AddConfigFlag(rootCmd)
 }
 
 // rootCmd represents the base command

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -9,11 +9,14 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 const (
 	WorldCLIConfigFileEnvVariable = "WORLD_CLI_CONFIG_FILE"
 	WorldCLIConfigFilename        = "world.toml"
+
+	flagForConfigFile = "config"
 )
 
 var (
@@ -30,6 +33,26 @@ type Config struct {
 	Debug     bool
 	Timeout   int
 	DockerEnv map[string]string
+}
+
+func AddConfigFlag(cmd *cobra.Command) {
+	cmd.Flags().String(flagForConfigFile, "", "a toml encoded config file")
+}
+
+func GetConfig(cmd *cobra.Command) (cfg Config, err error) {
+	if !cmd.Flags().Changed(flagForConfigFile) {
+		// The config flag was not set. Attempt to find the config via environment variables or in the local directory
+		return LoadConfig("")
+	}
+	// The config flag was explicitly set
+	configFile, err := cmd.Flags().GetString(flagForConfigFile)
+	if err != nil {
+		return cfg, err
+	}
+	if configFile == "" {
+		return cfg, errors.New("config cannot be empty")
+	}
+	return LoadConfig(configFile)
 }
 
 func LoadConfig(filename string) (Config, error) {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -42,7 +42,7 @@ func AddConfigFlag(cmd *cobra.Command) {
 func GetConfig(cmd *cobra.Command) (cfg Config, err error) {
 	if !cmd.Flags().Changed(flagForConfigFile) {
 		// The config flag was not set. Attempt to find the config via environment variables or in the local directory
-		return LoadConfig("")
+		return loadConfig("")
 	}
 	// The config flag was explicitly set
 	configFile, err := cmd.Flags().GetString(flagForConfigFile)
@@ -52,10 +52,10 @@ func GetConfig(cmd *cobra.Command) (cfg Config, err error) {
 	if configFile == "" {
 		return cfg, errors.New("config cannot be empty")
 	}
-	return LoadConfig(configFile)
+	return loadConfig(configFile)
 }
 
-func LoadConfig(filename string) (Config, error) {
+func loadConfig(filename string) (Config, error) {
 	if filename != "" {
 		return loadConfigFromFile(filename)
 	}

--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -17,6 +17,8 @@ const (
 	DockerServiceNakama      DockerService = "nakama"
 	DockerServiceCockroachDB DockerService = "cockroachdb"
 	DockerServiceRedis       DockerService = "redis"
+	DockerServiceEVM         DockerService = "evm"
+	DockerServiceDA          DockerService = "celestia-devnet"
 )
 
 func dockerCompose(args ...string) error {


### PR DESCRIPTION
Closes: #WORLD-505

## What is the purpose of the change
  
Add commands to start and stop evm and da layer containers.

To start the evm for prod (this will fail to start if some config variables are missing):

```
world evm start
```

To start evm in dev mode (A da layer container will be started and appropriate env variables will be injected into the config)

```
world evm start --dev
```

To stop the evm and da layers:

```
world evm stop
```

## Testing and Verifying
  
I ran manual tests locally after cloning the starter game template. 

The current state of starter-game-template has an incorrect negative block time. It's fixed with this PR: https://github.com/Argus-Labs/starter-game-template/pull/32