### PR TITLE
feat(world-cli): This enables better stdout logging for `world cardinal start`

### DIFF
--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -3,6 +3,7 @@ package tea_cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -33,7 +34,16 @@ func dockerComposeWithCfg(cfg config.Config, args ...string) error {
 		yml = path.Join(cfg.RootDir, ".ide-debug/docker-compose.debug.yml")
 	}
 	args = append([]string{"compose", "-f", yml}, args...)
-	return sh.RunWith(cfg.DockerEnv, "docker", args...)
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	env := os.Environ()
+	for k, v := range cfg.DockerEnv {
+		env = append(env, k+"="+v)
+	}
+	cmd.Env = env
+	return cmd.Run()
+	//return sh.RunWith(cfg.DockerEnv, "docker", args...)
 }
 
 // DockerStart starts a given docker container by name.


### PR DESCRIPTION
Closes: #628

## What is the purpose of the change

Docker compose has really good color printing. world-cli when running the command `world cardinal start` actually hides a lot of output and gets rid of the color. This should make everything identical to as if you were running `docker-compose`

Quick PR to help namra debug stuff as the logs with world-cli aren't displaying everything he needs. 