### PR TITLE
feat: update world-cli to use CARDINAL_LOG_LEVEL env var

### DIFF
--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -2,7 +2,9 @@ package cardinal
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/tea_cmd"
@@ -13,15 +15,27 @@ import (
 /////////////////
 
 const (
-	flagBuild  = "build"
-	flagDebug  = "debug"
-	flagDetach = "detach"
+	flagBuild    = "build"
+	flagDebug    = "debug"
+	flagDetach   = "detach"
+	flagLogLevel = "log-level"
+
+	// DockerCardinalEnvLogLevel Environment variable name for Docker
+	DockerCardinalEnvLogLevel = "CARDINAL_LOG_LEVEL"
+)
+
+var (
+	// ValidLogLevels Valid log levels for zerolog
+	validLogLevels = strings.Join([]string{zerolog.DebugLevel.String(), zerolog.InfoLevel.String(), zerolog.WarnLevel.String(),
+		zerolog.ErrorLevel.String(), zerolog.FatalLevel.String(), zerolog.PanicLevel.String(), zerolog.Disabled.String(),
+		zerolog.TraceLevel.String()}, ", ")
 )
 
 func init() {
 	startCmd.Flags().Bool(flagBuild, true, "Rebuild Docker images before starting")
 	startCmd.Flags().Bool(flagDebug, false, "Run in debug mode")
 	startCmd.Flags().Bool(flagDetach, false, "Run in detached mode")
+	startCmd.Flags().String(flagLogLevel, "", "Set the log level")
 }
 
 // startCmd starts your Cardinal game shard stack
@@ -53,6 +67,24 @@ This will start the following Docker services and its dependencies:
 			return err
 		}
 		cfg.Timeout = -1
+
+		// Replace cardinal log level using flag value if flag is set
+		logLevel, err := cmd.Flags().GetString(flagLogLevel)
+		if logLevel != "" {
+			zeroLogLevel, err := zerolog.ParseLevel(logLevel)
+			if err != nil {
+				return fmt.Errorf("invalid value for flag %s: must be one of (%v)", flagLogLevel, validLogLevels)
+			}
+			cfg.DockerEnv[DockerCardinalEnvLogLevel] = zeroLogLevel.String()
+		}
+
+		if val, exists := cfg.DockerEnv[DockerCardinalEnvLogLevel]; !exists || val == "" {
+			// Set default log level to 'info' if log level is not set
+			cfg.DockerEnv[DockerCardinalEnvLogLevel] = zerolog.InfoLevel.String()
+		} else if _, err := zerolog.ParseLevel(cfg.DockerEnv[DockerCardinalEnvLogLevel]); err != nil { // make sure the log level is valid when the flag is not set and using env var from config
+			// Error when CARDINAL_LOG_LEVEL is not a valid log level
+			return fmt.Errorf("invalid value for %s env variable in the config file: must be one of (%v)", DockerCardinalEnvLogLevel, validLogLevels)
+		}
 
 		fmt.Println("Starting Cardinal game shard...")
 		fmt.Println("This may take a few minutes to rebuild the Docker images.")

--- a/example-world.toml
+++ b/example-world.toml
@@ -9,6 +9,7 @@ REDIS_PASSWORD="" # required to be set in production
 CARDINAL_MODE="development"     # can be either "development" or "production". leaving blank will default to "development"
 BASE_SHARD_SEQUENCER_ADDRESS="" # required to be set in production
 BASE_SHARD_QUERY_ADDRESS=""     # required to be set in production
+CARDINAL_LOG_LEVEL="info"       # Set the log level
 
 [evm]
 # DA_AUTH_TOKEN is obtained from celestia client and passed in from world.toml. 


### PR DESCRIPTION
Closes: WORLD-681

Update world-cli to use CARDINAL_LOG_LEVEL env var

Configuration can be added to world.toml or using flag --log-level on 'world cardinal start` command.
