### PR TITLE
feat: update debug mode build using consolidated multistage dockerfile

### DIFF
--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -27,10 +27,18 @@ This will restart the following Docker services:
 		}
 		cfg.Build = true
 
-		err = tea_cmd.DockerRestart(cfg, []tea_cmd.DockerService{
-			tea_cmd.DockerServiceCardinal,
-			tea_cmd.DockerServiceNakama,
-		})
+		if cfg.Debug {
+			err = tea_cmd.DockerRestart(cfg, []tea_cmd.DockerService{
+				tea_cmd.DockerServiceCardinalDebug,
+				tea_cmd.DockerServiceNakama,
+			})
+		} else {
+			err = tea_cmd.DockerRestart(cfg, []tea_cmd.DockerService{
+				tea_cmd.DockerServiceCardinal,
+				tea_cmd.DockerServiceNakama,
+			})
+		}
+
 		if err != nil {
 			return err
 		}

--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -79,14 +79,19 @@ func DockerStart(cfg config.Config, services []DockerService) error {
 
 // DockerStartAll starts both cardinal and nakama
 func DockerStartAll(cfg config.Config) error {
-	if cfg.Debug {
-		return DockerStart(cfg,
-			[]DockerService{DockerServiceCardinalDebug, DockerServiceNakama, DockerServiceNakamaDB, DockerServiceRedis})
-	} else {
-		return DockerStart(cfg,
-			[]DockerService{DockerServiceCardinal, DockerServiceNakama, DockerServiceNakamaDB, DockerServiceRedis})
+	services := []DockerService{
+		DockerServiceNakama,
+		DockerServiceNakamaDB,
+		DockerServiceRedis,
 	}
-	return nil
+
+	if cfg.Debug {
+		services = append(services, DockerServiceCardinalDebug)
+	} else {
+		services = append(services, DockerServiceCardinal)
+	}
+
+	return DockerStart(cfg, services)
 }
 
 // DockerRestart restarts a given docker container by name, rebuilds the image if `build` is true

--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -125,6 +125,7 @@ func DockerStop(services []DockerService) error {
 func DockerStopAll() error {
 	return DockerStop([]DockerService{
 		DockerServiceCardinal,
+		DockerServiceCardinalDebug,
 		DockerServiceNakama,
 		DockerServiceNakamaDB,
 		DockerServiceRedis,

--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -27,13 +27,14 @@ func dockerCompose(args ...string) error {
 }
 
 func dockerComposeWithCfg(cfg config.Config, args ...string) error {
-	yml := ""
+	yml := path.Join(cfg.RootDir, "docker-compose.yml")
+
 	if !cfg.Debug {
-		yml = path.Join(cfg.RootDir, "docker-compose.yml")
+		args = append([]string{"compose", "-f", yml}, args...)
 	} else {
-		yml = path.Join(cfg.RootDir, ".ide-debug/docker-compose.debug.yml")
+		ymlDebug := path.Join(cfg.RootDir, ".ide-debug/compose.debug.override.yml")
+		args = append([]string{"compose", "-f", yml, "-f", ymlDebug}, args...)
 	}
-	args = append([]string{"compose", "-f", yml}, args...)
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Closes: #WORLD-716

## What is the purpose of the change
  
Update debug mode (`--debug`) using consolidated multistage dockerfile.
See `WORLD-716` and https://github.com/Argus-Labs/starter-game-template/pull/34 for complete context.


- Adjust the `--debug` mode to run the `cardinal-debug` container instead normal `cardinal` container.


## Testing and Verifying
  
- Run & build with debug mode: `world cardinal start --build --debug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the Docker Compose functionality to dynamically adjust configurations based on debug mode settings.
  - Modified the restart logic to select different Docker services based on the debug mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->