### PR TITLE
chore(git): clone latest version of starter-game-template

### DIFF
--- a/cmd/world/cardinal/create.go
+++ b/cmd/world/cardinal/create.go
@@ -122,9 +122,14 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case steps.SignalStepStartedMsg:
 		// If step 1 is started, dispatch the git clone command
 		if msg.Index == 1 {
+			err := tea_cmd.GitCloneCmd(TemplateGitUrl, m.projectNameInput.Value(), "Initial commit from World CLI")
+			teaCmd := func() tea.Msg {
+				return tea_cmd.GitCloneFinishMsg{Err: err}
+			}
+
 			return m, tea.Sequence(
 				NewLogCmd(style.ChevronIcon.Render()+"Cloning starter-game-template..."),
-				tea_cmd.GitCloneCmd(TemplateGitUrl, m.projectNameInput.Value(), "Initial commit from World CLI"),
+				teaCmd,
 			)
 		}
 		return m, nil

--- a/common/tea_cmd/git.go
+++ b/common/tea_cmd/git.go
@@ -2,56 +2,69 @@ package tea_cmd
 
 import (
 	"bytes"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/magefile/mage/sh"
 	"os"
+	"strings"
 )
 
 type GitCloneFinishMsg struct {
 	Err error
 }
 
-func git(args ...string) error {
+func git(args ...string) (string, error) {
 	var outBuff, errBuff bytes.Buffer
 	_, err := sh.Exec(nil, &outBuff, &errBuff, "git", args...)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return outBuff.String(), nil
 }
 
-func GitCloneCmd(url string, targetDir string, initMsg string) tea.Cmd {
-	return func() tea.Msg {
-		err := git("clone", url, targetDir)
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		err = os.Chdir(targetDir)
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		err = sh.Run("rm", "-rf", ".git")
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		err = git("init")
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		err = git("add", "-A")
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		err = git("commit", "-m", initMsg)
-		if err != nil {
-			return GitCloneFinishMsg{Err: err}
-		}
-
-		return GitCloneFinishMsg{Err: nil}
+func GitCloneCmd(url string, targetDir string, initMsg string) (err error) {
+	_, err = git("clone", url, targetDir)
+	if err != nil {
+		return
 	}
+
+	err = os.Chdir(targetDir)
+	if err != nil {
+		return
+	}
+
+	rev, err := git("rev-list", "--tags", "--max-count=1")
+	if err != nil {
+		return
+	}
+
+	tag, err := git("describe", "--tags", strings.TrimSpace(rev))
+	if err != nil {
+		return
+	}
+
+	_, err = git("checkout", strings.TrimSpace(tag))
+	if err != nil {
+		return
+	}
+
+	err = sh.Run("rm", "-rf", ".git")
+	if err != nil {
+		return
+	}
+
+	_, err = git("init")
+	if err != nil {
+		return
+	}
+
+	_, err = git("add", "-A")
+	if err != nil {
+		return
+	}
+
+	_, err = git("commit", "-m", initMsg)
+	if err != nil {
+		return
+	}
+
+	return
 }

--- a/common/tea_cmd/git_test.go
+++ b/common/tea_cmd/git_test.go
@@ -1,0 +1,71 @@
+package tea_cmd
+
+import (
+	"fmt"
+	"gotest.tools/v3/assert"
+	"os"
+	"testing"
+)
+
+const templateUrlTest = "https://github.com/Argus-Labs/starter-game-template.git"
+
+func TestGitCloneCmd(t *testing.T) {
+	type param struct {
+		url       string
+		targetDir string
+		initMsg   string
+	}
+
+	test := []struct {
+		name     string
+		wantErr  bool
+		expected string
+		param    param
+	}{
+		{
+			name:     "error clone wrong address",
+			wantErr:  true,
+			expected: `running "git clone wrong address targetDir" failed with exit code 128`,
+			param: param{
+				url:       "wrong address",
+				targetDir: "targetDir",
+				initMsg:   "initMsg",
+			},
+		},
+		{
+			name:    "success",
+			wantErr: false,
+			param: param{
+				url:       templateUrlTest,
+				targetDir: os.TempDir() + "/worldclitest",
+				initMsg:   "initMsg",
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			// clean up before test
+			cleanUpDir(tt.param.targetDir)
+
+			err := GitCloneCmd(tt.param.url, tt.param.targetDir, tt.param.initMsg)
+			if tt.wantErr {
+				assert.Error(t, err, tt.expected)
+			} else {
+				assert.NilError(t, err)
+			}
+
+			// clean up after test
+			cleanUpDir(tt.param.targetDir)
+		})
+	}
+}
+
+func cleanUpDir(targetDir string) {
+	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+		err := os.RemoveAll(targetDir)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes: WORLD-715

## Overview

Clone latest tags instead of main branch to instead of cloning main the branch. it's to prevent possibility that we might be in the process of updating starter-game-template and it's not ready for consumption yet.

## Brief Changelog
- add command `git rev-list --tags --max-count=1` and `git describe --tags` to get latest tags and checkout
- Modify `GitCloneCmd` func to be able to unit test

## Testing and Verifying
Added unit test for `GitCloneCmd` func