### PR TITLE
fix(redis): redis not stopped properly in dev mode

### DIFF
--- a/common/tea_cmd/docker.go
+++ b/common/tea_cmd/docker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/magefile/mage/sh"
 	"pkg.world.dev/world-cli/common/config"
-	"pkg.world.dev/world-cli/common/logger"
 )
 
 type DockerService string
@@ -34,11 +33,7 @@ func dockerComposeWithCfg(cfg config.Config, args ...string) error {
 
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
-
-	// hide stderr if not in debug mode
-	if logger.DebugMode {
-		cmd.Stderr = os.Stderr
-	}
+	cmd.Stderr = os.Stderr
 
 	env := os.Environ()
 	for k, v := range cfg.DockerEnv {

--- a/common/tea_cmd/git_test.go
+++ b/common/tea_cmd/git_test.go
@@ -2,6 +2,7 @@ package tea_cmd
 
 import (
 	"fmt"
+	"github.com/magefile/mage/sh"
 	"gotest.tools/v3/assert"
 	"os"
 	"testing"
@@ -19,13 +20,13 @@ func TestGitCloneCmd(t *testing.T) {
 	test := []struct {
 		name     string
 		wantErr  bool
-		expected string
+		expected int
 		param    param
 	}{
 		{
 			name:     "error clone wrong address",
 			wantErr:  true,
-			expected: `running "git clone wrong address targetDir" failed with exit code 128`,
+			expected: 128,
 			param: param{
 				url:       "wrong address",
 				targetDir: "targetDir",
@@ -50,7 +51,7 @@ func TestGitCloneCmd(t *testing.T) {
 
 			err := GitCloneCmd(tt.param.url, tt.param.targetDir, tt.param.initMsg)
 			if tt.wantErr {
-				assert.Error(t, err, tt.expected)
+				assert.Equal(t, sh.ExitStatus(err), tt.expected)
 			} else {
 				assert.NilError(t, err)
 			}


### PR DESCRIPTION
Closes: WORLD-728

## Overview
  
Fix redis not stopped properly when send sigint (ctrl+c) on dev mode

## Brief Changelog
  
- Remove `cmd.Wait()` on `runCardinal` func so program will continue until signal channel is created
- Add some message to the screen

## Testing and Verifying

Test the program using command `world dev` and `world dev --debug` with this conditions :
- all redis are stopped (both cardinal and cardinal-dev)
- redis cardinal is up -> it will show message `Maybe redis cardinal docker is still up, run 'world cardinal stop' and try again`
- redis cardinal-dev is up -> it will cleanup and rerun the redis again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced startup messages for better user feedback during development operations.
  - Improved error messaging for specific Redis-related issues.
  - Refined error handling in the Cardinal development command for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->