### PR TITLE
test(doctor): add test for doctor command in root package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -31,6 +29,7 @@ jobs:
           git config --global user.email "github-action@mail.com"
           git config --global user.name "github-action"
       - name: Test
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           go test ./... -coverprofile=coverage.out -covermode=count -v
       - name: Upload coverage results to Github artifact

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -3,7 +3,7 @@ package root
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
-
+	"io"
 	"pkg.world.dev/world-cli/common/dependency"
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/tea_cmd"
@@ -24,24 +24,28 @@ var DoctorDeps = []dependency.Dependency{
 
 // doctorCmd checks that required dependencies are installed
 // Usage: `world doctor`
-var doctorCmd = &cobra.Command{
-	Use:   "doctor",
-	Short: "Check that required dependencies are installed",
-	Long: `Check that required dependencies are installed.
+func getDoctorCmd(writer io.Writer) *cobra.Command {
+	doctorCmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check that required dependencies are installed",
+		Long: `Check that required dependencies are installed.
 
 World CLI requires the following dependencies to be installed:
 - Git
 - Go
 - Docker`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		logger.SetDebugMode(cmd)
-		p := tea.NewProgram(NewWorldDoctorModel())
-		_, err := p.Run()
-		if err != nil {
-			return err
-		}
-		return nil
-	},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.SetDebugMode(cmd)
+			p := tea.NewProgram(NewWorldDoctorModel(), tea.WithOutput(writer))
+			_, err := p.Run()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return doctorCmd
 }
 
 //////////////////////

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"pkg.world.dev/world-cli/cmd/world/cardinal"
@@ -18,7 +20,8 @@ func init() {
 	rootCmd.AddGroup(&cobra.Group{ID: "Core", Title: "World CLI Commands:"})
 
 	// Register base commands
-	rootCmd.AddCommand(createCmd, doctorCmd, versionCmd)
+	doctorCmd := getDoctorCmd(os.Stdout)
+	rootCmd.AddCommand(doctorCmd, versionCmd)
 
 	// Register subcommands
 	rootCmd.AddCommand(cardinal.BaseCmd)


### PR DESCRIPTION
Closes: WORLD-361

## Overview
  
Adding unit test for doctor command in root package

## Brief Changelog
  
- Capture output from tea cmd to a variable
- Assert the output

## Testing and Verifying

- Run the test for all dependecies with status ok
- Run the test with some of dependencies not ok 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Restructured command handling for improved output management and testing.
- **Tests**
	- Added tests to validate the execution of the new doctor command.
- **Documentation**
	- Revised subcommand help text to align with recent modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->