### PR TITLE
ci: fix TestGitCloneCmd test case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: "go.sum"
+      - name: Init Dummy Git config for testing
+        run: |
+          git config --global user.email "github-action@mail.com"
+          git config --global user.name "github-action"
       - name: Test
         run: |
           go test ./... -coverprofile=coverage.out -covermode=count -v
@@ -34,7 +38,7 @@ jobs:
         with:
           name: coverage
           path: ./coverage.out
-          
+
   upload-codecov:
     name: Upload coverage output to Codecov.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes: #DEVOP-168

## What is the purpose of the change
 
- Fix `TestGitCloneCmd` CI unit test case

## Testing and Verifying
- Passing Unit Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the CI workflow to include initialization of dummy Git configuration for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->