### PR TITLE
ci: github runner tty workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -31,6 +29,7 @@ jobs:
           git config --global user.email "github-action@mail.com"
           git config --global user.name "github-action"
       - name: Test
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           go test ./... -coverprofile=coverage.out -covermode=count -v
       - name: Upload coverage results to Github artifact


### PR DESCRIPTION
Closes: #DEVOP-168

Issue: There was a `TestExecuteDoctorCommand` test case that expected a certain output from `doctor` command. This terminal output needs to be captured from `/dev/tty` which by default doesn't exist on GitHub runner. 

## What is the purpose of the change

 - Add a workaround for a missing `/dev/tty` on GitHub-action runner, using `script` to wrap around the `go test` interactive session terminal. 
 
## Testing and Verifying
  - CI Test check success.
  
## Notes
  - TTY workaround discussion: https://github.com/actions/runner/issues/241#issuecomment-577370913