### PR TITLE
refactor(create): rename 'world cardinal create' command to just 'world create'

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -9,10 +9,10 @@ import (
 
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
-	BaseCmd.AddCommand(createCmd, startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
+	BaseCmd.AddCommand(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 
 	// Add --debug flag
-	logger.AddLogFlag(createCmd, startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
+	logger.AddLogFlag(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 }
 
 // BaseCmd is the base command for the cardinal subcommand

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -1,4 +1,4 @@
-package cardinal
+package root
 
 import (
 	"strings"

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -18,7 +18,7 @@ func init() {
 	rootCmd.AddGroup(&cobra.Group{ID: "Core", Title: "World CLI Commands:"})
 
 	// Register base commands
-	rootCmd.AddCommand(doctorCmd, versionCmd)
+	rootCmd.AddCommand(createCmd, doctorCmd, versionCmd)
 
 	// Register subcommands
 	rootCmd.AddCommand(cardinal.BaseCmd)
@@ -27,6 +27,7 @@ func init() {
 	config.AddConfigFlag(rootCmd)
 
 	// Add --debug flag
+	logger.AddLogFlag(createCmd)
 	logger.AddLogFlag(doctorCmd)
 }
 


### PR DESCRIPTION
Closes: WORLD-732

## Overview
  
Rename `world cardinal create` command to `world create`

## Brief Changelog
  
- Move create.go from cardinal package to root package
- Add create command to the root command

## Testing and Verifying

Test `world create` command is working properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Modified the `init` function in `cmd/world/cardinal/cardinal.go` to restructure the initialization of subcommands and log flags.
	- Renamed the "cardinal" package to "root" in `cmd/world/root/create.go`, impacting import paths and references.
- **New Features**
	- Included the `createCmd` in the `rootCmd` in `cmd/world/root/root.go`.
	- Added a `--debug` flag to the `createCmd` for enhanced debugging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->