### PR TITLE
test(cardinal): add test for create, start, stop, purge

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"github.com/spf13/cobra"
+
 	"pkg.world.dev/world-cli/common/dependency"
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/tea/style"
@@ -10,7 +11,6 @@ import (
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
 	BaseCmd.AddCommand(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
-
 	// Add --debug flag
 	logger.AddLogFlag(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 }
@@ -22,7 +22,7 @@ var BaseCmd = &cobra.Command{
 	Short:   "Manage your Cardinal game shard project",
 	Long:    style.CLIHeader("World CLI — CARDINAL", "Manage your Cardinal game shard project"),
 	GroupID: "Core",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return dependency.Check(
 			dependency.Go,
 			dependency.Git,

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -1,14 +1,14 @@
 package root
 
 import (
+	"github.com/spf13/cobra"
+	"io"
+	"pkg.world.dev/world-cli/common/logger"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
-	"github.com/spf13/cobra"
-
 	tea "github.com/charmbracelet/bubbletea"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/tea_cmd"
 	"pkg.world.dev/world-cli/tea/component/steps"
 	"pkg.world.dev/world-cli/tea/style"
@@ -22,21 +22,25 @@ const TemplateGitUrl = "https://github.com/Argus-Labs/starter-game-template.git"
 
 // createCmd creates a new World Engine project based on starter-game-template
 // Usage: `world cardinal create [directory_name]`
-var createCmd = &cobra.Command{
-	Use:   "create [directory_name]",
-	Short: "Create a World Engine game shard from scratch",
-	Long: `Create a World Engine game shard based on https://github.com/Argus-Labs/starter-game-template.
+func getCreateCmd(writer io.Writer) *cobra.Command {
+	createCmd := &cobra.Command{
+		Use:   "create [directory_name]",
+		Short: "Create a World Engine game shard from scratch",
+		Long: `Create a World Engine game shard based on https://github.com/Argus-Labs/starter-game-template.
 If [directory_name] is set, it will automatically clone the starter project into that directory. 
 Otherwise, it will prompt you to enter a directory name.`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		logger.SetDebugMode(cmd)
-		p := tea.NewProgram(NewWorldCreateModel(args))
-		if _, err := p.Run(); err != nil {
-			return err
-		}
-		return nil
-	},
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.SetDebugMode(cmd)
+			p := tea.NewProgram(NewWorldCreateModel(args), tea.WithOutput(writer))
+			if _, err := p.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return createCmd
 }
 
 //////////////////////

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -21,7 +21,8 @@ func init() {
 
 	// Register base commands
 	doctorCmd := getDoctorCmd(os.Stdout)
-	rootCmd.AddCommand(doctorCmd, versionCmd)
+	createCmd := getCreateCmd(os.Stdout)
+	rootCmd.AddCommand(createCmd, doctorCmd, versionCmd)
 
 	// Register subcommands
 	rootCmd.AddCommand(cardinal.BaseCmd)


### PR DESCRIPTION
Closes: WORLD-362

## Overview
  
Adding unit test for create, start, stop, purge command

## Brief Changelog
  
- Added new test that cover create, start, stop, and purge command

## Testing and Verifying

Test will do this scenario
- run create command to clone starter-game-template
- start the cardinal
- hit `/health` endpoint and verify the response
- stop the cardinal
- hit `/health` endpoint and make sure it will be error
- purge the cardinal