### PR TITLE
test: add test on restart and dev command

### DIFF
--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -12,6 +12,10 @@ import (
 // Cobra Setup //
 /////////////////
 
+func init() {
+	restartCmd.Flags().Bool(flagDetach, false, "Run in detached mode")
+}
+
 // restartCmd restarts your Cardinal game shard stack
 // Usage: `world cardinal restart`
 var restartCmd = &cobra.Command{
@@ -30,6 +34,13 @@ This will restart the following Docker services:
 			return err
 		}
 		cfg.Build = true
+		if replaceBoolWithFlag(cmd, flagDebug, &cfg.Debug); err != nil {
+			return err
+		}
+
+		if replaceBoolWithFlag(cmd, flagDetach, &cfg.Detach); err != nil {
+			return err
+		}
 
 		if cfg.Debug {
 			err = tea_cmd.DockerRestart(cfg, []tea_cmd.DockerService{


### PR DESCRIPTION
Closes: WORLD-532

## Overview
  
Add test for `restart` and `dev` command

## Brief Changelog
  
- Add Detach mode for restart
- Modify older test, adding restart before stop and purge
- Add new test for dev

## Testing and Verifying

- Running the unit test suite