### PR TITLE
chore: add docker env allow list for nakama

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -24,7 +24,7 @@ var (
 	// Items under these toml headers will be included in the environment variables when
 	// running docker. An error will be generated if a duplicate key is found across
 	// these sections.
-	dockerEnvHeaders = []string{"cardinal", "evm"}
+	dockerEnvHeaders = []string{"cardinal", "evm", "nakama"}
 )
 
 type Config struct {

--- a/example-world.toml
+++ b/example-world.toml
@@ -23,3 +23,6 @@ CHAIN_ID="world-engine"
 KEY_MNEMONIC="enact adjust liberty squirrel bulk ticket invest tissue antique window thank slam unknown fury script among bread social switch glide wool clog flag enroll"
 FAUCET_ADDR="world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5"
 BLOCK_TIME="1s"
+
+[nakama]
+ENABLE_ALLOWLIST="false" # enable nakama's beta key feature. you can generate and claim beta keys by setting this to true


### PR DESCRIPTION
Closes: WORLD-726

## What is the purpose of the change
  
Enable nakama's beta key feature through world.tom

## Testing and Verifying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the configuration to include support for a new environment variable.
	- Confidential changes made to enhance functionality.
	- Modified `dockerEnvHeaders` variable to include additional string element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->