### PR TITLE
ci: add ldflags for binary version & analytics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           [ ${{ matrix.goos }} = "windows" ] && output_name+=".exe"
 
           ## Get version from tag name
-          $bin_version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          bin_version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           ## Handle if event coming from PR, not release/tag
           [ "$bin_version" == "merge" ] && bin_version=${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           ## Get version from tag name
           bin_version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           ## Handle if event coming from PR, not release/tag
-          [ "$bin_version" == "merge" ] && bin_version=${{ github.event.pull_request.head.sha }}
+          if [ "${{ github.event_name }}" == "pull_request" ]; then bin_version=${{ github.event.pull_request.head.sha }}; fi
 
           env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags "-X main.AppVersion=$bin_version -X main.SentryDsn=${{ secrets.SENTRY_DSN }} -X main.PosthogApiKey=${{ secrets.POSTHOG_API_KEY }}" -o $output_name ./cmd/world
           echo "output_name=$output_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,12 @@ jobs:
           output_name=world_${{ matrix.goos }}_${{ matrix.goarch }}
           [ ${{ matrix.goos }} = "windows" ] && output_name+=".exe"
 
-          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o $output_name ./cmd/world
+          ## Get version from tag name
+          $bin_version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          ## Handle if event coming from PR, not release/tag
+          [ "$bin_version" == "merge" ] && bin_version=${{ github.event.pull_request.head.sha }}
+
+          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags "-X main.AppVersion=$bin_version -X main.SentryDsn=${{ secrets.SENTRY_DSN }} -X main.PosthogApiKey=${{ secrets.POSTHOG_API_KEY }}" -o $output_name ./cmd/world
           echo "output_name=$output_name" >> $GITHUB_OUTPUT
       - name: Compress Build Binary
         uses: a7ul/tar-action@v1.1.3


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

- add ldflags for binary version & analytics 
```
go build -ldflags "-X main.AppVersion={appVersion} -X main.SentryDsn={sentryDsn} -X main.PosthogApiKey={apiKey}
```
- get `sentryDsn` & `PosthogApiKey` from GitHub secrets
- get `appVersion` from workflow event ref (tagging) 

## Testing and Verifying

- Build CI success
- Analytics metrics working
- `world version` print the correct binary version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the build process by dynamically extracting version information from tag names or PR head SHA for merge events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->