### PR TITLE
ci: fix build secrets inherit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       create_release: true
+    secrets: inherit
 
   release:
     name: Release world-cli binary


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change
  
- fix build secrets blank during release