### PR TITLE
fix: send only error/fatal logs to sentry

### DIFF
--- a/telemetry/sentry.go
+++ b/telemetry/sentry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"slices"
 	"time"
 )
 
@@ -50,7 +51,8 @@ type SentryHook struct{}
 
 // Run is called for every log event and implements the zerolog.Hook interface
 func (h SentryHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
-	if sentryInitialized {
+	shouldBeLogged := slices.Contains(h.Levels(), level)
+	if sentryInitialized && shouldBeLogged {
 		// Capture error message
 		sentry.CaptureException(fmt.Errorf(msg))
 	}


### PR DESCRIPTION
Closes: WORLD-851

## What is the purpose of the change
  
debug/info logs don't need to be sent to sentry.

## Testing and Verifying

Manual testing done, not sure how to automate this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logging mechanism to include a check for specific log levels, ensuring more relevant data is captured for analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->