### PR TITLE
feat: rename go module to be match with shard game name

### DIFF
--- a/common/tea_cmd/git_test.go
+++ b/common/tea_cmd/git_test.go
@@ -2,10 +2,12 @@ package tea_cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/magefile/mage/sh"
 	"gotest.tools/v3/assert"
-	"os"
-	"testing"
 )
 
 const templateUrlTest = "https://github.com/Argus-Labs/starter-game-template.git"
@@ -38,7 +40,7 @@ func TestGitCloneCmd(t *testing.T) {
 			wantErr: false,
 			param: param{
 				url:       templateUrlTest,
-				targetDir: os.TempDir() + "/worldclitest",
+				targetDir: filepath.Join(os.TempDir(), "worldclitest"),
 				initMsg:   "initMsg",
 			},
 		},


### PR DESCRIPTION
Closes: WORLD-897

## What is the purpose of the change
  
Renaming go.mod module to be match with game shard name. and rename all import module.

## Testing and Verifying

- Covered by previous unit test.
- Run world create and check by running the game shard