### PR TITLE
fix: inconsistent log format on world cardinal dev hot reload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module pkg.world.dev/world-cli
 go 1.21.1
 
 require (
-	github.com/argus-labs/fresh v0.0.1-alpha
+	github.com/argus-labs/fresh v0.0.2
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/denisbrodbeck/machineid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/argus-labs/fresh v0.0.1-alpha h1:CQ34bjQzwki9XMfYDMMuEhtA354numpUz0n7Ll8WVyg=
-github.com/argus-labs/fresh v0.0.1-alpha/go.mod h1:0JyLyBC5gajmcQ8NK6qhf/GNy36I7PU/8XzHQVzDcWI=
+github.com/argus-labs/fresh v0.0.2 h1:rjmhnm7JkkN6FCzxEbSrIJoOsG0TkxQVBtVbOsbQVPM=
+github.com/argus-labs/fresh v0.0.2/go.mod h1:0JyLyBC5gajmcQ8NK6qhf/GNy36I7PU/8XzHQVzDcWI=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=


### PR DESCRIPTION
Closes: WORLD-857

## What is the purpose of the change
Fix inconsistent log format on `world cardinal dev --watch`. 
- Adjust log from fresh runner to be same format with cardinal

## Testing and Verifying

Tested by running `world cardinal dev --watch`

After :
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/f525ff03-83a0-4ac0-9311-343b35eeaf91.png)

Before :

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/4e7eb221-e002-4670-a4bf-d26dba214aca.png)

