### PR TITLE
ci: use GoReleaser for build & release binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,20 +7,14 @@ on:
   push:
     branches:
       - main
-  workflow_call:
-    inputs:
-      create_release:
-        description: 'Check if workflows called from Github Release event.'
-        default: false
-        required: false
-        type: boolean
+
 env:
   GO_VERSION: 1.21.1
 
 jobs:
   build-go:
     name: Go
-    runs-on: namespace-profile-linux-4vcpu-8gb-cached
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +22,5 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          ## skip cache, use Namespace volume cache
-          cache: false
       - name: Build
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,42 +26,11 @@ jobs:
         goarch: [amd64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v2
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: "go.sum"
-      - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
-        id: build
-        run: |
-          output_name=world_${{ matrix.goos }}_${{ matrix.goarch }}
-          [ ${{ matrix.goos }} = "windows" ] && output_name+=".exe"
-
-          ## Get version from tag name
-          bin_version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          ## Get sentry dsn from secret
-          sentry_dsn=${{ secrets.SENTRY_DSN }}
-          ## Get posthog api key from secret
-          posthog_api_key=${{ secrets.POSTHOG_API_KEY }}
-          ## Handle if event coming from PR, not release/tag
-          if [ "${{ github.event_name }}" == "pull_request" ]; then bin_version=${{ github.event.pull_request.head.sha }}; fi
-
-          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags "-X main.AppVersion=$bin_version -X main.SentryDsn=$sentry_dsn -X main.PosthogApiKey=$posthog_api_key" -o $output_name ./cmd/world
-          echo "output_name=$output_name" >> $GITHUB_OUTPUT
-      - name: Compress build binary
-        uses: a7ul/tar-action@v1.1.3
-        id: compress
-        with:
-          command: c
-          files: |
-            ./${{ steps.build.outputs.output_name }}
-          outPath: ${{ steps.build.outputs.output_name }}.tar.gz
-      - name: Upload binary to Github artifact
-        if: ${{ inputs.create_release }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: world-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: ./world*.tar.gz
+      - name: Build
+        run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,21 +14,21 @@ on:
         default: false
         required: false
         type: boolean
+env:
+  GO_VERSION: 1.21.0
 
 jobs:
   build-go:
     name: Go
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.21.x]
+    runs-on: namespace-profile-linux-4vcpu-8gb-cached
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "go.sum"
+          go-version: ${{ env.GO_VERSION }}
+          ## skip cache, use Namespace volume cache
+          cache: false
       - name: Build
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.x]
-        goos: [linux, windows, darwin]
-        goarch: [amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: boolean
 env:
-  GO_VERSION: 1.21.0
+  GO_VERSION: 1.21.1
 
 jobs:
   build-go:

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -15,7 +15,7 @@ jobs:
     name: Go
     runs-on: namespace-profile-linux-4vcpu-8gb-cached
     env:
-      GO_VERSION: 1.22.1
+      GO_VERSION: 1.21.1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,34 +4,32 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   go-test:
     name: Test
     uses: ./.github/workflows/test.yml
 
-  go-build:
-    name: Build
-    uses: ./.github/workflows/build.yml
-    with:
-      create_release: true
-    secrets: inherit
-
-  release:
-    name: Release World CLI binary
+  goreleaser:
     runs-on: ubuntu-latest
-    needs: [go-test, go-build]
-    strategy:
-      matrix:
-        go-version: [1.21.x]
     steps:
-      - name: Download World CLI build binary
-        uses: actions/download-artifact@v3
-      - name: Display downloaded files
-        run: |
-          ls -R
-      - name: Publish World CLI binary to corresponding Github Release
-        uses: skx/github-action-publish-binaries@master
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'world*/*.tar.gz'
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GORELEASER_VERSION: v1.24.0
-  GO_VERSION: 1.21.0
+  GO_VERSION: 1.21.1
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+env:
+  GORELEASER_VERSION: v1.24.0
+  GO_VERSION: 1.21.0
+
 permissions:
   contents: write
 
@@ -13,21 +17,28 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-4vcpu-8gb-cached
+    needs: go-test
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
+      - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: stable
-      - name: Run GoReleaser
+          go-version: ${{ env.GO_VERSION }}
+          ## skip cache, use Namespace volume cache
+          cache: false
+      - name: Setup Namespace cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+      - name: Run World CLI GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: ${{ env.GORELEASER_VERSION }}
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
+          POSTHOG_API_KEY: "${{ secrets.POSTHOG_API_KEY }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
   goreleaser:
     name: Release World CLI binary
-    runs-on: namespace-profile-linux-4vcpu-8gb-cached
+    runs-on: ubuntu-latest
     needs: go-test
     steps:
       - name: Checkout
@@ -29,12 +29,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          ## skip cache, use Namespace volume cache
-          cache: false
-      - name: Setup Namespace cache
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: go
       - name: Run World CLI goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -43,5 +37,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-          POSTHOG_API_KEY: "${{ secrets.POSTHOG_API_KEY }}"
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   goreleaser:
+    name: Release World CLI binary
     runs-on: namespace-profile-linux-4vcpu-8gb-cached
     needs: go-test
     steps:
@@ -34,7 +35,7 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: go
-      - name: Run World CLI GoReleaser
+      - name: Run World CLI goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # Setup Docker build to use Namespace workspace builder
-      - name: Configure Namespace powered Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -39,6 +36,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: make test-coverage
       - name: Upload coverage to Codecov
+        if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: 1.21.0
+  GO_VERSION: 1.21.1
 
 jobs:
   test-unit-coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 env:
   GO_VERSION: 1.21.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ go.work
 
 # Build
 world-cli
-world
 dist/
 
 # Mac

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ go.work
 
 # Build
 world-cli
+world
+dist/
 
 # Mac
 .DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - main: ./cmd/world
+    binary: world
+    env:
+      - CGO_ENABLED=0
+
+    ldflags:
+      - -s -w -X "main.goversion={{.Env.GOVERSION}}"
+      - -X "main.AppVersion={{.Version}}" -X "main.SentryDsn={{.Env.SENTRY_DSN}}" -X "main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}"
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,9 +18,10 @@ builds:
       - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}default_null{{ end }}
       - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}default_null{{ end }}
     ldflags:
+      - -s -w
       - -X main.AppVersion={{.Version}}
       - -X main.SentryDsn={{.Env.SENTRY_DSN}}
-      - -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}
+      - -X main.PosthogAPIKey={{.Env.POSTHOG_API_KEY}}
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,9 +20,7 @@ builds:
     binary: world
     env:
       - CGO_ENABLED=0
-
     ldflags:
-      - -s -w -X "main.goversion={{.Env.GOVERSION}}"
       - -X "main.AppVersion={{.Version}}" -X "main.SentryDsn={{.Env.SENTRY_DSN}}" -X "main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}"
     goos:
       - linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
       - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}defaul_null{{ end }}
       - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}defaul_null{{ end }}
     ldflags:
-      - -X "main.AppVersion={{.Version}}" -X "main.SentryDsn={{.Env.SENTRY_DSN}}" -X "main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}"
+      - -s -w -X main.AppVersion={{.Version}} -X main.SentryDsn={{.Env.SENTRY_DSN}} -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,10 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+      - "386"
 
 release:
   make_latest: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,8 @@ builds:
     binary: world
     env:
       - CGO_ENABLED=0
+      - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}defaul_null{{ end }}
+      - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}defaul_null{{ end }}
     ldflags:
       - -X "main.AppVersion={{.Version}}" -X "main.SentryDsn={{.Env.SENTRY_DSN}}" -X "main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}"
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,7 @@ builds:
 release:
   make_latest: false
   mode: append
+  replace_existing_artifacts: true
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,10 @@ builds:
       - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}default_null{{ end }}
       - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}default_null{{ end }}
     ldflags:
-      - -s -w -X main.AppVersion={{.Version}} -X main.SentryDsn={{.Env.SENTRY_DSN}} -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}
+      - -s -w
+      - -X main.AppVersion={{.Version}}
+      - -X main.SentryDsn={{.Env.SENTRY_DSN}}
+      - -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ builds:
 
 release:
   make_latest: false
+  mode: append
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,14 +20,17 @@ builds:
     binary: world
     env:
       - CGO_ENABLED=0
-      - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}defaul_null{{ end }}
-      - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}defaul_null{{ end }}
+      - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}default_null{{ end }}
+      - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}default_null{{ end }}
     ldflags:
       - -s -w -X main.AppVersion={{.Version}} -X main.SentryDsn={{.Env.SENTRY_DSN}} -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}
     goos:
       - linux
       - windows
       - darwin
+
+release:
+  make_latest: false
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,8 @@ builds:
 release:
   make_latest: false
   mode: append
-  replace_existing_artifacts: true
+  # uncomment after v1.25.0 stable released
+  # replace_existing_artifacts: true
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,6 @@ builds:
       - SENTRY_DSN={{ if index .Env "SENTRY_DSN"  }}{{ .Env.SENTRY_DSN }}{{ else }}default_null{{ end }}
       - POSTHOG_API_KEY={{ if index .Env "POSTHOG_API_KEY"  }}{{ .Env.POSTHOG_API_KEY }}{{ else }}default_null{{ end }}
     ldflags:
-      - -s -w
       - -X main.AppVersion={{.Version}}
       - -X main.SentryDsn={{.Env.SENTRY_DSN}}
       - -X main.PosthogApiKey={{.Env.POSTHOG_API_KEY}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ builds:
 release:
   make_latest: false
   mode: append
-  # uncomment after v1.25.0 stable released
+  # uncomment until v1.25.0 stable released
   # replace_existing_artifacts: true
 
 archives:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
@@ -10,9 +7,7 @@ version: 1
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
     - go generate ./...
 
 builds:

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -24,9 +24,9 @@ release:
 		exit 1; \
 	fi
 	@if [ -z "${GITHUB_TOKEN}" ]; then\
-		echo " [Error] GITHUB_TOKEN not found!"; \
-		echo " --> Provide GITHUB_TOKEN as env variable, or in a file at '~/.config/goreleaser/github_token'."; \
-		echo -e "     (Grant 'repo' scopes permission: https://github.com/settings/tokens/new)\n"; \
+		echo " [Error] GITHUB_TOKEN env variable not found!"; \
+		echo " --> GoReleaser requires an API token with the repo scope to deploy the artifacts to GitHub."; \
+		echo -e "     (https://github.com/settings/tokens/new)\n"; \
 		exit 1; \
 	fi
 	@echo "--> Release Tag: $(args_release_tag)"

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 goreleaser_version=v1.24.0
 
 goreleaser-install:

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -1,4 +1,16 @@
+goreleaser_version=v1.24.0
+
+goreleaser-install:
+	@echo "--> Checking if goreleaser $(goreleaser_version) is installed"
+	@if [ $$(goreleaser --version | grep GitVersion | awk '{ print $$2 }') != "$(goreleaser_version)" ]; then \
+		echo "--> Installing golangci-lint $(goreleaser_version)"; \
+		go install github.com/goreleaser/goreleaser@$(goreleaser_version); \
+	else \
+		echo "--> goreleaser $(goreleaser_version) is already installed"; \
+	fi
+
 build:
-	go build -o $(PKGNAME) -v ./cmd/$(PKGNAME)
-	
+	@$(MAKE) goreleaser-install
+	goreleaser build --clean --snapshot
+
 .PHONY: build

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -3,7 +3,7 @@ goreleaser_version=v1.24.0
 
 goreleaser-install:
 	@echo "--> Checking if goreleaser $(goreleaser_version) is installed"
-	@if [ $$(goreleaser --version 2> /dev/null | grep GitVersion | awk '{ print $$2 }') != "$(goreleaser_version)" ]; then \
+	@if [ "$$(goreleaser --version 2> /dev/null | grep GitVersion | awk '{ print $$2 }')" != "$(goreleaser_version)" ]; then \
 		echo "--> Installing goreleaser $(goreleaser_version)"; \
 		go install github.com/goreleaser/goreleaser@$(goreleaser_version); \
 	else \

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -15,4 +15,4 @@ build:
 	goreleaser build --clean --snapshot
 	@echo "--> Build binary is available in the ./dist directory"
 
-.PHONY: build
+.PHONY: build goreleaser-install

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -2,8 +2,8 @@ goreleaser_version=v1.24.0
 
 goreleaser-install:
 	@echo "--> Checking if goreleaser $(goreleaser_version) is installed"
-	@if [ $$(goreleaser --version | grep GitVersion | awk '{ print $$2 }') != "$(goreleaser_version)" ]; then \
-		echo "--> Installing golangci-lint $(goreleaser_version)"; \
+	@if [ $$(goreleaser --version 2> /dev/null | grep GitVersion | awk '{ print $$2 }') != "$(goreleaser_version)" ]; then \
+		echo "--> Installing goreleaser $(goreleaser_version)"; \
 		go install github.com/goreleaser/goreleaser@$(goreleaser_version); \
 	else \
 		echo "--> goreleaser $(goreleaser_version) is already installed"; \

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -35,6 +35,7 @@ release:
 	@echo "--> git: push tag $(args_release_tag)"
 	@git push origin $(args_release_tag)
 	@echo "--> goreleaser release"
+	goreleaser release --clean
 
 ## do-nothing targets for extra unused args passed into @release
 %:

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -13,5 +13,6 @@ goreleaser-install:
 build:
 	@$(MAKE) goreleaser-install
 	goreleaser build --clean --snapshot
+	@echo "--> Build binary is available in the ./dist directory"
 
 .PHONY: build

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -20,12 +20,21 @@ release:
 	$(eval args_count := $(words $(MAKECMDGOALS)))
 	$(eval args_release_tag := $(word 2, $(MAKECMDGOALS)))
 	@if [ "$(args_count)" != "2" ]; then \
-		echo -e " wrong argument!\n usage: make release <tag-version>"; \
+		echo " [Error] Wrong argument!";\
+		echo -e " --> usage: make release <tag-version>\n"; \
+		exit 1; \
+	fi
+	@if [ -z "${GITHUB_TOKEN}" ]; then\
+		echo " [Error] GITHUB_TOKEN not found!"; \
+		echo " --> Provide GITHUB_TOKEN as env variable, or in a file at '~/.config/goreleaser/github_token'."; \
+		echo -e "     (Grant 'repo' scopes permission: https://github.com/settings/tokens/new)\n"; \
 		exit 1; \
 	fi
 	@echo "--> Release Tag: $(args_release_tag)"
 	@echo "--> git: tags current commit HEAD"
+	@git tag $(args_release_tag) HEAD -f
 	@echo "--> git: push tag $(args_release_tag)"
+	@git push origin $(args_release_tag) -f
 	@echo "--> goreleaser release"
 
 ## do-nothing targets for extra args passed into @release

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -15,7 +15,6 @@ build:
 	@goreleaser build --clean --snapshot
 	@echo "--> Build binary is available in the ./dist directory"
 
-### WIP
 release:
 	$(eval args_count := $(words $(MAKECMDGOALS)))
 	$(eval args_release_tag := $(word 2, $(MAKECMDGOALS)))
@@ -37,7 +36,7 @@ release:
 	@git push origin $(args_release_tag) -f
 	@echo "--> goreleaser release"
 
-## do-nothing targets for extra args passed into @release
+## do-nothing targets for extra unused args passed into @release
 %:
 	@:
 

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -30,10 +30,10 @@ release:
 		exit 1; \
 	fi
 	@echo "--> Release Tag: $(args_release_tag)"
-	@echo "--> git: tags current commit HEAD"
-	@git tag $(args_release_tag) HEAD -f
+	@echo "--> git: tags current commit"
+	@git tag -a $(args_release_tag) -m "goreleaser: $(args_release_tag)"
 	@echo "--> git: push tag $(args_release_tag)"
-	@git push origin $(args_release_tag) -f
+	@git push origin $(args_release_tag)
 	@echo "--> goreleaser release"
 
 ## do-nothing targets for extra unused args passed into @release

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -12,7 +12,24 @@ goreleaser-install:
 
 build:
 	@$(MAKE) goreleaser-install
-	goreleaser build --clean --snapshot
+	@goreleaser build --clean --snapshot
 	@echo "--> Build binary is available in the ./dist directory"
 
-.PHONY: build goreleaser-install
+### WIP
+release:
+	$(eval args_count := $(words $(MAKECMDGOALS)))
+	$(eval args_release_tag := $(word 2, $(MAKECMDGOALS)))
+	@if [ "$(args_count)" != "2" ]; then \
+		echo -e " wrong argument!\n usage: make release <tag-version>"; \
+		exit 1; \
+	fi
+	@echo "--> Release Tag: $(args_release_tag)"
+	@echo "--> git: tags current commit HEAD"
+	@echo "--> git: push tag $(args_release_tag)"
+	@echo "--> goreleaser release"
+
+## do-nothing targets for extra args passed into @release
+%:
+	@:
+
+.PHONY: build goreleaser-install release

--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -2,22 +2,17 @@ clean:
 	@echo "--> Cleaning up"
 	@echo "--> Running go clean"
 	@go clean
-	@echo "--> Removing binary"
-	@rm -f $(PKGNAME)
+	@echo "--> Removing build './dist' directory"
+	@rm -rf ./dist
 	@echo "--> Removing coverage files"
 	@find . -type f -name "*.out" -exec rm -f {} \;
 
 
 install:
 	@echo "--> Installing World CLI"
-	@echo "--> Building binary"
-	@go build -o $(PKGNAME) -v ./cmd/$(PKGNAME)
-	@echo "--> Copying binary to /usr/local/bin"
 	@mkdir -p /usr/local/bin
-	@cp $(PKGNAME) /usr/local/bin
-	@chmod +x /usr/local/bin/$(PKGNAME)
+	@echo "--> Building binary, install to /usr/local/bin"
+	@goreleaser build --clean --single-target --snapshot -o /usr/local/bin/$(PKGNAME)
 	@echo "--> Installed $(PKGNAME) to /usr/local/bin"
-	@echo "--> Cleaning up"
-	@rm -f $(PKGNAME)
-	
+
 .PHONY: clean install


### PR DESCRIPTION
Closes: WORLD-971

## Overview

- Implement [GoReleaser](https://goreleaser.com/) for build and releasing world-cli binary package.
- Release can be done in two ways:
	- Create a manual release from GitHub pages, and CI will trigger the GoReleaser to do the build, upload all the binaries, and add the changelog.
	- Or, trigger it locally using `make release <tag-version>`, and it will automatically create the tag, push it, create the release, and upload all the binary builds.

## Brief Changelog

- add GoReleaser config file (.goreleaser.yml)
- update `make build` to use goreleaser cli
- add `make goreleaser-install`
- update CI related workflow for build & release
- fix Posthog API var missmatch on main branch
- add `make release <tag-version>` 



## Testing and Verifying

- `make install` & `make clean`
![image](https://github.com/Argus-Labs/world-cli/assets/29672212/f95c471b-90c5-450a-a18b-4d3e55c5aa36)

- `make release` 
  - handle wrong/incomplete argument:
![image](https://github.com/Argus-Labs/world-cli/assets/29672212/087d039c-a27f-4ca2-9aa3-20627e2b4e67)

  - success release v1.2.5-alpha-5
![image](https://github.com/Argus-Labs/world-cli/assets/29672212/a030cc8b-bc19-426f-83c3-03b4ee4f004d)
![image](https://github.com/Argus-Labs/world-cli/assets/29672212/b1cb0ff2-e859-4c7f-b9bd-06ecd007d132)
