### PR TITLE
feat: append generated router key to world.toml

### DIFF
--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -23,7 +23,7 @@ var (
 func init() {
 	// Set default app version in case not provided by ldflags
 	if AppVersion == "" {
-		AppVersion = "dev"
+		AppVersion = "v0.0.1-dev"
 	}
 	root.AppVersion = AppVersion
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -24,7 +24,7 @@ var (
 	// Items under these toml headers will be included in the environment variables when
 	// running docker. An error will be generated if a duplicate key is found across
 	// these sections.
-	dockerEnvHeaders = []string{"cardinal", "evm", "nakama"}
+	dockerEnvHeaders = []string{"cardinal", "evm", "nakama", "common"}
 )
 
 type Config struct {

--- a/common/teacmd/git_test.go
+++ b/common/teacmd/git_test.go
@@ -1,6 +1,7 @@
 package teacmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,5 +71,100 @@ func cleanUpDir(targetDir string) {
 		if err != nil {
 			fmt.Println(err)
 		}
+	}
+}
+
+func TestAppendToToml(t *testing.T) {
+	// Create a temporary TOML file for testing
+	tempFile, err := os.CreateTemp("", "test.toml")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(tempFile.Name())
+	})
+
+	// Define test cases
+	tests := []struct {
+		name          string
+		filePath      string
+		section       string
+		fields        map[string]any
+		expectedError error
+	}{
+		{
+			name:     "append first section and fields",
+			filePath: tempFile.Name(),
+			section:  "example_section",
+			fields: map[string]any{
+				"field1": "example_value",
+				"field2": 123,
+			},
+			expectedError: nil,
+		},
+		{
+			name:     "append fields to existing section",
+			filePath: tempFile.Name(),
+			section:  "example_section",
+			fields: map[string]any{
+				"field1": "replaced_value",
+				"field2": 321,
+			},
+			expectedError: nil,
+		},
+		{
+			name:     "create new section and append fields",
+			filePath: tempFile.Name(),
+			section:  "new_section",
+			fields: map[string]any{
+				"field3": true,
+				"field4": 3.14,
+			},
+			expectedError: nil,
+		},
+		// Add more test cases if needed
+	}
+
+	// Run test cases
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := appendToToml(tt.filePath, tt.section, tt.fields)
+			if !errors.Is(err, tt.expectedError) {
+				t.Errorf("unexpected error: got %v, want %v", err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestGenerateRandomHexString(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{
+			name:   "length 0",
+			length: 0,
+		},
+		{
+			name:   "length 8",
+			length: 8,
+		},
+		{
+			name:   "length 16",
+			length: 16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateRandomHexString(tt.length)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if len(got) != tt.length*2 {
+				t.Errorf("unexpected length of generated hex string: got %d, want %d", len(got), tt.length*2)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/magefile/mage v1.15.0
 	github.com/pelletier/go-toml v1.9.5
+	github.com/pelletier/go-toml/v2 v2.0.5
 	github.com/posthog/posthog-go v0.0.0-20240202122501-d793288ce2c9
 	github.com/rotisserie/eris v0.5.4
 	github.com/rs/zerolog v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/muesli/termenv v0.15.1 h1:UzuTb/+hhlBugQz28rpzey4ZuKcZ03MeKsoG7IJZIxs
 github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4ANqrZs2sQ=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
+github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
 github.com/pilu/config v0.0.0-20131214182432-3eb99e6c0b9a h1:Tg4E4cXPZSZyd3H1tJlYo6ZreXV0ZJvE/lorNqyw1AU=
 github.com/pilu/config v0.0.0-20131214182432-3eb99e6c0b9a/go.mod h1:9Or9aIl95Kp43zONcHd5tLZGKXb9iLx0pZjau0uJ5zg=
 github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a h1:U8Xgy85P2npR1jqpNF4q9rLSt6kzrOrWubkepc3lWbE=
@@ -91,7 +93,10 @@ github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRM
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -112,6 +117,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/gookit/color.v1 v1.1.6 h1:5fB10p6AUFjhd2ayq9JgmJWr9WlTrguFdw3qlYtKNHk=
 gopkg.in/gookit/color.v1 v1.1.6/go.mod h1:IcEkFGaveVShJ+j8ew+jwe9epHyGpJ9IrptHmW3laVY=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=


### PR DESCRIPTION
Closes: WORLD-990

## Overview

World CLI generates router key and append it to world.toml file

## Brief Changelog

- create function for appending the section and field to toml file
- create function for generating random hex string


## Testing and Verifying

- create unit test for added function
- test the env by running command `world cardinal start`
