### PR TITLE
feat: fetch & download cardinal editor on world create

### DIFF
--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -41,6 +41,7 @@ func main() {
 	err := globalconfig.SetupConfigDir()
 	if err != nil {
 		log.Err(err).Msg("could not setup config folder")
+		return
 	}
 
 	// Posthog Initialization

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -30,17 +30,18 @@ func init() {
 }
 
 func main() {
-	err := globalconfig.SetupConfigDir()
-	if err != nil {
-		log.Err(err).Msg("could not setup config folder")
-	}
-
 	// Sentry initialization
 	telemetry.SentryInit(SentryDsn)
 	defer telemetry.SentryFlush()
 
 	// Set logger sentry hook
 	log.Logger = log.Logger.Hook(telemetry.SentryHook{})
+
+	// Set up config directory "~/.worldcli/"
+	err := globalconfig.SetupConfigDir()
+	if err != nil {
+		log.Err(err).Msg("could not setup config folder")
+	}
 
 	// Posthog Initialization
 	telemetry.PosthogInit(PosthogAPIKey)

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"pkg.world.dev/world-cli/cmd/world/root"
+	"pkg.world.dev/world-cli/common/globalconfig"
 	"pkg.world.dev/world-cli/telemetry"
 
 	_ "pkg.world.dev/world-cli/common/logger"
@@ -29,6 +30,11 @@ func init() {
 }
 
 func main() {
+	err := globalconfig.SetupConfigDir()
+	if err != nil {
+		log.Err(err).Msg("could not setup config folder")
+	}
+
 	// Sentry initialization
 	telemetry.SentryInit(SentryDsn)
 	defer telemetry.SentryFlush()

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -124,7 +124,7 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			)
 		}
 		if msg.Index == 2 { //nolint:gomnd
-			err := teacmd.SetupCardinalEditor(m.projectNameInput.Value())
+			err := teacmd.SetupCardinalEditor()
 			teaCmd := func() tea.Msg {
 				return teacmd.GitCloneFinishMsg{Err: err}
 			}

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -54,6 +54,7 @@ func NewWorldCreateModel(args []string) WorldCreateModel {
 	createSteps.Steps = []steps.Entry{
 		steps.NewStep("Set game shard name"),
 		steps.NewStep("Initialize game shard with starter-game-template"),
+		steps.NewStep("Set up Cardinal Editor"),
 	}
 
 	// Set the project text if it was passed in as an argument
@@ -119,6 +120,17 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			return m, tea.Sequence(
 				NewLogCmd(style.ChevronIcon.Render()+"Cloning starter-game-template..."),
+				teaCmd,
+			)
+		}
+		if msg.Index == 2 { //nolint:gomnd
+			err := teacmd.SetupCardinalEditor(m.projectNameInput.Value())
+			teaCmd := func() tea.Msg {
+				return teacmd.GitCloneFinishMsg{Err: err}
+			}
+
+			return m, tea.Sequence(
+				NewLogCmd(style.ChevronIcon.Render()+"Setting up Cardinal Editor"),
 				teaCmd,
 			)
 		}

--- a/common/globalconfig/globalconfig.go
+++ b/common/globalconfig/globalconfig.go
@@ -1,0 +1,28 @@
+package globalconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	configDir = ".worldcli"
+)
+
+func GetConfigDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(homeDir, configDir), nil
+}
+
+func SetupConfigDir() error {
+	fullConfigDir, err := GetConfigDir()
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(fullConfigDir, 0755)
+}

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -18,6 +18,7 @@ const (
 	latestReleaseURL             = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
 	httpTimeout                  = 5 * time.Second
 	tmpZipFileName               = "tmp.zip"
+	editorDir                    = ".editor"
 	cardinalProjectIDPlaceholder = "__CARDINAL_PROJECT_ID__"
 )
 
@@ -134,7 +135,7 @@ func unzipFile() error {
 		}
 	}
 
-	if err = os.Rename(originalDir, ".editor"); err != nil {
+	if err = os.Rename(originalDir, editorDir); err != nil {
 		return err
 	}
 
@@ -150,7 +151,7 @@ func unzipFile() error {
 }
 
 func replaceProjectIDs() error {
-	assetsDir := ".editor/assets"
+	assetsDir := filepath.Join(editorDir, "assets")
 	files, err := os.ReadDir(assetsDir)
 	if err != nil {
 		return err

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -1,0 +1,151 @@
+package teacmd
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	latestReleaseURL = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
+	httpTimeout      = 2 * time.Second
+)
+
+type Asset struct {
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type Release struct {
+	Assets []Asset `json:"assets"`
+}
+
+func SetupCardinalEditor(targetDir string) error {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: httpTimeout,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var release Release
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(bodyBytes, &release); err != nil {
+		return err
+	}
+
+	err = downloadAndUnzipFle(release.Assets[0].BrowserDownloadURL, targetDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadAndUnzipFle(url string, targetDir string) error {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: httpTimeout,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = os.Chdir(targetDir)
+	if err != nil {
+		return err
+	}
+
+	err = unzipFile(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unzipFile(src io.Reader) error {
+	tmp := "tmp.zip"
+	file, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, src)
+	if err != nil {
+		return err
+	}
+
+	reader, err := zip.OpenReader(tmp)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	// save original folder name
+	var originalDir string
+	for _, file := range reader.File {
+		src, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+
+		if file.FileInfo().IsDir() {
+			if originalDir == "" {
+				originalDir = file.Name
+			}
+			err = os.MkdirAll(file.Name, 0777)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		dstPath := file.Name
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+
+		_, err = io.Copy(dst, src) //nolint:gosec // zip file is from us
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.Rename(originalDir, ".editor")
+	if err != nil {
+		println(err.Error())
+		return err
+	}
+
+	err = os.Remove(tmp)
+	if err != nil {
+		println(err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -7,12 +7,18 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
-	latestReleaseURL = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
-	httpTimeout      = 5 * time.Second
+	latestReleaseURL             = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
+	httpTimeout                  = 5 * time.Second
+	tmpZipFileName               = "tmp.zip"
+	cardinalProjectIDPlaceholder = "__CARDINAL_PROJECT_ID__"
 )
 
 type Asset struct {
@@ -47,15 +53,19 @@ func SetupCardinalEditor() error {
 		return err
 	}
 
-	err = downloadAndUnzipFle(release.Assets[0].BrowserDownloadURL)
+	err = downloadRelease(release.Assets[0].BrowserDownloadURL)
 	if err != nil {
+		return err
+	}
+
+	if err = unzipFile(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func downloadAndUnzipFle(url string) error {
+func downloadRelease(url string) error {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -70,7 +80,13 @@ func downloadAndUnzipFle(url string) error {
 	}
 	defer resp.Body.Close()
 
-	err = unzipFile(resp.Body)
+	file, err := os.Create(tmpZipFileName)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, resp.Body)
 	if err != nil {
 		return err
 	}
@@ -78,20 +94,8 @@ func downloadAndUnzipFle(url string) error {
 	return nil
 }
 
-func unzipFile(src io.Reader) error {
-	tmp := "tmp.zip"
-	file, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, src)
-	if err != nil {
-		return err
-	}
-
-	reader, err := zip.OpenReader(tmp)
+func unzipFile() error {
+	reader, err := zip.OpenReader(tmpZipFileName)
 	if err != nil {
 		return err
 	}
@@ -134,9 +138,46 @@ func unzipFile(src io.Reader) error {
 		return err
 	}
 
-	if err = os.Remove(tmp); err != nil {
+	if err = os.Remove(tmpZipFileName); err != nil {
+		return err
+	}
+
+	if err = replaceProjectIDs(); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func replaceProjectIDs() error {
+	assetsDir := ".editor/assets"
+	files, err := os.ReadDir(assetsDir)
+	if err != nil {
+		return err
+	}
+
+	// "ce" prefix is added because guids can start with numbers, which is not allowed in js
+	projectID := "ce" + strippedGUID()
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), ".js") {
+			content, err := os.ReadFile(filepath.Join(assetsDir, file.Name()))
+			if err != nil {
+				return err
+			}
+
+			newContent := strings.ReplaceAll(string(content), cardinalProjectIDPlaceholder, projectID)
+
+			err = os.WriteFile(filepath.Join(assetsDir, file.Name()), []byte(newContent), 0600)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func strippedGUID() string {
+	u := uuid.New()
+	return strings.ReplaceAll(u.String(), "-", "")
 }

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	latestReleaseURL = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
-	httpTimeout      = 2 * time.Second
+	httpTimeout      = 5 * time.Second
 )
 
 type Asset struct {
@@ -23,7 +23,7 @@ type Release struct {
 	Assets []Asset `json:"assets"`
 }
 
-func SetupCardinalEditor(targetDir string) error {
+func SetupCardinalEditor() error {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, latestReleaseURL, nil)
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func SetupCardinalEditor(targetDir string) error {
 		return err
 	}
 
-	err = downloadAndUnzipFle(release.Assets[0].BrowserDownloadURL, targetDir)
+	err = downloadAndUnzipFle(release.Assets[0].BrowserDownloadURL)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func SetupCardinalEditor(targetDir string) error {
 	return nil
 }
 
-func downloadAndUnzipFle(url string, targetDir string) error {
+func downloadAndUnzipFle(url string) error {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -69,11 +69,6 @@ func downloadAndUnzipFle(url string, targetDir string) error {
 		return err
 	}
 	defer resp.Body.Close()
-
-	err = os.Chdir(targetDir)
-	if err != nil {
-		return err
-	}
 
 	err = unzipFile(resp.Body)
 	if err != nil {
@@ -135,15 +130,11 @@ func unzipFile(src io.Reader) error {
 		}
 	}
 
-	err = os.Rename(originalDir, ".editor")
-	if err != nil {
-		println(err.Error())
+	if err = os.Rename(originalDir, ".editor"); err != nil {
 		return err
 	}
 
-	err = os.Remove(tmp)
-	if err != nil {
-		println(err.Error())
+	if err = os.Remove(tmp); err != nil {
 		return err
 	}
 

--- a/common/teacmd/editor_test.go
+++ b/common/teacmd/editor_test.go
@@ -103,10 +103,10 @@ func TestCopyDir(t *testing.T) {
 		err = copyDir("tmp", "tmp2")
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join("tmp"))
+		_, err = os.Stat("tmp")
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join("tmp2"))
+		_, err = os.Stat("tmp2")
 		assert.NilError(t, err)
 
 		_, err = os.Stat(filepath.Join("tmp2", "subdir"))

--- a/common/teacmd/editor_test.go
+++ b/common/teacmd/editor_test.go
@@ -1,0 +1,70 @@
+package teacmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSetupCardinalEditor(t *testing.T) {
+	t.Run("setup cardinal editor", func(t *testing.T) {
+		cleanUpDir(editorDir)
+
+		err := SetupCardinalEditor()
+		assert.NilError(t, err)
+
+		// check if .editor directory exists
+		_, err = os.Stat(editorDir)
+		assert.NilError(t, err)
+
+		// check if it's not empty
+		dir, err := os.ReadDir(editorDir)
+		assert.NilError(t, err)
+		assert.Assert(t, len(dir) != 0)
+
+		// check if project id is replaced
+		containsPlaceholder, err := containsCardinalProjectIDPlaceholder("")
+		assert.NilError(t, err)
+		assert.Equal(t, containsPlaceholder, false)
+
+		// TODO: check if cardinal editor works
+
+		cleanUpDir(editorDir)
+	})
+}
+
+func containsCardinalProjectIDPlaceholder(dir string) (bool, error) {
+	files, err := os.ReadDir(filepath.Join(editorDir, dir))
+	if err != nil {
+		return false, err
+	}
+
+	for _, file := range files {
+		// recurse over child directories
+		if file.IsDir() {
+			contains, err := containsCardinalProjectIDPlaceholder(filepath.Join(dir, file.Name()))
+			if contains || err != nil {
+				return contains, err
+			}
+			continue
+		}
+
+		if strings.HasSuffix(file.Name(), ".js") {
+			filePath := filepath.Join(editorDir, dir, file.Name())
+
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				return false, err
+			}
+
+			if strings.Contains(string(content), cardinalProjectIDPlaceholder) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/common/teacmd/editor_test.go
+++ b/common/teacmd/editor_test.go
@@ -88,38 +88,38 @@ func containsCardinalProjectIDPlaceholder(dir string, originalID string) (bool, 
 }
 func TestCopyDir(t *testing.T) {
 	t.Run("Test copy directory", func(t *testing.T) {
-		err := os.MkdirAll(filepath.Join(testDir, "tmp"), 0755)
-		assert.Check(t, os.IsExist(err))
-
-		err = os.MkdirAll(filepath.Join(testDir, "tmp", "subdir"), 0755)
-		assert.Check(t, os.IsExist(err))
-
-		_, err = os.Create(filepath.Join(testDir, "tmp", "file1"))
+		err := os.MkdirAll("tmp", 0755)
 		assert.NilError(t, err)
 
-		_, err = os.Create(filepath.Join(testDir, "tmp", "subdir", "file2"))
+		err = os.MkdirAll(filepath.Join("tmp", "subdir"), 0755)
 		assert.NilError(t, err)
 
-		err = copyDir(filepath.Join(testDir, "tmp"), filepath.Join(testDir, "tmp2"))
+		_, err = os.Create(filepath.Join("tmp", "file1"))
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join(testDir, "tmp"))
-		assert.Check(t, os.IsNotExist(err))
+		_, err = os.Create(filepath.Join("tmp", "subdir", "file2"))
+		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join(testDir, "tmp2"))
-		assert.Check(t, os.IsExist(err))
+		err = copyDir("tmp", "tmp2")
+		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join(testDir, "tmp2", "subdir"))
-		assert.Check(t, os.IsExist(err))
+		_, err = os.Stat(filepath.Join("tmp"))
+		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join(testDir, "tmp2", "file1"))
-		assert.Check(t, os.IsExist(err))
+		_, err = os.Stat(filepath.Join("tmp2"))
+		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join(testDir, "tmp2", "subdir", "file2"))
-		assert.Check(t, os.IsExist(err))
+		_, err = os.Stat(filepath.Join("tmp2", "subdir"))
+		assert.NilError(t, err)
 
-		cleanUpDir(filepath.Join(testDir, "tmp"))
-		cleanUpDir(filepath.Join(testDir, "tmp2"))
+		_, err = os.Stat(filepath.Join("tmp2", "file1"))
+		assert.NilError(t, err)
+
+		_, err = os.Stat(filepath.Join("tmp2", "subdir", "file2"))
+		assert.NilError(t, err)
+
+		cleanUpDir("tmp")
+		cleanUpDir("tmp2")
 	})
 }
 

--- a/common/teacmd/editor_test.go
+++ b/common/teacmd/editor_test.go
@@ -86,3 +86,46 @@ func containsCardinalProjectIDPlaceholder(dir string, originalID string) (bool, 
 
 	return false, nil
 }
+func TestCopyDir(t *testing.T) {
+	t.Run("Test copy directory", func(t *testing.T) {
+		err := os.MkdirAll(filepath.Join(testDir, "tmp"), 0755)
+		assert.Check(t, os.IsExist(err))
+
+		err = os.MkdirAll(filepath.Join(testDir, "tmp", "subdir"), 0755)
+		assert.Check(t, os.IsExist(err))
+
+		_, err = os.Create(filepath.Join(testDir, "tmp", "file1"))
+		assert.NilError(t, err)
+
+		_, err = os.Create(filepath.Join(testDir, "tmp", "subdir", "file2"))
+		assert.NilError(t, err)
+
+		err = copyDir(filepath.Join(testDir, "tmp"), filepath.Join(testDir, "tmp2"))
+		assert.NilError(t, err)
+
+		_, err = os.Stat(filepath.Join(testDir, "tmp"))
+		assert.Check(t, os.IsNotExist(err))
+
+		_, err = os.Stat(filepath.Join(testDir, "tmp2"))
+		assert.Check(t, os.IsExist(err))
+
+		_, err = os.Stat(filepath.Join(testDir, "tmp2", "subdir"))
+		assert.Check(t, os.IsExist(err))
+
+		_, err = os.Stat(filepath.Join(testDir, "tmp2", "file1"))
+		assert.Check(t, os.IsExist(err))
+
+		_, err = os.Stat(filepath.Join(testDir, "tmp2", "subdir", "file2"))
+		assert.Check(t, os.IsExist(err))
+
+		cleanUpDir(filepath.Join(testDir, "tmp"))
+		cleanUpDir(filepath.Join(testDir, "tmp2"))
+	})
+}
+
+func TestStrippedGUID(t *testing.T) {
+	t.Run("Test guid doesn't contain -", func(t *testing.T) {
+		s := strippedGUID()
+		assert.Check(t, !strings.Contains(s, "-"))
+	})
+}

--- a/telemetry/posthog.go
+++ b/telemetry/posthog.go
@@ -8,12 +8,14 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	"github.com/posthog/posthog-go"
 	"github.com/rs/zerolog/log"
+
+	"pkg.world.dev/world-cli/common/globalconfig"
 )
 
 const (
 	PostInstallationEvent = "World CLI Installation"
 	RunningEvent          = "World CLI Running"
-	timestampFile         = ".worldcli"
+	timestampFile         = "last_logged_time"
 )
 
 var (
@@ -71,11 +73,11 @@ func getLastLoggedTime() (time.Time, error) {
 
 // getTimestampFilePath returns the path to the timestamp file.
 func getTimestampFilePath() (string, error) {
-	homeDir, err := os.UserHomeDir()
+	configDir, err := globalconfig.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(homeDir, timestampFile), nil
+	return filepath.Join(configDir, timestampFile), nil
 }
 
 // updateLastLoggedTime updates the last visited timestamp in the file.


### PR DESCRIPTION
Closes: WORLD-999
<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview
Sets up Cardinal Editor on `world create`. The set up steps include:
- download the latest release from github
- unzip into `{targetDirectory}/.editor`
- replace all instances of `__CARDINAL_PROJECT_ID__` with a guid
<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog
- New step in `world create`
- SetupCardinalEditor function in the `teacmd` package
- Unit tests for it

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying
Added unit test that checks if the editor is setup correct. (though it doesn't check if it works correctly, as the web server isn't implemented yet)

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->