### PR TITLE
feat: run cadinal editor on dev mode

### DIFF
--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -87,6 +88,11 @@ func checkLatestVersion() error {
 		return nil
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Debug(eris.Wrap(errors.New("status is not 200"), "error fetching the latest release"))
+		return nil
+	}
 
 	// Unmarshal the response body into the Release structure
 	var release Release

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
+	TargetEditorDir = ".editor"
+
 	latestReleaseURL             = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases/latest"
 	httpTimeout                  = 2 * time.Second
-	targetEditorDir              = ".editor"
 	cardinalProjectIDPlaceholder = "__CARDINAL_PROJECT_ID__"
 )
 
@@ -46,7 +47,7 @@ func SetupCardinalEditor() error {
 	}
 
 	// rename version tag dir to .editor
-	err = copyDir(editorDir, targetEditorDir)
+	err = copyDir(editorDir, TargetEditorDir)
 	if err != nil {
 		return err
 	}
@@ -54,7 +55,7 @@ func SetupCardinalEditor() error {
 	// rename project id
 	// "ce" prefix is added because guids can start with numbers, which is not allowed in js
 	projectID := "ce" + strippedGUID()
-	err = replaceProjectIDs(targetEditorDir, projectID)
+	err = replaceProjectIDs(TargetEditorDir, projectID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes: WORLD-1000

## Overview

Add feature run cardinal on `world cardinal dev`

## Brief Changelog
- add function to serve cardinal editor web files
- add function to find unused port from 3000 to 4000
- add step to run cardinal editor before running redis and cardinal server (it will not block the process if cardinal editor failed to run)

## Testing and Verifying

manually tested using `world cardinal dev` command

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/d8464305-83c0-4190-8c52-e74a80668b83.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/06a3d01b-8821-441e-a8e7-e534fe5f3ef9.png)


## Todo
This will be updated in the next PR

- Check cardinal version to be match with cardinal server
- Setup cardinal editor dir if not exists
