### PR TITLE
fix: delete .worldcli cache file if it exists before creating .worldcli directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dist/
 
 # Test
 /starter-game
+
+# Built binary
+world

--- a/common/globalconfig/globalconfig.go
+++ b/common/globalconfig/globalconfig.go
@@ -24,5 +24,16 @@ func SetupConfigDir() error {
 		return err
 	}
 
+	fs, err := os.Stat(fullConfigDir)
+	if !os.IsNotExist(err) {
+		// remove old .worldcli file
+		if !fs.IsDir() {
+			err = os.Remove(fullConfigDir)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return os.MkdirAll(fullConfigDir, 0755)
 }


### PR DESCRIPTION
Closes: WORLD-1020

## Overview
Previously the `.worldcli` file was used as a cache for the last logged in time for posthog. This file was moved to `.worldcli/last_logged_time`, so the setup function should remove it before creating the `.worldcli` directory.

## Brief Changelog
- delete .worldcli cache file if it exists before creating .worldcli directory

## Testing and Verifying
Manually tested & verified