### PR TITLE
fix: quick hotfix to have a default/fallback value for cardinal editor versioning

### DIFF
--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -36,13 +36,14 @@ const (
 )
 
 var (
+	defaultVersion = "v0.3.0"
 	// Cardinal : Cardinal Editor version map
 	// TODO this version map need to store in somewhere that can be accessed online
 	cardinalVersionMap = map[string]string{
 		"v1.2.2-beta": "v0.1.0",
 		"v1.2.3-beta": "v0.1.0",
-		"v1.2.4-beta": "v0.3.0",
-		"v1.2.5-beta": "v0.3.0",
+		"v1.2.4-beta": defaultVersion,
+		"v1.2.5-beta": defaultVersion,
 	}
 )
 
@@ -64,6 +65,10 @@ func SetupCardinalEditor() error {
 
 	downloadURL := latestReleaseURL
 	downloadVersion, versionIsExist := cardinalVersionMap[cardinalVersion]
+	if downloadVersion == "" {
+		// default to defaultVersion
+		downloadVersion = defaultVersion
+	}
 	if versionIsExist {
 		downloadURL = fmt.Sprintf("%s/tags/%s", releaseURL, downloadVersion)
 	}

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -65,7 +65,7 @@ func SetupCardinalEditor() error {
 
 	downloadURL := latestReleaseURL
 	downloadVersion, versionIsExist := cardinalVersionMap[cardinalVersion]
-	if downloadVersion == "" {
+	if !versionIsExist {
 		// default to defaultVersion
 		downloadVersion = defaultVersion
 	}


### PR DESCRIPTION
## Overview

this is just a quick patch fix to a small bug. i opened a linear ticket to address this more thoroughly.  https://linear.app/arguslabs/issue/WORLD-1046/cardinal-cardinal-editor-version-map-in-cli

## Brief Changelog


## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->