### PR TITLE
fix: cardinal editor version mapping

### DIFF
--- a/example-world.toml
+++ b/example-world.toml
@@ -25,7 +25,7 @@ FAUCET_ADDR="world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5"
 BLOCK_TIME="1s"
 
 [common]
-ROUTER_KEY=4a02ea35e37727a2e22b62520c03a3cf0b139418a4401027baedfc93834dc6bd # key to secure router communications.
+ROUTER_KEY="4a02ea35e37727a2e22b62520c03a3cf0b139418a4401027baedfc93834dc6bd" # key to secure router communications.
 
 [nakama]
 ENABLE_ALLOWLIST="false" # enable nakama's beta key feature. you can generate and claim beta keys by setting this to true


### PR DESCRIPTION
Closes: WORLD-1046

## Overview

Make world cli check cardinal editor version mapping to cardinal editor repo

## Brief Changelog

- Create func to fetch version map

## Testing and Verifying

- Added unit test for new func
- Tested manually using `world cardinal dev` command
