### PR TITLE
fix(world-cli): Ensure the build flag defaults to true

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 func AddConfigFlag(cmd *cobra.Command) {
-	cmd.Flags().String(flagForConfigFile, "", "a toml encoded config file")
+	cmd.PersistentFlags().String(flagForConfigFile, "", "a toml encoded config file")
 }
 
 func GetConfig(cmd *cobra.Command) (*Config, error) {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -58,8 +58,8 @@ func GetConfig(cmd *cobra.Command) (*Config, error) {
 // 4. A config file found in a parent directory.
 func findAndLoadConfigFile(cmd *cobra.Command) (*Config, error) {
 	// First look for the config file in the config file flag.
-	if cmd.Flags().Changed(flagForConfigFile) {
-		configFile, err := cmd.Flags().GetString(flagForConfigFile)
+	if cmd.PersistentFlags().Changed(flagForConfigFile) {
+		configFile, err := cmd.PersistentFlags().GetString(flagForConfigFile)
 		if err != nil {
 			return nil, err
 		}

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -21,7 +21,10 @@ func cmdZero() *cobra.Command {
 func cmdWithConfig(filename string) *cobra.Command {
 	cmd := cmdZero()
 	AddConfigFlag(cmd)
-	_ = cmd.Flags().Set(flagForConfigFile, filename)
+	err := cmd.PersistentFlags().Set(flagForConfigFile, filename)
+	if err != nil {
+		panic(err)
+	}
 	return cmd
 }
 


### PR DESCRIPTION
Closes: WORLD-1063

## Overview

Currently, `world cardinal start` will not rebuild the cardinal container when the code has been modified. Either `world cardinal start --build` or `world cardinal start --build=true` needs to be run. This PR makes it so the following 3 commands have the same behavior:
```
world cardinal start
world cardinal start --build
world cardinal start --build=true
```

## Brief Changelog

Ensure the cfg.Build field is set to true by default.
Refactor the config source file to make the precedent ordering more clear. 

## Testing and Verifying

To manually test this, checkout this branch and navigate to the `world-cli/cmd/world` directory. Then run:
`go build -o newworld main.go`

This creates an executable called `newworld`. This allows you to compare the behavior of the default `world` behavior to this branch.

Navigate to the starter-game-template directory.

Run `world cardinal start`

Docker containers will be built and started. Ctrl+c this process.

Modify the main.go file in the starter game template (e.g. add random newline). 

Run `world cardinal start` again. This should start quickly (because the cardinal container was not rebuilt).

Ctrl+c this process.

Run `<path-to-newworld>/newworld cardinal start`. This should take a little longer to run, because the cardinal container is actually getting rebuilt this time. You should see some log output signaling that a container is being built.

Ctrl+c this process.

Run `<path-to-newworld>/newworld cardinal start` again. This should start quickly. While docker received the signal to build cardinal, cardinal hasn't been modified, so it should start quickly.

