### PR TITLE
fix: find world.tom on parent dir

### DIFF
--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -109,7 +109,7 @@ This will start the following Docker services and its dependencies:
 				fmt.Println(cmdBlue.Render(fmt.Sprint("Cardinal Editor will be run on localhost:", cardinalEditorPort)))
 				cePrepChan := make(chan struct{})
 				go func() {
-					err := runCardinalEditor(cardinalEditorPort, cePrepChan)
+					err := runCardinalEditor(cfg.RootDir, cfg.GameDir, cardinalEditorPort, cePrepChan)
 					if err != nil {
 						cmdStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
 						fmt.Println(cmdStyle.Render("Warning: Failed to run Cardinal Editor"))

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -124,7 +124,7 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			)
 		}
 		if msg.Index == 2 { //nolint:gomnd
-			err := teacmd.SetupCardinalEditor()
+			err := teacmd.SetupCardinalEditor(".", "cardinal")
 			teaCmd := func() tea.Msg {
 				return teacmd.GitCloneFinishMsg{Err: err}
 			}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -29,6 +29,7 @@ var (
 
 type Config struct {
 	RootDir   string
+	GameDir   string
 	Detach    bool
 	Build     bool
 	Debug     bool
@@ -101,7 +102,7 @@ func loadConfigFromFile(filename string) (*Config, error) {
 	}
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open %q: %w", filename, err)
+		return nil, err
 	}
 	defer file.Close()
 
@@ -116,6 +117,16 @@ func loadConfigFromFile(filename string) (*Config, error) {
 		}
 	} else {
 		cfg.RootDir, _ = filepath.Split(filename)
+	}
+
+	// Load the game directory.
+	if gameDir, ok := data["game_dir"]; ok {
+		cfg.GameDir, ok = gameDir.(string)
+		if !ok {
+			return nil, errors.New("game_dir must be a string")
+		}
+	} else {
+		cfg.GameDir = "cardinal"
 	}
 
 	for _, header := range dockerEnvHeaders {

--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -31,8 +31,6 @@ const (
 
 	cardinalProjectIDPlaceholder = "__CARDINAL_PROJECT_ID__"
 
-	cardinalGomodPath = "cardinal/go.mod"
-
 	cardinalPkgPath = "pkg.world.dev/world-engine/cardinal"
 
 	versionMapURL = "https://raw.githubusercontent.com/Argus-Labs/cardinal-editor/main/version_map.json"
@@ -58,7 +56,7 @@ type Release struct {
 	Assets []Asset `json:"assets"`
 }
 
-func SetupCardinalEditor() error {
+func SetupCardinalEditor(rootDir string, gameDir string) error {
 	// Get the version map
 	cardinalVersionMap, err := getVersionMap(versionMapURL)
 	if err != nil {
@@ -67,7 +65,7 @@ func SetupCardinalEditor() error {
 	}
 
 	// Check version
-	cardinalVersion, err := getModuleVersion(cardinalGomodPath, cardinalPkgPath)
+	cardinalVersion, err := getModuleVersion(filepath.Join(rootDir, gameDir, "go.mod"), cardinalPkgPath)
 	if err != nil {
 		return eris.Wrap(err, "failed to get cardinal version")
 	}


### PR DESCRIPTION
Closes: WORLD-1084 & WORLD-1078 & WORLD-1045

## Overview

Fix find world.toml recursively on parent dir

## Brief Changelog

- load config and get root dir
- change hardcoded chdir using rootdir
- fix return error when file not exist

## Testing and Verifying

Manually verified by running `world cardinal dev`