### PR TITLE
feat: cardinal pretty logging, improve goroutine reliability, kill --watch

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -34,6 +34,6 @@ var BaseCmd = &cobra.Command{
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
 	BaseCmd.AddCommand(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
-	// Add --debug flag
+	// Add --log-debug flag
 	logger.AddLogFlag(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 }

--- a/cmd/world/cardinal/common_flag.go
+++ b/cmd/world/cardinal/common_flag.go
@@ -1,0 +1,7 @@
+package cardinal
+
+import "github.com/spf13/cobra"
+
+func registerEditorFlag(cmd *cobra.Command, defaultEnable bool) {
+	cmd.Flags().Bool("editor", defaultEnable, "Run Cardinal Editor, useful for prototyping and debugging")
+}

--- a/cmd/world/cardinal/util_editor.go
+++ b/cmd/world/cardinal/util_editor.go
@@ -1,0 +1,52 @@
+package cardinal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/rotisserie/eris"
+	"golang.org/x/sync/errgroup"
+
+	"pkg.world.dev/world-cli/common/teacmd"
+)
+
+const ceReadTimeout = 5 * time.Second
+
+// startCardinalEditor runs the Cardinal Editor
+func startCardinalEditor(ctx context.Context, rootDir string, gameDir string, port int) error {
+	if err := teacmd.SetupCardinalEditor(rootDir, gameDir); err != nil {
+		return err
+	}
+
+	// Create a new HTTP server
+	fs := http.FileServer(http.Dir(filepath.Join(rootDir, teacmd.TargetEditorDir)))
+	http.Handle("/", fs)
+	server := &http.Server{
+		Addr:        fmt.Sprintf(":%d", port),
+		ReadTimeout: ceReadTimeout,
+	}
+
+	group, ctx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		if err := server.ListenAndServe(); err != nil && !eris.Is(err, http.ErrServerClosed) {
+			return eris.Wrap(err, "Cardinal Editor server encountered an error")
+		}
+		return nil
+	})
+	group.Go(func() error {
+		<-ctx.Done()
+		if err := server.Shutdown(ctx); err != nil {
+			return eris.Wrap(err, "Failed to gracefully shutdown server")
+		}
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/common/env.go
+++ b/common/env.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"os"
+
+	"github.com/rotisserie/eris"
+)
+
+// WithEnv sets the environment variables from the given map.
+func WithEnv(env map[string]string) error {
+	for key, value := range env {
+		if err := os.Setenv(key, value); err != nil {
+			return eris.Wrap(err, "Failed to set env var")
+		}
+	}
+	return nil
+}

--- a/common/logger/init.go
+++ b/common/logger/init.go
@@ -15,7 +15,7 @@ const (
 
 	NoColor   = true
 	UseCaller = false // for developer, if you want to expose line of code of caller
-	flagDebug = "debug"
+	flagDebug = "log-debug"
 )
 
 var (
@@ -63,17 +63,17 @@ func PrintLogs() {
 }
 
 // SetDebugMode Allow particular logger/message to be printed
-// This function will extract flag --debug from command
+// This function will extract flag --log-debug from command
 func SetDebugMode(cmd *cobra.Command) {
-	val, err := cmd.Flags().GetBool("debug")
+	val, err := cmd.Flags().GetBool(flagDebug)
 	if err == nil {
 		DebugMode = val
 	}
 }
 
-// AddLogFlag set flag --debug
+// AddLogFlag set flag --log-debug
 func AddLogFlag(cmd ...*cobra.Command) {
 	for _, c := range cmd {
-		c.Flags().Bool(flagDebug, false, "Run in debug mode")
+		c.Flags().Bool(flagDebug, false, "Enable World CLI debug logs")
 	}
 }

--- a/common/port.go
+++ b/common/port.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"fmt"
+	"net"
+)
+
+// FindUnusedPort finds an unused port in the range [start, end] for Cardinal Editor
+func FindUnusedPort(start int, end int) (int, error) {
+	for port := start; port <= end; port++ {
+		address := fmt.Sprintf(":%d", port)
+		listener, err := net.Listen("tcp", address)
+		if err == nil {
+			if err := listener.Close(); err != nil {
+				return 0, err
+			}
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port in the range %d-%d", start, end)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module pkg.world.dev/world-cli
 go 1.21.1
 
 require (
-	github.com/argus-labs/fresh v0.0.2
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/denisbrodbeck/machineid v1.0.1
@@ -25,9 +24,7 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/howeyc/fsnotify v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/pilu/config v0.0.0-20131214182432-3eb99e6c0b9a // indirect
 )
 
 require (
@@ -45,7 +42,7 @@ require (
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/argus-labs/fresh v0.0.2 h1:rjmhnm7JkkN6FCzxEbSrIJoOsG0TkxQVBtVbOsbQVPM=
-github.com/argus-labs/fresh v0.0.2/go.mod h1:0JyLyBC5gajmcQ8NK6qhf/GNy36I7PU/8XzHQVzDcWI=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -34,8 +32,6 @@ github.com/guumaster/logsymbols v0.3.1 h1:bnCE484dAQFvMWt2EfZAzF1oCgu8yo/Vp1QGQ0
 github.com/guumaster/logsymbols v0.3.1/go.mod h1:1M5/1js2Z7Yo8DRB3QrPURwqsXeOfgsJv1Utjookknw=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/howeyc/fsnotify v0.9.0 h1:0gtV5JmOKH4A8SsFxG2BczSeXWWPvcMT0euZt5gDAxY=
-github.com/howeyc/fsnotify v0.9.0/go.mod h1:41HzSPxBGeFRQKEEwgh49TRw/nKBsYZ2cF1OzPjSJsA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -65,10 +61,6 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
-github.com/pilu/config v0.0.0-20131214182432-3eb99e6c0b9a h1:Tg4E4cXPZSZyd3H1tJlYo6ZreXV0ZJvE/lorNqyw1AU=
-github.com/pilu/config v0.0.0-20131214182432-3eb99e6c0b9a/go.mod h1:9Or9aIl95Kp43zONcHd5tLZGKXb9iLx0pZjau0uJ5zg=
-github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a h1:U8Xgy85P2npR1jqpNF4q9rLSt6kzrOrWubkepc3lWbE=
-github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a/go.mod h1:QKd9TvGj31l6g+MV2PqthhK68d5ZPv/Q2PvtsS0mM3I=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
### TL;DR

### What changed?

- `world cardinal dev` now use pretty logging on latest Cardinal version. This is done by setting `CARDINAL_PRETTY_LOG` to true.
- Refactors to goroutine management in `world cardinal start` and `world cardinal dev` to make it more reliable using error group.
- Disable printing the usage guide when a command returns an error.
- Various string reformatting using lipgloss to make things look pretty.
- Prevent exit code 130, 137, 143 from being treated as an error since it's an expected exit code from Docker when it receives termination signal (i.e. Ctrl + C, SIGKILL, SIGTERM, etc)
- Kill `world cardinal dev --watch` flag because runner is ugly and buggy af

### How to test?

1. Run `world cardinal dev` and `world cardinal start` and try to break it. This includes running it against various edge cases (i.e. Redis already running, kill redis when cardinal is running, etc)
