### PR TITLE
fix: adjust closing file to make world cli run on windows

### DIFF
--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -177,12 +177,12 @@ func downloadAndUnzip(url string, targetDir string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {
 		return err
 	}
+	file.Close()
 
 	if err = unzipFile(tmpZipFileName, targetDir); err != nil {
 		return err
@@ -227,12 +227,12 @@ func unzipFile(filename string, targetDir string) error {
 		if err != nil {
 			return err
 		}
-		defer dst.Close()
 
 		_, err = io.Copy(dst, src) //nolint:gosec // zip file is from us
 		if err != nil {
 			return err
 		}
+		dst.Close()
 	}
 
 	if err = os.Rename(filepath.Join(filepath.Dir(targetDir), originalDir), targetDir); err != nil {


### PR DESCRIPTION
Closes: WORLD-1149

## Overview

When trying to run world cli on windows, there's an issue when exec `world create`. This PR is adjusting the code for windows OS.

## Brief Changelog

- Adjust file close to avoid Access Denied

## Testing and Verifying

Manually tested on windows without using WSL