### PR TITLE
chore: hide login command before world forge launched

### DIFF
--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -66,8 +66,7 @@ func init() {
 	// Register base commands
 	doctorCmd := getDoctorCmd(os.Stdout)
 	createCmd := getCreateCmd(os.Stdout)
-	loginCmd := getLoginCmd()
-	rootCmd.AddCommand(createCmd, doctorCmd, versionCmd, loginCmd)
+	rootCmd.AddCommand(createCmd, doctorCmd, versionCmd)
 
 	// Register subcommands
 	rootCmd.AddCommand(cardinal.BaseCmd)


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

Hide login command before world forge launched.

## Brief Changelog

- Remove loginCmd form root

## Testing and Verifying

Manually tested by running `world login` and `world -h`