### PR TITLE
fix: re enable debug mode

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -34,6 +34,4 @@ var BaseCmd = &cobra.Command{
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
 	BaseCmd.AddCommand(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
-	// Add --log-debug flag
-	logger.AddLogFlag(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 }

--- a/cmd/world/cardinal/dev.go
+++ b/cmd/world/cardinal/dev.go
@@ -52,8 +52,6 @@ var devCmd = &cobra.Command{
 			return err
 		}
 
-		logger.SetDebugMode(cmd)
-
 		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err

--- a/cmd/world/cardinal/purge.go
+++ b/cmd/world/cardinal/purge.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
@@ -20,8 +19,7 @@ var purgeCmd = &cobra.Command{
 	Short: "Stop and reset the state of your Cardinal game shard",
 	Long: `Stop and reset the state of your Cardinal game shard.
 This command stop all Docker services and remove all Docker volumes.`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
+	RunE: func(_ *cobra.Command, _ []string) error {
 		err := teacmd.DockerPurge()
 		if err != nil {
 			return err

--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"pkg.world.dev/world-cli/common/config"
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
@@ -19,8 +18,6 @@ This will restart the following Docker services:
 - Cardinal (Core game logic)
 - Nakama (Relay)`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
-
 		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err

--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -11,7 +11,6 @@ import (
 
 	"pkg.world.dev/world-cli/common"
 	"pkg.world.dev/world-cli/common/config"
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
@@ -58,8 +57,6 @@ This will start the following Docker services and its dependencies:
 - Nakama (Relay)
 - Redis (Cardinal dependency)`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
-
 		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err
@@ -150,6 +147,7 @@ func init() {
 	startCmd.Flags().Bool(flagBuild, true, "Rebuild Docker images before starting")
 	startCmd.Flags().Bool(flagDetach, false, "Run in detached mode")
 	startCmd.Flags().String(flagLogLevel, "", "Set the log level")
+	startCmd.Flags().Bool(flagDebug, false, "Enable delve debugging")
 }
 
 // replaceBoolWithFlag overwrites the contents of vale with the contents of the given flag. If the flag

--- a/cmd/world/cardinal/stop.go
+++ b/cmd/world/cardinal/stop.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
@@ -24,8 +23,7 @@ This will stop the following Docker services:
 - Cardinal (Game shard)
 - Nakama (Relay) + DB
 - Redis (Cardinal dependency)`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
+	RunE: func(_ *cobra.Command, _ []string) error {
 		err := teacmd.DockerStopAll()
 		if err != nil {
 			return err

--- a/cmd/world/evm/evm.go
+++ b/cmd/world/evm/evm.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"github.com/spf13/cobra"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -28,6 +27,4 @@ var BaseCmd = &cobra.Command{
 func init() {
 	// Register subcommands - `world evm [subcommand]`
 	BaseCmd.AddCommand(startCmd, stopCmd)
-	// Add --debug flag
-	logger.AddLogFlag(startCmd, stopCmd)
 }

--- a/cmd/world/evm/start.go
+++ b/cmd/world/evm/start.go
@@ -27,8 +27,6 @@ var startCmd = &cobra.Command{
 	Short: "Start the EVM base shard. Use --da-auth-token to pass in an auth token directly.",
 	Long:  "Start the EVM base shard. Requires connection to celestia DA.",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
-
 		cfg, err := config.GetConfig(cmd)
 		if err != nil {
 			return err

--- a/cmd/world/evm/stop.go
+++ b/cmd/world/evm/stop.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
@@ -13,9 +12,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the EVM base shard and DA layer client.",
 	Long:  "Stop the EVM base shard and data availability layer client if they are running.",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		logger.SetDebugMode(cmd)
-
+	RunE: func(_ *cobra.Command, _ []string) error {
 		err := teacmd.DockerStop(services(teacmd.DockerServiceEVM, teacmd.DockerServiceDA))
 		if err != nil {
 			return err

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -8,7 +8,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/component/steps"
 	"pkg.world.dev/world-cli/tea/style"
@@ -204,8 +203,7 @@ If [directory_name] is set, it will automatically clone the starter project into
 Otherwise, it will prompt you to enter a directory name.`,
 		GroupID: "starter",
 		Args:    cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			logger.SetDebugMode(cmd)
+		RunE: func(_ *cobra.Command, args []string) error {
 			p := tea.NewProgram(NewWorldCreateModel(args), tea.WithOutput(writer))
 			if _, err := p.Run(); err != nil {
 				return err

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"pkg.world.dev/world-cli/common/dependency"
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -84,8 +83,7 @@ World CLI requires the following dependencies to be installed:
 - Go
 - Docker`,
 		GroupID: "starter",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			logger.SetDebugMode(cmd)
+		RunE: func(_ *cobra.Command, _ []string) error {
 			p := tea.NewProgram(NewWorldDoctorModel(), tea.WithOutput(writer))
 			_, err := p.Run()
 			if err != nil {

--- a/cmd/world/root/login.go
+++ b/cmd/world/root/login.go
@@ -39,8 +39,6 @@ func getLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Authenticate using an access token",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			logger.SetDebugMode(cmd)
-
 			err := loginOnBrowser(cmd.Context())
 			if err != nil {
 				return eris.Wrap(err, "failed to login")

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -74,10 +74,7 @@ func init() {
 	rootCmd.AddCommand(evm.BaseCmd)
 
 	config.AddConfigFlag(rootCmd)
-
-	// Add --debug flag
-	logger.AddLogFlag(createCmd)
-	logger.AddLogFlag(doctorCmd)
+	logger.AddVerboseFlag(rootCmd)
 }
 
 func checkLatestVersion() error {

--- a/common/logger/init.go
+++ b/common/logger/init.go
@@ -15,14 +15,13 @@ const (
 
 	NoColor   = true
 	UseCaller = false // for developer, if you want to expose line of code of caller
-	flagDebug = "log-debug"
 )
 
 var (
 	logBuffer bytes.Buffer
 
-	// DebugMode flag for determining debug mode
-	DebugMode = false
+	// VerboseMode flag for determining verbose logging
+	verboseMode = false
 )
 
 func init() {
@@ -52,7 +51,7 @@ func init() {
 
 // PrintLogs print all stacked log
 func PrintLogs() {
-	if DebugMode {
+	if verboseMode {
 		// Extract the logs from the buffer and print them
 		logs := logBuffer.String()
 		if len(logs) > 0 {
@@ -62,18 +61,9 @@ func PrintLogs() {
 	}
 }
 
-// SetDebugMode Allow particular logger/message to be printed
-// This function will extract flag --log-debug from command
-func SetDebugMode(cmd *cobra.Command) {
-	val, err := cmd.Flags().GetBool(flagDebug)
-	if err == nil {
-		DebugMode = val
-	}
-}
-
-// AddLogFlag set flag --log-debug
-func AddLogFlag(cmd ...*cobra.Command) {
+// AddVerboseFlag set flag --log-debug
+func AddVerboseFlag(cmd ...*cobra.Command) {
 	for _, c := range cmd {
-		c.Flags().Bool(flagDebug, false, "Enable World CLI debug logs")
+		c.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable World CLI debug logs")
 	}
 }

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -118,21 +118,21 @@ func FatalWithFields(msg string, kv map[string]interface{}) {
 
 // Printf standard printf with debug mode validation
 func Printf(format string, v ...interface{}) {
-	if DebugMode {
+	if verboseMode {
 		fmt.Printf(format, v...)
 	}
 }
 
 // Println standard println with debug mode validation
 func Println(v ...interface{}) {
-	if DebugMode {
+	if verboseMode {
 		fmt.Println(v...)
 	}
 }
 
 // Print standard print with debug mode validation
 func Print(v ...interface{}) {
-	if DebugMode {
+	if verboseMode {
 		fmt.Print(v...)
 	}
 }

--- a/common/teacmd/docker.go
+++ b/common/teacmd/docker.go
@@ -44,6 +44,7 @@ func dockerComposeWithCfg(cfg *config.Config, args ...string) error {
 	}
 	if cfg.Debug {
 		env = append(env, "CARDINAL_ADDR=cardinal-debug:4040")
+		env = append(env, "CARDINAL_CONTAINER=cardinal-debug")
 	}
 
 	cmd.Env = env


### PR DESCRIPTION
Closes: WORLD-1154

## Overview

Re enable debug mode with delve on `world cardinal start` with `--debug` flag

## Brief Changelog

- Re activate `--debug` flag
- Add `nakama-debug` container to fix nakama cannot run because `cardinal` is not running

## Testing and Verifying

- Tested manually using `world cardinal start --debug` command and delve with vs code

Notes : Unit test failed because https://github.com/Argus-Labs/starter-game-template/pull/51 need to be merged first and create new tag