### PR TITLE
fix: world cardinal dev using redis from docker-compose

### DIFF
--- a/cmd/world/cardinal/dev.go
+++ b/cmd/world/cardinal/dev.go
@@ -211,10 +211,8 @@ func startRedis(ctx context.Context) error {
 
 	// Start Redis container
 	group.Go(func() error {
-		//nolint:gosec // not applicable
 		cmd := exec.Command(
-			"docker", "run", "-d", "-p", fmt.Sprintf("%s:%s", RedisPort, RedisPort),
-			"--name", "cardinal-dev-redis", "redis",
+			"docker", "compose", "up", "-d", "redis",
 		)
 
 		// Retry starting Redis container until successful
@@ -273,10 +271,10 @@ func startRedis(ctx context.Context) error {
 }
 
 func stopRedis() error {
-	logger.Println("Stopping cardinal-dev-redis container")
-	if err := sh.Run("docker", "rm", "-f", "cardinal-dev-redis"); err != nil {
+	logger.Println("Stopping redis container")
+	if err := sh.Run("docker", "compose", "down"); err != nil {
 		logger.Println("Failed to delete Redis container automatically")
-		logger.Println("Please delete it manually with `docker rm -f cardinal-dev-redis`")
+		logger.Println("Please delete it manually with `docker compose down`")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Closes: WORLD-1157

## Overview

As per now `world cardinal dev` is using redis with different container with docker-compose. Sometimes it causing port already in use problem when the container is not removed and user want to exec `world cardinal start`.

## Brief Changelog

- Change redis using docker compose instead of running a new different container.

## Testing and Verifying

Tested manually using `world cadinal dev` 