### PR TITLE
feat: use redis in docker compose, remove go mod vendor prepare step

### DIFF
--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -165,5 +165,6 @@ func contextWithSigterm(ctx context.Context) context.Context {
 			fmt.Println(textStyle.Render("Cancellation signal received. Terminating..."))
 		}
 	}()
+
 	return ctx
 }

--- a/common/teacmd/docker.go
+++ b/common/teacmd/docker.go
@@ -200,13 +200,7 @@ func prepareDir(dir string) error {
 	if err = os.Chdir(dir); err != nil {
 		return err
 	}
-	if err = sh.Rm("./vendor"); err != nil {
-		return err
-	}
 	if err = sh.Run("go", "mod", "tidy"); err != nil {
-		return err
-	}
-	if err = sh.Run("go", "mod", "vendor"); err != nil {
 		return err
 	}
 	if err = os.Chdir(startDir); err != nil {


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->