### PR TITLE
fix: docker api parallel exec, git config, wrong dir cardinal editor

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -20,7 +20,6 @@ var BaseCmd = &cobra.Command{
 			dependency.Go,
 			dependency.Git,
 			dependency.Docker,
-			dependency.DockerCompose,
 			dependency.DockerDaemon,
 		)
 	},

--- a/cmd/world/cardinal/dev.go
+++ b/cmd/world/cardinal/dev.go
@@ -132,20 +132,26 @@ func startCardinalDevMode(ctx context.Context, cfg *config.Config, prettyLog boo
 	// Check and wait until Redis is running and is available in the expected port
 	isRedisHealthy := false
 	for !isRedisHealthy {
-		redisAddress := fmt.Sprintf("localhost:%s", RedisPort)
-		conn, err := net.DialTimeout("tcp", redisAddress, time.Second)
-		if err != nil {
-			logger.Printf("Failed to connect to Redis at %s: %s\n", redisAddress, err)
-			time.Sleep(1 * time.Second)
-			continue
-		}
+		// using select to allow for context cancellation
+		select {
+		case <-ctx.Done():
+			return eris.Wrap(ctx.Err(), "Context canceled")
+		default:
+			redisAddress := fmt.Sprintf("localhost:%s", RedisPort)
+			conn, err := net.DialTimeout("tcp", redisAddress, time.Second)
+			if err != nil {
+				logger.Printf("Failed to connect to Redis at %s: %s\n", redisAddress, err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
 
-		// Cleanup connection
-		if err := conn.Close(); err != nil {
-			continue
-		}
+			// Cleanup connection
+			if err := conn.Close(); err != nil {
+				continue
+			}
 
-		isRedisHealthy = true
+			isRedisHealthy = true
+		}
 	}
 
 	// Move into the cardinal directory
@@ -236,10 +242,14 @@ func startRedis(ctx context.Context, cfg *config.Config) error {
 	}
 	defer dockerClient.Close()
 
+	// Create context with cancel
+	ctx, cancel := context.WithCancel(ctx)
+
 	// Start Redis container
 	group.Go(func() error {
 		cfg.Detach = true
-		if err := dockerClient.Start(ctx, cfg, service.Redis); err != nil {
+		if err := dockerClient.Start(ctx, service.Redis); err != nil {
+			cancel()
 			return eris.Wrap(err, "Encountered an error with Redis")
 		}
 		return nil
@@ -251,7 +261,8 @@ func startRedis(ctx context.Context, cfg *config.Config) error {
 	// 2) The parent context is canceled for whatever reason.
 	group.Go(func() error {
 		<-ctx.Done()
-		if err := dockerClient.Stop(cfg, service.Redis); err != nil {
+		// Using context background because cmd context is already done
+		if err := dockerClient.Stop(context.Background(), service.Redis); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/world/cardinal/purge.go
+++ b/cmd/world/cardinal/purge.go
@@ -34,7 +34,7 @@ This command stop all Docker services and remove all Docker volumes.`,
 		}
 		defer dockerClient.Close()
 
-		err = dockerClient.Purge(cfg, service.Nakama, service.Cardinal, service.NakamaDB, service.Redis)
+		err = dockerClient.Purge(cmd.Context(), service.Nakama, service.Cardinal, service.NakamaDB, service.Redis)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -39,7 +39,7 @@ This will restart the following Docker services:
 		}
 		defer dockerClient.Close()
 
-		err = dockerClient.Restart(cmd.Context(), cfg, service.Cardinal, service.Nakama)
+		err = dockerClient.Restart(cmd.Context(), service.Cardinal, service.Nakama)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -120,7 +120,7 @@ This will start the following Docker services and its dependencies:
 
 		// Start the World Engine stack
 		group.Go(func() error {
-			if err := dockerClient.Start(ctx, cfg, service.NakamaDB,
+			if err := dockerClient.Start(ctx, service.NakamaDB,
 				service.Redis, service.Cardinal, service.Nakama); err != nil {
 				return eris.Wrap(err, "Encountered an error with Docker")
 			}

--- a/cmd/world/cardinal/stop.go
+++ b/cmd/world/cardinal/stop.go
@@ -38,7 +38,7 @@ This will stop the following Docker services:
 		}
 		defer dockerClient.Close()
 
-		err = dockerClient.Stop(cfg, service.Nakama, service.Cardinal, service.NakamaDB, service.Redis)
+		err = dockerClient.Stop(cmd.Context(), service.Nakama, service.Cardinal, service.NakamaDB, service.Redis)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/cardinal/util_editor.go
+++ b/cmd/world/cardinal/util_editor.go
@@ -10,19 +10,19 @@ import (
 	"github.com/rotisserie/eris"
 	"golang.org/x/sync/errgroup"
 
-	"pkg.world.dev/world-cli/common/teacmd"
+	"pkg.world.dev/world-cli/common/editor"
 )
 
 const ceReadTimeout = 5 * time.Second
 
 // startCardinalEditor runs the Cardinal Editor
 func startCardinalEditor(ctx context.Context, rootDir string, gameDir string, port int) error {
-	if err := teacmd.SetupCardinalEditor(rootDir, gameDir); err != nil {
+	if err := editor.SetupCardinalEditor(rootDir, gameDir); err != nil {
 		return err
 	}
 
 	// Create a new HTTP server
-	fs := http.FileServer(http.Dir(filepath.Join(rootDir, teacmd.TargetEditorDir)))
+	fs := http.FileServer(http.Dir(filepath.Join(rootDir, editor.EditorDir)))
 	http.Handle("/", fs)
 	server := &http.Server{
 		Addr:        fmt.Sprintf(":%d", port),

--- a/cmd/world/evm/start.go
+++ b/cmd/world/evm/start.go
@@ -50,14 +50,15 @@ var startCmd = &cobra.Command{
 		cfg.Detach = false
 		cfg.Timeout = 0
 
-		err = dockerClient.Start(cmd.Context(), cfg, service.EVM)
+		err = dockerClient.Start(cmd.Context(), service.EVM)
 		if err != nil {
 			return fmt.Errorf("error starting %s docker container: %w", teacmd.DockerServiceEVM, err)
 		}
 
 		// Stop the DA service if it was started in dev mode
 		if cfg.DevDA {
-			err = dockerClient.Stop(cfg, service.CelestiaDevNet)
+			// using context background because cmd.Context() is already done
+			err = dockerClient.Stop(context.Background(), service.CelestiaDevNet)
 			if err != nil {
 				return eris.Wrap(err, "Failed to stop DA service")
 			}
@@ -80,7 +81,7 @@ func validateDevDALayer(ctx context.Context, cfg *config.Config, dockerClient *d
 	cfg.Detach = true
 	cfg.Timeout = -1
 	logger.Println("starting DA docker service for dev mode...")
-	if err := dockerClient.Start(ctx, cfg, service.CelestiaDevNet); err != nil {
+	if err := dockerClient.Start(ctx, service.CelestiaDevNet); err != nil {
 		return fmt.Errorf("error starting %s docker container: %w", daService, err)
 	}
 	logger.Println("started DA service...")

--- a/cmd/world/evm/stop.go
+++ b/cmd/world/evm/stop.go
@@ -27,7 +27,7 @@ var stopCmd = &cobra.Command{
 		}
 		defer dockerClient.Close()
 
-		err = dockerClient.Stop(cfg, service.EVM, service.CelestiaDevNet)
+		err = dockerClient.Stop(cmd.Context(), service.EVM, service.CelestiaDevNet)
 		if err != nil {
 			return err
 		}

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"pkg.world.dev/world-cli/common/editor"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/component/steps"
 	"pkg.world.dev/world-cli/tea/style"
@@ -123,7 +124,7 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			)
 		}
 		if msg.Index == 2 { //nolint:gomnd
-			err := teacmd.SetupCardinalEditor(".", "cardinal")
+			err := editor.SetupCardinalEditor(".", "cardinal")
 			teaCmd := func() tea.Msg {
 				return teacmd.GitCloneFinishMsg{Err: err}
 			}

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -15,6 +15,36 @@ import (
 	"pkg.world.dev/world-cli/common/logger"
 )
 
+const (
+	START processType = iota
+	STOP
+	REMOVE
+	CREATE
+)
+
+var (
+	processName = map[processType]string{
+		START:  "start",
+		STOP:   "stop",
+		REMOVE: "remove",
+		CREATE: "create",
+	}
+
+	processInitName = map[processType]string{
+		START:  "starting",
+		STOP:   "stopping",
+		REMOVE: "removing",
+		CREATE: "creating",
+	}
+
+	processFinishName = map[processType]string{
+		START:  "started",
+		STOP:   "stopped",
+		REMOVE: "removed",
+		CREATE: "created",
+	}
+)
+
 type Client struct {
 	client *client.Client
 	cfg    *config.Config
@@ -39,24 +69,24 @@ func (c *Client) Close() error {
 	return c.client.Close()
 }
 
-func (c *Client) Start(ctx context.Context, cfg *config.Config,
+func (c *Client) Start(ctx context.Context,
 	serviceBuilders ...service.Builder) error {
 	defer func() {
-		if !cfg.Detach {
-			err := c.Stop(cfg, serviceBuilders...)
+		if !c.cfg.Detach {
+			err := c.Stop(context.Background(), serviceBuilders...)
 			if err != nil {
 				logger.Error("Failed to stop containers", err)
 			}
 		}
 	}()
 
-	namespace := cfg.DockerEnv["CARDINAL_NAMESPACE"]
+	namespace := c.cfg.DockerEnv["CARDINAL_NAMESPACE"]
 	err := c.createNetworkIfNotExists(ctx, namespace)
 	if err != nil {
 		return eris.Wrap(err, "Failed to create network")
 	}
 
-	err = c.createVolumeIfNotExists(ctx, namespace)
+	err = c.processVolume(ctx, CREATE, namespace)
 	if err != nil {
 		return eris.Wrap(err, "Failed to create volume")
 	}
@@ -64,7 +94,8 @@ func (c *Client) Start(ctx context.Context, cfg *config.Config,
 	// get all services
 	dockerServices := make([]service.Service, 0)
 	for _, sb := range serviceBuilders {
-		dockerServices = append(dockerServices, sb(cfg))
+		ds := sb(c.cfg)
+		dockerServices = append(dockerServices, ds)
 	}
 
 	// Pull all images before starting containers
@@ -73,51 +104,60 @@ func (c *Client) Start(ctx context.Context, cfg *config.Config,
 		return eris.Wrap(err, "Failed to pull images")
 	}
 
-	// Start all containers
-	for _, dockerService := range dockerServices {
-		// build image if needed
-		if cfg.Build && dockerService.Dockerfile != "" {
-			if err := c.buildImage(ctx, dockerService.Dockerfile, dockerService.BuildTarget, dockerService.Image); err != nil {
-				return eris.Wrap(err, "Failed to build image")
-			}
-		}
-
-		// create container & start
-		if err := c.startContainer(ctx, dockerService); err != nil {
-			return eris.Wrap(err, "Failed to create container")
+	// Build all images before starting containers
+	if c.cfg.Build {
+		err = c.buildImages(ctx, dockerServices...)
+		if err != nil {
+			return eris.Wrap(err, "Failed to build images")
 		}
 	}
 
+	// Start all containers
+	err = c.processMultipleContainers(ctx, START, dockerServices...)
+	if err != nil {
+		return eris.Wrap(err, "Failed to start containers")
+	}
+
 	// log containers if not detached
-	if !cfg.Detach {
+	if !c.cfg.Detach {
 		c.logMultipleContainers(ctx, dockerServices...)
 	}
 
 	return nil
 }
 
-func (c *Client) Stop(cfg *config.Config, serviceBuilders ...service.Builder) error {
-	ctx := context.Background()
+func (c *Client) Stop(ctx context.Context, serviceBuilders ...service.Builder) error {
+	// get all services
+	dockerServices := make([]service.Service, 0)
 	for _, sb := range serviceBuilders {
-		dockerService := sb(cfg)
-		if err := c.stopContainer(ctx, dockerService.Name); err != nil {
-			return eris.Wrap(err, "Failed to stop container")
-		}
+		ds := sb(c.cfg)
+		dockerServices = append(dockerServices, ds)
+	}
+
+	// Stop all containers
+	err := c.processMultipleContainers(ctx, STOP, dockerServices...)
+	if err != nil {
+		return eris.Wrap(err, "Failed to stop containers")
 	}
 
 	return nil
 }
 
-func (c *Client) Purge(cfg *config.Config, serviceBuilders ...service.Builder) error {
-	ctx := context.Background()
+func (c *Client) Purge(ctx context.Context, serviceBuilders ...service.Builder) error {
+	// get all services
+	dockerServices := make([]service.Service, 0)
 	for _, sb := range serviceBuilders {
-		dockerService := sb(cfg)
-		if err := c.removeContainer(ctx, dockerService.Name); err != nil {
-			return eris.Wrap(err, "Failed to remove container")
-		}
+		ds := sb(c.cfg)
+		dockerServices = append(dockerServices, ds)
 	}
 
-	err := c.removeVolume(ctx, cfg.DockerEnv["CARDINAL_NAMESPACE"])
+	// remove all containers
+	err := c.processMultipleContainers(ctx, REMOVE, dockerServices...)
+	if err != nil {
+		return eris.Wrap(err, "Failed to remove containers")
+	}
+
+	err = c.processVolume(ctx, REMOVE, c.cfg.DockerEnv["CARDINAL_NAMESPACE"])
 	if err != nil {
 		return err
 	}
@@ -125,15 +165,15 @@ func (c *Client) Purge(cfg *config.Config, serviceBuilders ...service.Builder) e
 	return nil
 }
 
-func (c *Client) Restart(ctx context.Context, cfg *config.Config,
+func (c *Client) Restart(ctx context.Context,
 	serviceBuilders ...service.Builder) error {
 	// stop containers
-	err := c.Stop(cfg, serviceBuilders...)
+	err := c.Stop(ctx, serviceBuilders...)
 	if err != nil {
 		return err
 	}
 
-	return c.Start(ctx, cfg, serviceBuilders...)
+	return c.Start(ctx, serviceBuilders...)
 }
 
 func (c *Client) Exec(ctx context.Context, containerID string, cmd []string) (string, error) {

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -13,9 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -25,13 +23,91 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 
 	"pkg.world.dev/world-cli/common/docker/service"
-	"pkg.world.dev/world-cli/common/logger"
-	teaspinner "pkg.world.dev/world-cli/tea/component/spinner"
+	"pkg.world.dev/world-cli/tea/component/multispinner"
+	"pkg.world.dev/world-cli/tea/style"
 )
 
-func (c *Client) buildImage(ctx context.Context, dockerfile, target, imageName string) error {
-	contextPrint("Building", "2", "image", imageName)
-	fmt.Println() // Add a newline after the context print
+func (c *Client) buildImages(ctx context.Context, dockerServices ...service.Service) error {
+	// Filter all services that need to be built
+	var (
+		serviceToBuild []service.Service
+		imagesName     []string
+	)
+	for _, dockerService := range dockerServices {
+		if dockerService.Dockerfile != "" {
+			serviceToBuild = append(serviceToBuild, dockerService)
+			imagesName = append(imagesName, dockerService.Image)
+		}
+	}
+
+	if len(serviceToBuild) == 0 {
+		return nil
+	}
+
+	// Create ctx with cancel
+	ctx, cancel := context.WithCancel(ctx)
+
+	// Channel to collect errors from the goroutines
+	errChan := make(chan error, len(imagesName))
+
+	p := tea.NewProgram(multispinner.CreateSpinner(imagesName, cancel))
+
+	for _, ds := range serviceToBuild {
+		// Capture dockerService in the loop
+		dockerService := ds
+
+		go func() {
+			p.Send(multispinner.ProcessState{
+				State: "building",
+				Type:  "image",
+				Name:  dockerService.Image,
+			})
+
+			// Start the build process
+			buildResponse, err := c.buildImage(ctx, dockerService)
+			if err != nil {
+				p.Send(multispinner.ProcessState{
+					Icon:   style.CrossIcon.Render(),
+					State:  "building",
+					Type:   "image",
+					Name:   dockerService.Image,
+					Detail: err.Error(),
+					Done:   true,
+				})
+				errChan <- err
+				return
+			}
+			defer buildResponse.Body.Close()
+
+			// Print the build logs
+			err = c.readBuildLog(ctx, buildResponse.Body, p, dockerService.Image)
+			if err != nil {
+				errChan <- err
+			}
+		}()
+	}
+
+	// Run the program
+	if _, err := p.Run(); err != nil {
+		return eris.Wrap(err, "Error running program")
+	}
+
+	// Close the error channel and check for errors
+	close(errChan)
+	errs := make([]error, 0)
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	// If there were any errors, return them as a combined error
+	if len(errs) > 0 {
+		return eris.New(fmt.Sprintf("Errors: %v", errs))
+	}
+
+	return nil
+}
+
+func (c *Client) buildImage(ctx context.Context, dockerService service.Service) (*types.ImageBuildResponse, error) {
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
@@ -39,18 +115,18 @@ func (c *Client) buildImage(ctx context.Context, dockerfile, target, imageName s
 	// Add the Dockerfile to the tar archive
 	header := &tar.Header{
 		Name: "Dockerfile",
-		Size: int64(len(dockerfile)),
+		Size: int64(len(dockerService.Dockerfile)),
 	}
 	if err := tw.WriteHeader(header); err != nil {
-		return eris.Wrap(err, "Failed to write header to tar writer")
+		return nil, eris.Wrap(err, "Failed to write header to tar writer")
 	}
-	if _, err := tw.Write([]byte(dockerfile)); err != nil {
-		return eris.Wrap(err, "Failed to write Dockerfile to tar writer")
+	if _, err := tw.Write([]byte(dockerService.Dockerfile)); err != nil {
+		return nil, eris.Wrap(err, "Failed to write Dockerfile to tar writer")
 	}
 
 	// Add source code to the tar archive
 	if err := c.addFileToTarWriter(".", tw); err != nil {
-		return eris.Wrap(err, "Failed to add source code to tar writer")
+		return nil, eris.Wrap(err, "Failed to add source code to tar writer")
 	}
 
 	// Read the tar archive
@@ -58,8 +134,8 @@ func (c *Client) buildImage(ctx context.Context, dockerfile, target, imageName s
 
 	buildOptions := types.ImageBuildOptions{
 		Dockerfile: "Dockerfile",
-		Tags:       []string{imageName},
-		Target:     target,
+		Tags:       []string{dockerService.Image},
+		Target:     dockerService.BuildTarget,
 	}
 
 	if service.BuildkitSupport {
@@ -69,14 +145,10 @@ func (c *Client) buildImage(ctx context.Context, dockerfile, target, imageName s
 	// Build the image
 	buildResponse, err := c.client.ImageBuild(ctx, tarReader, buildOptions)
 	if err != nil {
-		return err
+		return nil, eris.Wrap(err, "Failed to build image")
 	}
-	defer buildResponse.Body.Close()
 
-	// Print the build logs
-	c.readBuildLog(ctx, buildResponse.Body)
-
-	return nil
+	return &buildResponse, nil
 }
 
 // AddFileToTarWriter adds a file or directory to the tar writer
@@ -139,94 +211,101 @@ func (c *Client) addFileToTarWriter(baseDir string, tw *tar.Writer) error {
 //   - error: Error message from the build process
 //
 // 2. Output from the build process with buildkit
-func (c *Client) readBuildLog(ctx context.Context, reader io.Reader) {
-	// Create context with cancel
-	ctx, cancel := context.WithCancel(ctx)
-
+//   - moby.buildkit.trace: Output from the build process
+//   - error: Need to research how buildkit log send error messages (TODO)
+func (c *Client) readBuildLog(ctx context.Context, reader io.Reader, p *tea.Program, imageName string) error {
 	// Create a new JSON decoder
 	decoder := json.NewDecoder(reader)
 
-	// Initialize the spinner
-	s := spinner.New()
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("69"))
-	s.Spinner = spinner.Points
+	for stop := false; !stop; {
+		select {
+		case <-ctx.Done():
+			stop = true
+		default:
+			var step string
+			var err error
+			if service.BuildkitSupport {
+				// Parse the buildkit response
+				step, err = c.parseBuildkitResp(decoder, &stop)
+			} else {
+				// Parse the non-buildkit response
+				step, err = c.parseNonBuildkitResp(decoder, &stop)
+			}
 
-	// Initialize the model
-	m := teaspinner.Spinner{
-		Spinner: s,
-		Cancel:  cancel,
-	}
+			// Send the step to the spinner
+			if err != nil {
+				p.Send(multispinner.ProcessState{
+					Icon:   style.CrossIcon.Render(),
+					State:  "building",
+					Type:   "image",
+					Name:   imageName,
+					Detail: err.Error(),
+					Done:   true,
+				})
+				return err
+			}
 
-	// Start the bubbletea program
-	p := tea.NewProgram(m)
-	go func() {
-		for stop := false; !stop; {
-			select {
-			case <-ctx.Done():
-				stop = true
-			default:
-				var step string
-				if service.BuildkitSupport {
-					// Parse the buildkit response
-					step = c.parseBuildkitResp(decoder, &stop)
-				} else {
-					// Parse the non-buildkit response
-					step = c.parseNonBuildkitResp(decoder, &stop)
-				}
-
-				// Send the step to the spinner
-				if step != "" {
-					p.Send(teaspinner.LogMsg(step))
-				}
+			if step != "" {
+				p.Send(multispinner.ProcessState{
+					State:  "building",
+					Type:   "image",
+					Name:   imageName,
+					Detail: step,
+				})
 			}
 		}
-		// Send a completion message to the spinner
-		p.Send(teaspinner.LogMsg("spin: completed"))
-	}()
-
-	// Run the program
-	if _, err := p.Run(); err != nil {
-		fmt.Println("Error running program:", err)
 	}
+
+	// Send the final message to the spinner
+	p.Send(multispinner.ProcessState{
+		Icon:  style.TickIcon.Render(),
+		State: "built",
+		Type:  "image",
+		Name:  imageName,
+		Done:  true,
+	})
+
+	return nil
 }
 
-func (c *Client) parseBuildkitResp(decoder *json.Decoder, stop *bool) string {
+func (c *Client) parseBuildkitResp(decoder *json.Decoder, stop *bool) (string, error) {
 	var msg jsonmessage.JSONMessage
 	if err := decoder.Decode(&msg); errors.Is(err, io.EOF) {
 		*stop = true
 	} else if err != nil {
-		logger.Errorf("Error decoding build output: %v", err)
+		return "", eris.Wrap(err, "Error decoding build output")
 	}
 
 	var resp controlapi.StatusResponse
 
 	if msg.ID != "moby.buildkit.trace" {
-		return ""
+		return "", nil
 	}
 
 	var dt []byte
 	// ignoring all messages that are not understood
+	// need to research how buildkit log send error messages
 	if err := json.Unmarshal(*msg.Aux, &dt); err != nil {
-		return ""
+		return "", nil //nolint:nilerr // ignore error
 	}
 	if err := (&resp).Unmarshal(dt); err != nil {
-		return ""
+		return "", nil //nolint:nilerr // ignore error
 	}
 
 	if len(resp.Vertexes) == 0 {
-		return ""
+		return "", nil
 	}
 
 	// return the name of the vertex (step) that is currently being executed
-	return resp.Vertexes[len(resp.Vertexes)-1].Name
+	return resp.Vertexes[len(resp.Vertexes)-1].Name, nil
 }
 
-func (c *Client) parseNonBuildkitResp(decoder *json.Decoder, stop *bool) string {
+func (c *Client) parseNonBuildkitResp(decoder *json.Decoder, stop *bool) (string, error) {
 	var event map[string]interface{}
 	if err := decoder.Decode(&event); errors.Is(err, io.EOF) {
 		*stop = true
 	} else if err != nil {
-		logger.Errorf("Error decoding build output: %v", err)
+		return "", eris.Wrap(err, "Error decoding build output")
 	}
 
 	// Only show the step if it's a build step
@@ -236,10 +315,10 @@ func (c *Client) parseNonBuildkitResp(decoder *json.Decoder, stop *bool) string 
 			step = strings.TrimSpace(step)
 		}
 	} else if val, ok = event["error"]; ok && val != "" {
-		logger.Errorf("Error building image: %v", val)
+		return "", eris.New(val.(string))
 	}
 
-	return step
+	return step, nil
 }
 
 // filterImages filters the images that need to be pulled
@@ -299,13 +378,8 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 		// Create a new progress bar for this image
 		bar := p.AddBar(100, //nolint:gomnd
 			mpb.PrependDecorators(
-				decor.Name(fmt.Sprintf("%s %s: ", foregroundPrint("Pulling", "2"), imageName)),
+				decor.Name(fmt.Sprintf("%s %s: ", style.ForegroundPrint("Pulling", "2"), imageName)),
 				decor.Percentage(decor.WCSyncSpace),
-			),
-			mpb.AppendDecorators(
-				decor.OnComplete(
-					decor.EwmaETA(decor.ET_STYLE_GO, 30, decor.WCSyncWidth), "done", //nolint:gomnd
-				),
 			),
 		)
 

--- a/common/docker/client_network.go
+++ b/common/docker/client_network.go
@@ -3,28 +3,85 @@ package docker
 import (
 	"context"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/network"
+	"github.com/rotisserie/eris"
 
-	"pkg.world.dev/world-cli/common/logger"
+	"pkg.world.dev/world-cli/tea/component/multispinner"
+	"pkg.world.dev/world-cli/tea/style"
 )
 
 func (c *Client) createNetworkIfNotExists(ctx context.Context, networkName string) error {
-	networks, err := c.client.NetworkList(ctx, network.ListOptions{})
-	if err != nil {
-		return err
-	}
+	// Create context with cancel
+	ctx, cancel := context.WithCancel(ctx)
+	p := tea.NewProgram(multispinner.CreateSpinner([]string{networkName}, cancel))
 
-	for _, network := range networks {
-		if network.Name == networkName {
-			logger.Infof("Network %s already exists", networkName)
-			return nil
+	errChan := make(chan error, 1)
+
+	go func() {
+		p.Send(multispinner.ProcessState{
+			State: "creating",
+			Type:  "network",
+			Name:  networkName,
+		})
+
+		networks, err := c.client.NetworkList(ctx, network.ListOptions{})
+		if err != nil {
+			p.Send(multispinner.ProcessState{
+				Icon:   style.CrossIcon.Render(),
+				Type:   "network",
+				Name:   networkName,
+				State:  "creating",
+				Detail: err.Error(),
+				Done:   true,
+			})
+			errChan <- eris.Wrap(err, "Failed to list networks")
+			return
 		}
+
+		networkExist := false
+		for _, network := range networks {
+			if network.Name == networkName {
+				networkExist = true
+				break
+			}
+		}
+
+		if !networkExist {
+			_, err = c.client.NetworkCreate(ctx, networkName, network.CreateOptions{
+				Driver: "bridge",
+			})
+			if err != nil {
+				p.Send(multispinner.ProcessState{
+					Icon:   style.CrossIcon.Render(),
+					Type:   "network",
+					Name:   networkName,
+					State:  "creating",
+					Detail: err.Error(),
+					Done:   true,
+				})
+				errChan <- eris.Wrapf(err, "Failed to create network %s", networkName)
+				return
+			}
+		}
+
+		p.Send(multispinner.ProcessState{
+			Icon:  style.TickIcon.Render(),
+			Type:  "network",
+			Name:  networkName,
+			State: "created",
+			Done:  true,
+		})
+	}()
+
+	// Run the program
+	if _, err := p.Run(); err != nil {
+		return eris.Wrap(err, "Failed to run multispinner")
 	}
 
-	_, err = c.client.NetworkCreate(ctx, networkName, network.CreateOptions{
-		Driver: "bridge",
-	})
-	if err != nil {
+	// Close the error channel and check for errors
+	close(errChan)
+	if err := <-errChan; err != nil {
 		return err
 	}
 

--- a/common/docker/client_util.go
+++ b/common/docker/client_util.go
@@ -2,27 +2,13 @@ package docker
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/docker/docker/client"
 
 	"pkg.world.dev/world-cli/common/logger"
 )
-
-func contextPrint(title, titleColor, subject, object string) {
-	titleStr := foregroundPrint(title, titleColor)
-	arrowStr := foregroundPrint("→", "241")
-	subjectStr := foregroundPrint(subject, "4")
-
-	fmt.Printf("%s %s %s %s ", titleStr, arrowStr, subjectStr, object)
-}
-
-func foregroundPrint(text string, color string) string {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(text)
-}
 
 func checkBuildkitSupport(cli *client.Client) bool {
 	ctx := context.Background()

--- a/common/docker/client_volume.go
+++ b/common/docker/client_volume.go
@@ -4,61 +4,97 @@ import (
 	"context"
 	"fmt"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/rotisserie/eris"
 
-	"pkg.world.dev/world-cli/common/logger"
+	"pkg.world.dev/world-cli/tea/component/multispinner"
 	"pkg.world.dev/world-cli/tea/style"
 )
 
-func (c *Client) createVolumeIfNotExists(ctx context.Context, volumeName string) error {
-	volumes, err := c.client.VolumeList(ctx, volume.ListOptions{})
-	if err != nil {
+func (c *Client) processVolume(ctx context.Context, processType processType, volumeName string) error {
+	// Create context with cancel
+	ctx, cancel := context.WithCancel(ctx)
+	p := tea.NewProgram(multispinner.CreateSpinner([]string{volumeName}, cancel))
+
+	errChan := make(chan error, 1)
+
+	go func() {
+		p.Send(multispinner.ProcessState{
+			State: processInitName[processType],
+			Type:  "volume",
+			Name:  volumeName,
+		})
+
+		volumes, err := c.client.VolumeList(ctx, volume.ListOptions{})
+		if err != nil {
+			p.Send(multispinner.ProcessState{
+				Icon:   style.CrossIcon.Render(),
+				Type:   "volume",
+				Name:   volumeName,
+				State:  processInitName[processType],
+				Detail: err.Error(),
+				Done:   true,
+			})
+			errChan <- eris.Wrap(err, "Failed to list volumes")
+			return
+		}
+
+		volumeExist := false
+		for _, volume := range volumes.Volumes {
+			if volume.Name == volumeName {
+				volumeExist = true
+				break
+			}
+		}
+
+		switch processType {
+		case CREATE:
+			if !volumeExist {
+				_, err = c.client.VolumeCreate(ctx, volume.CreateOptions{Name: volumeName})
+			}
+		case REMOVE:
+			if volumeExist {
+				err = c.client.VolumeRemove(ctx, volumeName, true)
+			}
+		case START, STOP:
+			err = eris.New(fmt.Sprintf("%s process type is not supported for volumes", processName[processType]))
+		default:
+			err = eris.New(fmt.Sprintf("Unknown process type: %d", processType))
+		}
+
+		if err != nil {
+			p.Send(multispinner.ProcessState{
+				Icon:   style.CrossIcon.Render(),
+				Type:   "volume",
+				Name:   volumeName,
+				State:  processInitName[processType],
+				Detail: err.Error(),
+				Done:   true,
+			})
+			errChan <- eris.Wrapf(err, "Failed to %s volume %s", processName[processType], volumeName)
+			return
+		}
+
+		p.Send(multispinner.ProcessState{
+			Icon:  style.TickIcon.Render(),
+			Type:  "volume",
+			Name:  volumeName,
+			State: processFinishName[processType],
+			Done:  true,
+		})
+	}()
+
+	// Run the program
+	if _, err := p.Run(); err != nil {
+		return eris.Wrap(err, "Failed to run multispinner")
+	}
+
+	// Close the error channel and check for errors
+	close(errChan)
+	if err := <-errChan; err != nil {
 		return err
 	}
 
-	for _, volume := range volumes.Volumes {
-		if volume.Name == volumeName {
-			logger.Debugf("Volume %s already exists\n", volumeName)
-			return nil
-		}
-	}
-
-	_, err = c.client.VolumeCreate(ctx, volume.CreateOptions{Name: volumeName})
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Created volume %s\n", volumeName)
-	return nil
-}
-
-func (c *Client) removeVolume(ctx context.Context, volumeName string) error {
-	volumes, err := c.client.VolumeList(ctx, volume.ListOptions{})
-	if err != nil {
-		return eris.Wrap(err, "Failed to list volumes")
-	}
-
-	isExist := false
-	for _, v := range volumes.Volumes {
-		if v.Name == volumeName {
-			isExist = true
-			break
-		}
-	}
-
-	// Return if volume does not exist
-	if !isExist {
-		return nil
-	}
-
-	contextPrint("Removing", "1", "volume", volumeName)
-
-	err = c.client.VolumeRemove(ctx, volumeName, true)
-	if err != nil {
-		return eris.Wrapf(err, "Failed to remove volume %s", volumeName)
-	}
-
-	fmt.Println(style.TickIcon.Render())
 	return nil
 }

--- a/common/editor/editor.go
+++ b/common/editor/editor.go
@@ -1,4 +1,4 @@
-package teacmd
+package editor
 
 import (
 	"archive/zip"
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	TargetEditorDir = ".editor"
+	EditorDir = ".editor"
 
 	releaseURL       = "https://api.github.com/repos/Argus-Labs/cardinal-editor/releases"
 	latestReleaseURL = releaseURL + "/latest"
@@ -77,15 +77,16 @@ func SetupCardinalEditor(rootDir string, gameDir string) error {
 	}
 
 	// Check if the Cardinal Editor directory exists
-	if _, err := os.Stat(TargetEditorDir); !os.IsNotExist(err) {
+	targetEditorDir := filepath.Join(rootDir, EditorDir)
+	if _, err := os.Stat(targetEditorDir); !os.IsNotExist(err) {
 		// Check the version of cardinal editor is appropriate
-		if fileExists(filepath.Join(TargetEditorDir, downloadVersion)) {
+		if fileExists(filepath.Join(targetEditorDir, downloadVersion)) {
 			// do nothing if the version is already downloaded
 			return nil
 		}
 
 		// Remove the existing Cardinal Editor directory
-		os.RemoveAll(TargetEditorDir)
+		os.RemoveAll(targetEditorDir)
 	}
 
 	configDir, err := globalconfig.GetConfigDir()
@@ -99,7 +100,7 @@ func SetupCardinalEditor(rootDir string, gameDir string) error {
 	}
 
 	// rename version tag dir to .editor
-	err = copyDir(editorDir, TargetEditorDir)
+	err = copyDir(editorDir, targetEditorDir)
 	if err != nil {
 		return err
 	}
@@ -107,13 +108,13 @@ func SetupCardinalEditor(rootDir string, gameDir string) error {
 	// rename project id
 	// "ce" prefix is added because guids can start with numbers, which is not allowed in js
 	projectID := "ce" + strippedGUID()
-	err = replaceProjectIDs(TargetEditorDir, projectID)
+	err = replaceProjectIDs(targetEditorDir, projectID)
 	if err != nil {
 		return err
 	}
 
 	// this file is used to check if the version is already downloaded
-	err = addFileVersion(filepath.Join(TargetEditorDir, downloadVersion))
+	err = addFileVersion(filepath.Join(targetEditorDir, downloadVersion))
 	if err != nil {
 		return err
 	}

--- a/common/editor/editor_test.go
+++ b/common/editor/editor_test.go
@@ -1,4 +1,4 @@
-package teacmd
+package editor
 
 import (
 	"fmt"
@@ -19,7 +19,7 @@ const (
 
 func TestSetupCardinalEditor(t *testing.T) {
 	t.Run("setup cardinal editor", func(t *testing.T) {
-		cleanUpDir(testDir)
+		assert.NilError(t, cleanUpDir(testDir))
 
 		editorDir, _, err := downloadReleaseIfNotCached(latestReleaseURL, testDir)
 		assert.NilError(t, err)
@@ -53,7 +53,7 @@ func TestSetupCardinalEditor(t *testing.T) {
 
 		// TODO: check if cardinal editor works
 
-		cleanUpDir(testDir)
+		assert.NilError(t, cleanUpDir(testDir))
 	})
 }
 
@@ -121,8 +121,8 @@ func TestCopyDir(t *testing.T) {
 		_, err = os.Stat(filepath.Join("tmp2", "subdir", "file2"))
 		assert.NilError(t, err)
 
-		cleanUpDir("tmp")
-		cleanUpDir("tmp2")
+		assert.NilError(t, cleanUpDir("tmp"))
+		assert.NilError(t, cleanUpDir("tmp2"))
 	})
 }
 
@@ -338,4 +338,8 @@ func compareMaps(a, b map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func cleanUpDir(targetDir string) error {
+	return os.RemoveAll(targetDir)
 }

--- a/common/teacmd/git.go
+++ b/common/teacmd/git.go
@@ -32,7 +32,14 @@ type GitCloneFinishMsg struct {
 
 func git(args ...string) (string, error) {
 	var outBuff, errBuff bytes.Buffer
-	_, err := sh.Exec(nil, &outBuff, &errBuff, "git", args...)
+
+	// Define environment variables
+	env := map[string]string{
+		"GIT_COMMITTER_NAME":  "World CLI",
+		"GIT_COMMITTER_EMAIL": "no-reply@world.dev",
+	}
+
+	_, err := sh.Exec(env, &outBuff, &errBuff, "git", args...)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +101,7 @@ func GitCloneCmd(url string, targetDir string, initMsg string) error {
 		return err
 	}
 
-	_, err = git("commit", "-m", initMsg)
+	_, err = git("commit", "--author=\"World CLI <no-reply@world.dev>\"", "-m", initMsg)
 	if err != nil {
 		return err
 	}

--- a/tea/component/multispinner/multispinner.go
+++ b/tea/component/multispinner/multispinner.go
@@ -1,0 +1,154 @@
+package multispinner
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"pkg.world.dev/world-cli/tea/style"
+)
+
+// Spinner is a component that displays a spinner while updating the logs
+type MultiSpinner struct {
+	processMap  *ProcessStateMap // need to be pointer because of the mutex
+	processList []string         // list of process names
+
+	spinner spinner.Model // spinner model
+	cancel  func()        // cancel function for context cancellation
+	allDone bool
+}
+
+type ProcessStateMap struct {
+	sync.Mutex
+	value map[string]ProcessState
+}
+
+type ProcessState struct {
+	Icon   string
+	State  string
+	Type   string
+	Name   string
+	Detail string
+	Done   bool
+}
+
+func CreateSpinner(processList []string, cancel func()) MultiSpinner {
+	// Initialize the spinner
+	s := spinner.New()
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("69"))
+	s.Spinner = spinner.Points
+
+	// Initialize the process map
+	processMap := &ProcessStateMap{
+		value: make(map[string]ProcessState),
+	}
+
+	// put all processes in the map
+	for _, process := range processList {
+		processMap.value[process] = ProcessState{
+			Name: process,
+		}
+	}
+
+	return MultiSpinner{
+		spinner:     s,
+		processList: processList,
+		processMap:  processMap,
+		cancel:      cancel,
+	}
+}
+
+// Init is called when the program starts and returns the initial command
+func (s MultiSpinner) Init() tea.Cmd {
+	// Start the spinner
+	return s.spinner.Tick
+}
+
+// Update handles incoming messages
+func (s MultiSpinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// case ctrl + c
+		if msg.String() == "ctrl+c" {
+			if s.cancel != nil {
+				s.cancel()
+			}
+			return s, tea.Quit
+		}
+	case spinner.TickMsg:
+		// Update the spinner
+		var cmd tea.Cmd
+		s.spinner, cmd = s.spinner.Update(msg)
+		// If all processes are done, quit after the view is updated
+		if s.allDone {
+			return s, tea.Batch(cmd, tea.Quit)
+		}
+		return s, cmd
+	case ProcessState:
+		s.setState(msg.Name, msg)
+
+		// check if all processes are done
+		allDone := true
+		for _, state := range s.getStates() {
+			if !state.Done {
+				allDone = false
+				break
+			}
+		}
+
+		if allDone {
+			// Set the flag to indicate all processes are done
+			s.allDone = true
+			// Return a spinner tick to update the view one last time before quitting
+			return s, s.spinner.Tick
+		}
+	}
+
+	return s, nil
+}
+
+// View renders the UI
+func (s MultiSpinner) View() string {
+	text := ""
+
+	processStates := s.getStates()
+
+	for _, state := range processStates {
+		icon := state.Icon
+		if !state.Done {
+			icon = s.spinner.View()
+		}
+
+		text += fmt.Sprintf("%s %s %s %s %s", icon,
+			style.ForegroundPrint(state.State, "12"),
+			style.ForegroundPrint(state.Type, "13"),
+			style.ForegroundPrint(state.Name, "2"),
+			state.Detail)
+
+		text += "\n"
+	}
+
+	return text
+}
+
+func (s MultiSpinner) setState(process string, state ProcessState) {
+	s.processMap.Lock()
+	defer s.processMap.Unlock()
+
+	s.processMap.value[process] = state
+}
+
+func (s MultiSpinner) getStates() []ProcessState {
+	s.processMap.Lock()
+	defer s.processMap.Unlock()
+
+	states := make([]ProcessState, 0, len(s.processMap.value))
+	for _, process := range s.processList {
+		states = append(states, s.processMap.value[process])
+	}
+
+	return states
+}

--- a/tea/style/util.go
+++ b/tea/style/util.go
@@ -1,0 +1,19 @@
+package style
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func ContextPrint(title, titleColor, subject, object string) {
+	titleStr := ForegroundPrint(title, titleColor)
+	arrowStr := ForegroundPrint("→", "241")
+	subjectStr := ForegroundPrint(subject, "4")
+
+	fmt.Printf("%s %s %s %s ", titleStr, arrowStr, subjectStr, object)
+}
+
+func ForegroundPrint(text string, color string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(text)
+}


### PR DESCRIPTION
Closes: WORLD-1177, WORLD-1189

## Overview

When user trying to exec `world create` but git configuration `.gitconfig` for username and password is not configured it will be returned error, but the gameshard dir is already created.

The issue is because on the last step of `world create` it will exec git commit, and it will need username and email to be configured in `.gitconfig`

Fix some PR review bug and changes :
- Fixing stuck on `world cardinal dev` command if docker container is not running
- Adjust creating/starting/stopping indicator on world cli
- Make stopping container parallel instead of one by one
- Remove extra letter on container log
- Fix cardinal editor target directory to root of game shard

## Brief Changelog

- Add envar for world cli default git email and username
- Add context cancelation when checking redis is healthy to fix stuck on `world cardinal dev`
- Add multispinner component to handle process animation and concurrent process / parallel
- Removing first escape ANSI character on container log 

## Testing and Verifying
- Adjusted unit test
- Manual Test

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/YO1Dcg4NByYdZHvKXaTq/64dc0f73-aaad-4b7a-85b1-954cd6a2e194.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/YO1Dcg4NByYdZHvKXaTq/64dc0f73-aaad-4b7a-85b1-954cd6a2e194.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/64dc0f73-aaad-4b7a-85b1-954cd6a2e194.mov">Screen Recording 2024-09-11 at 23.18.35.mov</video>

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/YO1Dcg4NByYdZHvKXaTq/9874d754-34cb-4905-a2dd-51f7a0771a6b.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/YO1Dcg4NByYdZHvKXaTq/9874d754-34cb-4905-a2dd-51f7a0771a6b.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/9874d754-34cb-4905-a2dd-51f7a0771a6b.mov">Screen Recording 2024-09-11 at 23.17.35.mov</video>

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/YO1Dcg4NByYdZHvKXaTq/8a53643e-dba0-4dd8-ab75-af937e78eccd.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/YO1Dcg4NByYdZHvKXaTq/8a53643e-dba0-4dd8-ab75-af937e78eccd.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/8a53643e-dba0-4dd8-ab75-af937e78eccd.mov">Screen Recording 2024-09-11 at 23.16.30.mov</video>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced context management for service startup and error handling in development mode.
	- Introduced a `MultiSpinner` component for visual feedback during multiple concurrent processes.
	- Improved user experience with asynchronous operations for creating and removing Docker volumes.
	- Updated Cardinal Editor setup to utilize the new `editor` package.
	- Added support for specifying Git commit authors in version control operations.

- **Bug Fixes**
	- Refined error handling for Docker service interactions, ensuring context cancellation is respected.

- **Documentation**
	- Updated tests for the Cardinal editor setup and improved coverage for various functionalities.

- **Chores**
	- Streamlined method signatures in Docker client interactions, removing unnecessary parameters.
	- Removed deprecated functions related to console output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->