### PR TITLE
fix: modify icon with standard char

### DIFF
--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -87,7 +87,9 @@ func TestExecuteDoctorCommand(t *testing.T) {
 		// Remove the first three characters for the example(✓  Git)
 		resultString := ""
 		if len(line) > 5 {
-			resultString = line[5:]
+			resultString = strings.ReplaceAll(line[5:], "(OK)", "")
+			resultString = strings.ReplaceAll(resultString, "(FAIL)", "")
+			resultString = strings.TrimSpace(resultString)
 		}
 		for dep := range seenDependencies {
 			if resultString != "" && resultString == dep {

--- a/common/docker/client_util.go
+++ b/common/docker/client_util.go
@@ -15,7 +15,7 @@ import (
 func contextPrint(title, titleColor, subject, object string) {
 	titleStr := foregroundPrint(title, titleColor)
 	arrowStr := foregroundPrint("→", "241")
-	subjectStr := foregroundPrint(subject, "4")
+	subjectStr := foregroundPrint(subject, "5")
 
 	fmt.Printf("%s %s %s %s ", titleStr, arrowStr, subjectStr, object)
 }

--- a/tea/style/icon.go
+++ b/tea/style/icon.go
@@ -4,9 +4,9 @@ import "github.com/charmbracelet/lipgloss"
 
 var (
 	QuestionIcon    = lipgloss.NewStyle().Foreground(lipgloss.Color("251")).SetString("? ").Bold(true)
-	CrossIcon       = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).SetString("✗ ").Bold(true)
-	TickIcon        = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).SetString("✓ ").Bold(true)
-	TodoIcon        = lipgloss.NewStyle().SetString("• ").Bold(true)
-	DoubleRightIcon = lipgloss.NewStyle().Foreground(lipgloss.Color("251")).SetString("» ").Bold(true)
-	ChevronIcon     = lipgloss.NewStyle().Foreground(lipgloss.Color("251")).SetString("› ").Bold(true)
+	CrossIcon       = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).SetString("(FAIL) ").Bold(true)
+	TickIcon        = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).SetString("(OK)   ").Bold(true)
+	TodoIcon        = lipgloss.NewStyle().SetString("- ").Bold(true)
+	DoubleRightIcon = lipgloss.NewStyle().Foreground(lipgloss.Color("251")).SetString(">> ").Bold(true)
+	ChevronIcon     = lipgloss.NewStyle().Foreground(lipgloss.Color("251")).SetString("> ").Bold(true)
 )


### PR DESCRIPTION
Closes: WORLD-1178 & WORLD-1179

## Overview

Currently cmd and powershell in windows cannot read tick and cross icon from world CLI

## Brief Changelog

Change icon to standard char 
- tick -> OK 
- cross -> FAIL
- Todo -> -
- Double Right -> >>
- Chevron -> >

## Testing and Verifying

Manually tested

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/10e46cd3-18df-4fc7-857d-8db0389ac00d.png)

