### PR TITLE
fix: Code scanning alert #1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/common/teacmd/editor.go
+++ b/common/teacmd/editor.go
@@ -202,7 +202,10 @@ func unzipFile(filename string, targetDir string) error {
 	var originalDir string
 	for i, file := range reader.File {
 		if i == 0 {
-			originalDir = file.Name
+			originalDir, err = sanitizeExtractPath(filepath.Dir(targetDir), file.Name)
+			if err != nil {
+				return err
+			}
 		}
 
 		src, err := file.Open()
@@ -235,7 +238,7 @@ func unzipFile(filename string, targetDir string) error {
 		dst.Close()
 	}
 
-	if err = os.Rename(filepath.Join(filepath.Dir(targetDir), originalDir), targetDir); err != nil {
+	if err = os.Rename(originalDir, targetDir); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/Argus-Labs/world-cli/security/code-scanning/1](https://github.com/Argus-Labs/world-cli/security/code-scanning/1)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for file extraction paths during the unzip process, enhancing robustness.
	- Simplified the renaming operation for extracted files to ensure correct path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->