### PR TITLE
fix: bug finding on ui/ux and docker built image issue

### DIFF
--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -37,6 +37,7 @@ var BaseCmd = &cobra.Command{
 func init() {
 	// Register subcommands - `world cardinal [subcommand]`
 	BaseCmd.AddCommand(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
+	registerConfigAndVerboseFlags(startCmd, devCmd, restartCmd, purgeCmd, stopCmd)
 }
 
 func getServices(cfg *config.Config) []service.Builder {

--- a/cmd/world/cardinal/common_flag.go
+++ b/cmd/world/cardinal/common_flag.go
@@ -1,7 +1,19 @@
 package cardinal
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"pkg.world.dev/world-cli/common/config"
+	"pkg.world.dev/world-cli/common/logger"
+)
 
 func registerEditorFlag(cmd *cobra.Command, defaultEnable bool) {
 	cmd.Flags().Bool("editor", defaultEnable, "Run Cardinal Editor, useful for prototyping and debugging")
+}
+
+func registerConfigAndVerboseFlags(cmds ...*cobra.Command) {
+	for _, cmd := range cmds {
+		config.AddConfigFlag(cmd)
+		logger.AddVerboseFlag(cmd)
+	}
 }

--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -33,6 +33,7 @@ const (
 var (
 	// ValidLogLevels Valid log levels for zerolog
 	validLogLevels = strings.Join([]string{
+		zerolog.TraceLevel.String(),
 		zerolog.DebugLevel.String(),
 		zerolog.InfoLevel.String(),
 		zerolog.WarnLevel.String(),
@@ -40,7 +41,6 @@ var (
 		zerolog.FatalLevel.String(),
 		zerolog.PanicLevel.String(),
 		zerolog.Disabled.String(),
-		zerolog.TraceLevel.String(),
 	}, ", ")
 
 	ErrGracefulExit = eris.New("Process gracefully exited")
@@ -158,7 +158,8 @@ func init() {
 	registerEditorFlag(startCmd, true)
 	startCmd.Flags().Bool(flagBuild, true, "Rebuild Docker images before starting")
 	startCmd.Flags().Bool(flagDetach, false, "Run in detached mode")
-	startCmd.Flags().String(flagLogLevel, "", "Set the log level")
+	startCmd.Flags().String(flagLogLevel, "",
+		fmt.Sprintf("Set the log level for Cardinal. Must be one of (%v)", validLogLevels))
 	startCmd.Flags().Bool(flagDebug, false, "Enable delve debugging")
 	startCmd.Flags().Bool(flagTelemetry, false, "Enable tracing, metrics, and profiling")
 }

--- a/cmd/world/evm/evm.go
+++ b/cmd/world/evm/evm.go
@@ -3,6 +3,8 @@ package evm
 import (
 	"github.com/spf13/cobra"
 
+	"pkg.world.dev/world-cli/common/config"
+	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -27,4 +29,12 @@ var BaseCmd = &cobra.Command{
 func init() {
 	// Register subcommands - `world evm [subcommand]`
 	BaseCmd.AddCommand(startCmd, stopCmd)
+	registerConfigAndVerboseFlags(startCmd, stopCmd)
+}
+
+func registerConfigAndVerboseFlags(cmds ...*cobra.Command) {
+	for _, cmd := range cmds {
+		config.AddConfigFlag(cmd)
+		logger.AddVerboseFlag(cmd)
+	}
 }

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -19,7 +19,6 @@ import (
 
 	"pkg.world.dev/world-cli/cmd/world/cardinal"
 	"pkg.world.dev/world-cli/cmd/world/evm"
-	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -74,9 +73,6 @@ func init() {
 
 	// Remove completion subcommand
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-
-	config.AddConfigFlag(rootCmd)
-	logger.AddVerboseFlag(rootCmd)
 }
 
 func checkLatestVersion() error {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 }
 
 func AddConfigFlag(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&configFile, flagForConfigFile, "c", "", "a toml encoded config file")
+	cmd.Flags().StringVarP(&configFile, flagForConfigFile, "c", "", "A TOML config file")
 }
 
 func GetConfig() (*Config, error) {

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -21,9 +21,9 @@ func cmdZero() *cobra.Command {
 func cmdWithConfig(t *testing.T, filename string) {
 	cmd := cmdZero()
 	AddConfigFlag(cmd)
-	assert.NilError(t, cmd.PersistentFlags().Set(flagForConfigFile, filename))
+	assert.NilError(t, cmd.Flags().Set(flagForConfigFile, filename))
 	t.Cleanup(func() {
-		assert.NilError(t, cmd.PersistentFlags().Set(flagForConfigFile, ""))
+		assert.NilError(t, cmd.Flags().Set(flagForConfigFile, ""))
 	})
 }
 

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -62,6 +62,22 @@ func (c *Client) buildImages(ctx context.Context, dockerServices ...service.Serv
 				Name:  dockerService.Image,
 			})
 
+			// Remove the container
+			err := c.removeContainer(ctx, dockerService.Name)
+			fmt.Printf("Removing container %s\n", dockerService.Image)
+			if err != nil {
+				p.Send(multispinner.ProcessState{
+					Icon:   style.CrossIcon.Render(),
+					State:  "building",
+					Type:   "image",
+					Name:   dockerService.Image,
+					Detail: err.Error(),
+					Done:   true,
+				})
+				errChan <- err
+				return
+			}
+
 			// Start the build process
 			buildResponse, err := c.buildImage(ctx, dockerService)
 			if err != nil {

--- a/common/docker/service/cardinal.go
+++ b/common/docker/service/cardinal.go
@@ -40,6 +40,51 @@ func Cardinal(cfg *config.Config) Service {
 		dockerfile = strings.ReplaceAll(dockerfile, mountCacheScript, "")
 	}
 
+	// Set env variables
+	const falseValue = "false"
+
+	// Set Base Shard Router Key
+	baseShardRouterKey := cfg.DockerEnv["BASE_SHARD_ROUTER_KEY"]
+	if baseShardRouterKey == "" {
+		baseShardRouterKey = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01"
+	}
+
+	// Set Cardinal Log Level
+	cardinalLogLevel := cfg.DockerEnv["CARDINAL_LOG_LEVEL"]
+	if cardinalLogLevel == "" {
+		cardinalLogLevel = "info"
+	}
+
+	// Set Cardinal Log Pretty
+	cardinalLogPretty := cfg.DockerEnv["CARDINAL_LOG_PRETTY"]
+	if cardinalLogPretty == "" {
+		cardinalLogPretty = "true"
+	}
+
+	// Set Cardinal Rollup Enabled
+	cardinalRollupEnabled := cfg.DockerEnv["CARDINAL_ROLLUP_ENABLED"]
+	if cardinalRollupEnabled == "" {
+		cardinalRollupEnabled = falseValue
+	}
+
+	// Set Telemetry Profiler Enabled
+	telemetryProfilerEnabled := cfg.DockerEnv["TELEMETRY_PROFILER_ENABLED"]
+	if telemetryProfilerEnabled == "" {
+		telemetryProfilerEnabled = falseValue
+	}
+
+	// Set telemetry trace enabled
+	telemetryTraceEnabled := cfg.DockerEnv["TELEMETRY_TRACE_ENABLED"]
+	if telemetryTraceEnabled == "" {
+		telemetryTraceEnabled = falseValue
+	}
+
+	// Set router key
+	routerKey := cfg.DockerEnv["ROUTER_KEY"]
+	if routerKey == "" {
+		routerKey = "25a0f627050d11b1461b2728ea3f704e141312b1d4f2a21edcec4eccddd940c2"
+	}
+
 	service := Service{
 		Name: getCardinalContainerName(cfg),
 		Config: container.Config{
@@ -47,6 +92,13 @@ func Cardinal(cfg *config.Config) Service {
 			Env: []string{
 				fmt.Sprintf("REDIS_ADDRESS=%s:6379", getRedisContainerName(cfg)),
 				fmt.Sprintf("BASE_SHARD_SEQUENCER_ADDRESS=%s:9601", getEVMContainerName(cfg)),
+				fmt.Sprintf("BASE_SHARD_ROUTER_KEY=%s", baseShardRouterKey),
+				fmt.Sprintf("CARDINAL_LOG_LEVEL=%s", cardinalLogLevel),
+				fmt.Sprintf("CARDINAL_LOG_PRETTY=%s", cardinalLogPretty),
+				fmt.Sprintf("CARDINAL_ROLLUP_ENABLED=%s", cardinalRollupEnabled),
+				fmt.Sprintf("TELEMETRY_PROFILER_ENABLED=%s", telemetryProfilerEnabled),
+				fmt.Sprintf("TELEMETRY_TRACE_ENABLED=%s", telemetryTraceEnabled),
+				fmt.Sprintf("ROUTER_KEY=%s", routerKey),
 			},
 			ExposedPorts: getExposedPorts(exposedPorts),
 		},

--- a/common/docker/service/evm.go
+++ b/common/docker/service/evm.go
@@ -21,6 +21,11 @@ func EVM(cfg *config.Config) Service {
 		daBaseURL = fmt.Sprintf("http://%s", getCelestiaDevNetContainerName(cfg))
 	}
 
+	daNamespaceID := cfg.DockerEnv["DA_NAMESPACE_ID"]
+	if daNamespaceID == "" {
+		daNamespaceID = "67480c4a88c4d12935d4"
+	}
+
 	faucetEnabled := cfg.DockerEnv["FAUCET_ENABLED"]
 	if faucetEnabled == "" {
 		faucetEnabled = "false" //nolint:goconst // default values should be local to the service
@@ -41,6 +46,22 @@ func EVM(cfg *config.Config) Service {
 		baseShardRouterKey = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01"
 	}
 
+	routerKey := cfg.DockerEnv["ROUTER_KEY"]
+	if routerKey == "" {
+		routerKey = "25a0f627050d11b1461b2728ea3f704e141312b1d4f2a21edcec4eccddd940c2"
+	}
+
+	chainID := cfg.DockerEnv["CHAIN_ID"]
+	if chainID == "" {
+		chainID = "world-420"
+	}
+
+	chainKeyMnemonic := cfg.DockerEnv["CHAIN_KEY_MNEMONIC"]
+	if chainKeyMnemonic == "" {
+		chainKeyMnemonic = "enact adjust liberty squirrel bulk ticket invest tissue antique window" +
+			"thank slam unknown fury script among bread social switch glide wool clog flag enroll"
+	}
+
 	return Service{
 		Name: getEVMContainerName(cfg),
 		Config: container.Config{
@@ -48,10 +69,14 @@ func EVM(cfg *config.Config) Service {
 			Env: []string{
 				fmt.Sprintf("DA_BASE_URL=%s", daBaseURL),
 				fmt.Sprintf("DA_AUTH_TOKEN=%s", cfg.DockerEnv["DA_AUTH_TOKEN"]),
+				fmt.Sprintf("DA_NAMESPACE_ID=%s", daNamespaceID),
 				fmt.Sprintf("FAUCET_ENABLED=%s", faucetEnabled),
 				fmt.Sprintf("FAUCET_ADDRESS=%s", faucetAddress),
 				fmt.Sprintf("FAUCET_AMOUNT=%s", faucetAmount),
 				fmt.Sprintf("BASE_SHARD_ROUTER_KEY=%s", baseShardRouterKey),
+				fmt.Sprintf("ROUTER_KEY=%s", routerKey),
+				fmt.Sprintf("CHAIN_ID=%s", chainID),
+				fmt.Sprintf("CHAIN_KEY_MNEMONIC=%s", chainKeyMnemonic),
 			},
 			ExposedPorts: getExposedPorts([]int{1317, 26657, 9090, 9601}),
 		},

--- a/common/docker/service/redis.go
+++ b/common/docker/service/redis.go
@@ -34,10 +34,7 @@ func Redis(cfg *config.Config) Service {
 	return Service{
 		Name: getRedisContainerName(cfg),
 		Config: container.Config{
-			Image: "redis:latest",
-			Env: []string{
-				fmt.Sprintf("REDIS_PASSWORD=%s", cfg.DockerEnv["REDIS_PASSWORD"]),
-			},
+			Image:        "redis:latest",
 			ExposedPorts: getExposedPorts(exposedPorts),
 		},
 		HostConfig: container.HostConfig{

--- a/common/logger/init.go
+++ b/common/logger/init.go
@@ -64,6 +64,6 @@ func PrintLogs() {
 // AddVerboseFlag set flag --log-debug
 func AddVerboseFlag(cmd ...*cobra.Command) {
 	for _, c := range cmd {
-		c.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable World CLI debug logs")
+		c.Flags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable World CLI debug logs")
 	}
 }


### PR DESCRIPTION
Closes: WORLD-1196, WORLD-1205, WORLD-1206, WORLD-1207

## Overview

Fix bug findings on world cli v1.3.1-Beta4

## Brief Changelog

- Fix docker image not builded without exec `world cardinal purge` firs. it's because container need to be removed first so that docker create new container with new image
- Remove red and yellow color for container name
- Fix `--log-level` flag not functioned properly, it's because the envar is not passed to the docker env.
- Move `-v` and `-c` from global flags to only flag in 3rd subcommand
- Add help for `--log-level` value (ex : info, debug, etc)

## Testing and Verifying

- Manually tested
- Still covered by unit test