### PR TITLE
fix: jaeger traces not persisted across container restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ dist/
 /starter-game
 
 # Built binary
-world
+./world

--- a/common/docker/service/evm.go
+++ b/common/docker/service/evm.go
@@ -28,7 +28,7 @@ func EVM(cfg *config.Config) Service {
 
 	faucetEnabled := cfg.DockerEnv["FAUCET_ENABLED"]
 	if faucetEnabled == "" {
-		faucetEnabled = "false" //nolint:goconst // default values should be local to the service
+		faucetEnabled = "false"
 	}
 
 	faucetAddress := cfg.DockerEnv["FAUCET_ADDRESS"]

--- a/common/docker/service/jaeger.go
+++ b/common/docker/service/jaeger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 
 	"pkg.world.dev/world-cli/common/config"
 )
@@ -19,10 +20,21 @@ func Jaeger(cfg *config.Config) Service {
 		Name: getJaegerContainerName(cfg),
 		Config: container.Config{
 			Image: "jaegertracing/all-in-one:1.61.0",
+			// hard-coding this since it won't change much and the defaults work. users most likely
+			// won't need to change these. note that this storage configuration isn't recommended to
+			// be used for production environment, but is good enough for local development.
+			// for more info see: https://www.jaegertracing.io/docs/1.62/deployment/#span-storage-backends
+			Env: []string{
+				"SPAN_STORAGE_TYPE=badger",
+				"BADGER_EPHEMERAL=false",
+				"BADGER_DIRECTORY_VALUE=/badger/data",
+				"BADGER_DIRECTORY_KEY=/badger/key",
+			},
 		},
 		HostConfig: container.HostConfig{
 			PortBindings: newPortMap(exposedPorts),
 			NetworkMode:  container.NetworkMode(cfg.DockerEnv["CARDINAL_NAMESPACE"]),
+			Mounts:       []mount.Mount{{Type: mount.TypeVolume, Source: cfg.DockerEnv["CARDINAL_NAMESPACE"], Target: "/badger"}},
 		},
 	}
 }

--- a/common/docker/service/jaeger.go
+++ b/common/docker/service/jaeger.go
@@ -31,6 +31,13 @@ func Jaeger(cfg *config.Config) Service {
 				"BADGER_DIRECTORY_KEY=/badger/key",
 				"QUERY_ADDITIONAL_HEADERS=Access-Control-Allow-Origin:*",
 			},
+			// running as the default user (uid 10001) doesn't work on mac because the volume is owned by
+			// root. A way to get around this is to create another container to change the owner of the
+			// /badger directory. since we're not able to start services following a dependency graph yet,
+			// we'll just run as root. world cli is also mainly used for local dev, so the security
+			// benefits of running as non-root doesn't really apply here.
+			// src: https://github.com/jaegertracing/jaeger/issues/4906
+			User: "root",
 		},
 		HostConfig: container.HostConfig{
 			PortBindings: newPortMap(exposedPorts),

--- a/common/docker/service/jaeger.go
+++ b/common/docker/service/jaeger.go
@@ -29,6 +29,7 @@ func Jaeger(cfg *config.Config) Service {
 				"BADGER_EPHEMERAL=false",
 				"BADGER_DIRECTORY_VALUE=/badger/data",
 				"BADGER_DIRECTORY_KEY=/badger/key",
+				"QUERY_ADDITIONAL_HEADERS=Access-Control-Allow-Origin:*",
 			},
 		},
 		HostConfig: container.HostConfig{

--- a/common/docker/service/jaeger.go
+++ b/common/docker/service/jaeger.go
@@ -34,7 +34,8 @@ func Jaeger(cfg *config.Config) Service {
 		HostConfig: container.HostConfig{
 			PortBindings: newPortMap(exposedPorts),
 			NetworkMode:  container.NetworkMode(cfg.DockerEnv["CARDINAL_NAMESPACE"]),
-			Mounts:       []mount.Mount{{Type: mount.TypeVolume, Source: cfg.DockerEnv["CARDINAL_NAMESPACE"], Target: "/badger"}},
+			Mounts: []mount.Mount{{Type: mount.TypeVolume,
+				Source: cfg.DockerEnv["CARDINAL_NAMESPACE"], Target: "/badger"}},
 		},
 	}
 }

--- a/common/docker/service/nakama.go
+++ b/common/docker/service/nakama.go
@@ -37,7 +37,7 @@ func Nakama(cfg *config.Config) Service {
 
 	traceEnabled := cfg.DockerEnv["NAKAMA_TRACE_ENABLED"]
 	if traceEnabled == "" || !cfg.Telemetry {
-		traceEnabled = "false"
+		traceEnabled = "true"
 	}
 
 	traceSampleRate := cfg.DockerEnv["NAKAMA_TRACE_SAMPLE_RATE"]
@@ -45,7 +45,7 @@ func Nakama(cfg *config.Config) Service {
 		traceSampleRate = "0.6"
 	}
 
-	metricsEnabled := false
+	metricsEnabled := true
 	if cfg.Telemetry {
 		cfgMetricsEnabled, err := strconv.ParseBool(cfg.DockerEnv["NAKAMA_METRICS_ENABLED"])
 		if err == nil {


### PR DESCRIPTION
Closes: WORLD-1208

## Overview

Previously the Jaeger container only stores the spans in memory, which is lost when the container is restarted. This PR fixes this by [configuring Jaeger to use Badger](https://www.jaegertracing.io/docs/1.62/deployment/#span-storage-backends) as the span storage engine with a Docker volume.

## Brief Changelog

- Updated the Jaeger container config to use badger

## Testing and Verifying

Manually tested and verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Jaeger service configuration with additional environment variables for local development.
	- Introduced volume mount configuration for improved service management.
	- Adjusted default settings for telemetry and metrics to be enabled by default, enhancing monitoring capabilities.

- **Chores**
	- Updated `.gitignore` to refine binary path specifications.
	- Removed linting directive from EVM function without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->