### PR TITLE
fix: check dir is exists before create/clone on world cardinal create command

### DIFF
--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -116,9 +116,15 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 	// set tea ouput to variable
 	teaOut := &bytes.Buffer{}
 	createCmd := getCreateCmd(teaOut)
-	createCmd.SetArgs([]string{gameDir})
 
+	// checkout the repo
+	sgtDir := gameDir + "/sgt"
+	createCmd.SetArgs([]string{sgtDir})
 	err = createCmd.Execute()
+	assert.NilError(t, err)
+
+	// Change dir
+	err = os.Chdir(sgtDir)
 	assert.NilError(t, err)
 
 	// Start cardinal
@@ -173,6 +179,9 @@ func TestDev(t *testing.T) {
 	createCmd := getCreateCmd(teaOut)
 	createCmd.SetArgs([]string{gameDir})
 
+	// checkout the repo
+	sgtDir := gameDir + "/sgt"
+	createCmd.SetArgs([]string{sgtDir})
 	err = createCmd.Execute()
 	assert.NilError(t, err)
 
@@ -280,6 +289,9 @@ func TestEVMStart(t *testing.T) {
 	createCmd := getCreateCmd(teaOut)
 	createCmd.SetArgs([]string{gameDir})
 
+	// checkout the repo
+	sgtDir := gameDir + "/sgt"
+	createCmd.SetArgs([]string{sgtDir})
 	err = createCmd.Execute()
 	assert.NilError(t, err)
 

--- a/common/docker/client_test.go
+++ b/common/docker/client_test.go
@@ -180,9 +180,11 @@ func TestBuild(t *testing.T) {
 	err = os.Chdir(dir)
 	assert.NilError(t, err)
 
+	sgtDir := dir + "/sgt"
+
 	// Pull the repository
 	templateGitURL := "https://github.com/Argus-Labs/starter-game-template.git"
-	err = teacmd.GitCloneCmd(templateGitURL, dir, "Initial commit from World CLI")
+	err = teacmd.GitCloneCmd(templateGitURL, sgtDir, "Initial commit from World CLI")
 	assert.NilError(t, err)
 
 	// Preparation
@@ -190,7 +192,7 @@ func TestBuild(t *testing.T) {
 		DockerEnv: map[string]string{
 			"CARDINAL_NAMESPACE": cardinalNamespace,
 		},
-		RootDir: dir,
+		RootDir: sgtDir,
 	}
 	cardinalService := service.Cardinal(cfg)
 	ctx := context.Background()

--- a/common/teacmd/git.go
+++ b/common/teacmd/git.go
@@ -47,6 +47,12 @@ func git(args ...string) (string, error) {
 }
 
 func GitCloneCmd(url string, targetDir string, initMsg string) error {
+	// check targetDir exists
+	if _, err := os.Stat(targetDir); err == nil {
+		return eris.Errorf("Game shard named '%s' already exists in this directory, "+
+			"please change the directory or use another name", targetDir)
+	}
+
 	_, err := git("clone", url, targetDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes: WORLD-1044

## Overview

if you world create with name == "foobar" and you already have a dir named "foobar", the error message you get isn't very helpful.

## Brief Changelog

- add checking for the exists dir before doing clone

## Testing and Verifying

- Manually tested using `world cardinal create` command
- Adjusted unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the Git clone operation to prevent overwriting existing directories by returning an error if the target directory already exists.
- **Tests**
	- Updated test cases to utilize a new directory structure for command execution, ensuring consistent behavior in command tests.
	- Modified the `TestBuild` function to clone repositories into a specific subdirectory within the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->