### PR TITLE
feat: parameterize nakama image

### DIFF
--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -239,7 +239,7 @@ func evmIsDown(t *testing.T) bool {
 
 func ServiceIsUp(name, address string, t *testing.T) bool {
 	up := false
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 120; i++ {
 		conn, err := net.DialTimeout("tcp", address, time.Second)
 		if err != nil {
 			time.Sleep(time.Second)
@@ -255,7 +255,7 @@ func ServiceIsUp(name, address string, t *testing.T) bool {
 
 func ServiceIsDown(name, address string, t *testing.T) bool {
 	down := false
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 120; i++ {
 		conn, err := net.DialTimeout("tcp", address, time.Second)
 		if err != nil {
 			down = true

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -64,7 +64,6 @@ func (c *Client) buildImages(ctx context.Context, dockerServices ...service.Serv
 
 			// Remove the container
 			err := c.removeContainer(ctx, dockerService.Name)
-			fmt.Printf("Removing container %s\n", dockerService.Image)
 			if err != nil {
 				p.Send(multispinner.ProcessState{
 					Icon:   style.CrossIcon.Render(),

--- a/common/editor/editor.go
+++ b/common/editor/editor.go
@@ -150,6 +150,10 @@ func downloadReleaseIfNotCached(downloadURL, configDir string) (string, string, 
 	editorDir := filepath.Join(configDir, "editor")
 
 	targetDir := filepath.Join(editorDir, release.Name)
+	if release.Assets == nil || (release.Assets != nil && len(release.Assets) == 0) {
+		return targetDir, release.Name, eris.New(fmt.Sprintf("No assets found in release %s", release.Name))
+	}
+
 	if _, err = os.Stat(targetDir); os.IsNotExist(err) {
 		return targetDir, release.Name, downloadAndUnzip(release.Assets[0].BrowserDownloadURL, targetDir)
 	}


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

Change nakama image to alway use latest version and can be parameterize through world.toml if user want to use specific version

## Brief Changelog

- Change nakama default image to latest version
- Add `NAKAMA_IMAGE` and `NAKAMA_IMAGE_PLATFORM` on world.toml to use specific version of nakama 

## Testing and Verifying

Tested manually using `world cardinal start` command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for the Nakama container image and platform settings via environment variables.
	- Improved configurability for the EVM container image and platform settings based on environment variables.
- **Improvements**
	- Improved logging for container removal during image building.
	- Enhanced error reporting and progress handling when pulling images.
	- Added robust error handling for asset availability in the release download process.
	- Increased retry duration for service status checks, allowing more time for services to become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->