### PR TITLE
feat: add deployment reset command

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -16,8 +16,8 @@ import (
 
 var statusFailRegEx = regexp.MustCompile(`[^a-zA-Z0-9\. ]+`)
 
-// Deploy a project
-func deploy(ctx context.Context) error {
+// Deployment a project
+func deployment(ctx context.Context, deployType string) error {
 	globalConfig, err := globalconfig.GetGlobalConfig()
 	if err != nil {
 		return eris.Wrap(err, "Failed to get global config")
@@ -56,79 +56,14 @@ func deploy(ctx context.Context) error {
 	fmt.Printf("Project Slug: %s\n", prj.Slug)
 	fmt.Printf("Repository:   %s\n\n", prj.RepoURL)
 
-	deployURL := fmt.Sprintf("%s/api/organization/%s/project/%s/deploy", baseURL, organizationID, projectID)
+	deployURL := fmt.Sprintf("%s/api/organization/%s/project/%s/%s", baseURL, organizationID, projectID, deployType)
 	_, err = sendRequest(ctx, http.MethodPost, deployURL, nil)
 	if err != nil {
-		return eris.Wrap(err, "Failed to deploy project")
+		return eris.Wrap(err, fmt.Sprintf("Failed to %s project", deployType))
 	}
 
-	fmt.Println("\n✨ Your deployment is being processed! ✨")
-	fmt.Println("\nTo check the status of your deployment, run:")
-	fmt.Println("  $ 'world forge deployment status'")
-
-	return nil
-}
-
-// Destroy a project
-func destroy(ctx context.Context) error {
-	globalConfig, err := globalconfig.GetGlobalConfig()
-	if err != nil {
-		return eris.Wrap(err, "Failed to get global config")
-	}
-
-	projectID := globalConfig.ProjectID
-	organizationID := globalConfig.OrganizationID
-
-	if organizationID == "" {
-		printNoSelectedOrganization()
-		return nil
-	}
-
-	if projectID == "" {
-		printNoSelectedProject()
-		return nil
-	}
-
-	// Get organization details
-	org, err := getSelectedOrganization(ctx)
-	if err != nil {
-		return eris.Wrap(err, "Failed to get organization details")
-	}
-
-	// Get project details
-	prj, err := getSelectedProject(ctx)
-	if err != nil {
-		return eris.Wrap(err, "Failed to get project details")
-	}
-
-	fmt.Println("Project Details")
-	fmt.Println("-----------------")
-	fmt.Printf("Organization: %s\n", org.Name)
-	fmt.Printf("Org Slug:     %s\n", org.Slug)
-	fmt.Printf("Project:      %s\n", prj.Name)
-	fmt.Printf("Project Slug: %s\n", prj.Slug)
-	fmt.Printf("Repository:   %s\n\n", prj.RepoURL)
-
-	fmt.Print("Are you sure you want to destroy this project? (y/N): ")
-	response, err := getInput()
-	if err != nil {
-		return eris.Wrap(err, "Failed to read response")
-	}
-
-	response = strings.ToLower(strings.TrimSpace(response))
-	if response != "y" {
-		fmt.Println("Destroy cancelled")
-		return nil
-	}
-
-	destroyURL := fmt.Sprintf("%s/api/organization/%s/project/%s/destroy", baseURL, organizationID, projectID)
-	_, err = sendRequest(ctx, http.MethodPost, destroyURL, nil)
-	if err != nil {
-		return eris.Wrap(err, "Failed to destroy project")
-	}
-
-	fmt.Println("\n🗑️  Your destroy request is being processed!")
-	fmt.Println("\nTo check the status of your destroy request, run:")
+	fmt.Printf("\n✨ Your %s is being processed! ✨\n", deployType)
+	fmt.Printf("\nTo check the status of your %s, run:\n", deployType)
 	fmt.Println("  $ 'world forge deployment status'")
 
 	return nil

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -159,7 +159,7 @@ var (
 			if !checkLogin() {
 				return nil
 			}
-			return deploy(cmd.Context())
+			return deployment(cmd.Context(), "deploy")
 		},
 	}
 
@@ -170,7 +170,18 @@ var (
 			if !checkLogin() {
 				return nil
 			}
-			return destroy(cmd.Context())
+			return deployment(cmd.Context(), "destroy")
+		},
+	}
+
+	resetCmd = &cobra.Command{
+		Use:   "reset",
+		Short: "Reset a project",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !checkLogin() {
+				return nil
+			}
+			return deployment(cmd.Context(), "reset")
 		},
 	}
 
@@ -218,5 +229,6 @@ func init() {
 	deploymentCmd.AddCommand(deployCmd)
 	deploymentCmd.AddCommand(destroyCmd)
 	deploymentCmd.AddCommand(statusCmd)
+	deploymentCmd.AddCommand(resetCmd)
 	BaseCmd.AddCommand(deploymentCmd)
 }


### PR DESCRIPTION
Closes: WORLD-1327 & WORLD-1328

## Overview

Check destroy command and add reset command

## Brief Changelog

- merge the deploy, destroy func

## Testing and Verifying

Manual test runing `world forge deployment reset` command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
    - Added a new project reset functionality.
    - Enhanced deployment commands with more flexible action types.

- **Improvements**
    - Consolidated deployment-related actions into a single method.
    - Improved error handling and context for deployment operations.

- **Changes**
    - Updated deployment command structure to support deploy, destroy, and reset actions.
    - Standardized deployment method signature across different operations.

The release introduces more flexible project management capabilities with a unified deployment approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->