### PR TITLE
fix: Added human readable username for deployments

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -130,6 +130,10 @@ func status(ctx context.Context) error {
 	if !ok {
 		return eris.New("Failed to unmarshal deployment executor_id")
 	}
+	executorName, ok := data["executor_name"].(string)
+	if ok {
+		executorID = executorName
+	}
 	executionTimeStr, ok := data["execution_time"].(string)
 	if !ok {
 		return eris.New("Failed to unmarshal deployment execution_time")


### PR DESCRIPTION
## Overview

Instead of displaying a GUID, now displays a human readable username and email for build status:

Example: `Build:        #1 on 20 Dec 24 17:50 UTC by Zulkhair Abdullah Daim <zul@argus.gg>`

## Testing and Verifying

- This change is a trivial rework/code cleanup without any test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved executor identification in deployment status reporting by extracting a more descriptive executor name when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->