### PR TITLE
feat: world forge project deletion

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -172,6 +172,17 @@ var (
 			return createProject(cmd.Context())
 		},
 	}
+
+	deleteProjectCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a project",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !checkLogin() {
+				return nil
+			}
+			return deleteProject(cmd.Context())
+		},
+	}
 )
 
 // Deployment commands
@@ -260,6 +271,7 @@ func init() {
 	// Add project commands
 	projectCmd.AddCommand(createProjectCmd)
 	projectCmd.AddCommand(switchProjectCmd)
+	projectCmd.AddCommand(deleteProjectCmd)
 	BaseCmd.AddCommand(projectCmd)
 
 	// Add deployment commands


### PR DESCRIPTION
Closes: WORLD-1360

## Overview
Add `world forge project delete` command

## Brief Changelog

- Add new function for project deletion

## Testing and Verifying

Manually test with local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new command to delete projects.
	- Implemented project deletion functionality with user confirmation and warning.

- **User Experience**
	- Users can now delete projects and associated resources.
	- Added safety checks and confirmation prompts before project deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->