### PR TITLE
feat: Updated CLI to permit force deploy

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -14,6 +14,12 @@ import (
 	"pkg.world.dev/world-cli/common/globalconfig"
 )
 
+const (
+	DeploymentTypeDeploy  = "deploy"
+	DeploymentTypeDestroy = "destroy"
+	DeploymentTypeReset   = "reset"
+)
+
 var statusFailRegEx = regexp.MustCompile(`[^a-zA-Z0-9\. ]+`)
 
 // Deployment a project
@@ -126,7 +132,9 @@ func status(ctx context.Context) error {
 	if !ok {
 		return eris.New("Failed to unmarshal deployment type")
 	}
-	if deployType != "deploy" && deployType != "destroy" && deployType != "reset" {
+	if deployType != DeploymentTypeDeploy &&
+		deployType != DeploymentTypeDestroy &&
+		deployType != DeploymentTypeReset {
 		return eris.Errorf("Unknown deployment type %s", deployType)
 	}
 	executorID, ok := data["executor_id"].(string)
@@ -150,7 +158,7 @@ func status(ctx context.Context) error {
 		return eris.New("Failed to unmarshal deployment build_state")
 	}
 	switch deployType {
-	case "deploy":
+	case DeploymentTypeDeploy:
 		bnf, ok := data["build_number"].(float64)
 		if !ok {
 			return eris.New("Failed to unmarshal deployment build_number")
@@ -172,12 +180,12 @@ func status(ctx context.Context) error {
 			return nil
 		}
 		fmt.Printf("Build:        #%d on %s by %s\n", buildNumber, dt.Format(time.RFC822), executorID)
-	case "destroy":
+	case DeploymentTypeDestroy:
 		fmt.Printf("Destroyed:    on %s by %s", dt.Format(time.RFC822), executorID)
 		if buildState != "failed" {
 			return nil // if destroy failed, continue on to show health, otherwise stop here.
 		}
-	case "reset":
+	case DeploymentTypeReset:
 		fmt.Printf("Reset:        on %s by %s\n", dt.Format(time.RFC822), executorID)
 		// results can be "passed" or "failed", but either way continue to show the health
 	default:

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -56,6 +56,9 @@ func deployment(ctx context.Context, deployType string) error {
 	fmt.Printf("Project Slug: %s\n", prj.Slug)
 	fmt.Printf("Repository:   %s\n\n", prj.RepoURL)
 
+	if deployType == "forceDeploy" {
+		deployType = "deploy?force=true"
+	}
 	deployURL := fmt.Sprintf("%s/api/organization/%s/project/%s/%s", baseURL, organizationID, projectID, deployType)
 	_, err = sendRequest(ctx, http.MethodPost, deployURL, nil)
 	if err != nil {

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -217,7 +217,12 @@ var (
 			if !checkLogin() {
 				return nil
 			}
-			return deployment(cmd.Context(), "deploy")
+			force, _ := cmd.Flags().GetBool("force")
+			deployType := "deploy"
+			if force {
+				deployType = "forceDeploy"
+			}
+			return deployment(cmd.Context(), deployType)
 		},
 	}
 
@@ -287,6 +292,8 @@ func init() {
 	BaseCmd.AddCommand(projectCmd)
 
 	// Add deployment commands
+	deployCmd.Flags().Bool("force", false,
+		"Start the deploy even if one is currently running. Cancels current running deploy.")
 	deploymentCmd.AddCommand(deployCmd)
 	deploymentCmd.AddCommand(destroyCmd)
 	deploymentCmd.AddCommand(statusCmd)


### PR DESCRIPTION
Closes: PLAT-88

`world forge deployment deploy` now supports a flag `--force`. When used, any currently running deployment will be cancelled and the new one started. Without that flag, the deploy will fail if there is a currently running deployment that is less than an hour old

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `--force` flag to the deployment command.
	- Enhanced deployment functionality to allow forcing a deployment when another is in progress.

- **Improvements**
	- Updated deployment logic to utilize constants for deployment types, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->