### PR TITLE
chore: world create shallow clone for latest tag

### DIFF
--- a/common/teacmd/git_test.go
+++ b/common/teacmd/git_test.go
@@ -29,7 +29,7 @@ func TestGitCloneCmd(t *testing.T) {
 		{
 			name:     "error clone wrong address",
 			wantErr:  true,
-			expected: 128,
+			expected: 1,
 			param: param{
 				url:       "wrong address",
 				targetDir: "targetDir",


### PR DESCRIPTION
Closes: PLAT-9

## Overview

Optimize world create shallow clone for latest tag

## Brief Changelog

- Clone only the latest tag (shallow clone)
- Improved error handling with clearer messages.

## Testing and Verifying

- Manually tested using `world create` command
- Adjusted unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced Git operations to automatically use the latest version, resulting in clearer feedback during errors.
- **Tests**
  - Adjusted the error response for invalid Git addresses to align with the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->