### PR TITLE
feat: add world forge deployment promote command

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -258,6 +258,17 @@ var (
 			return status(cmd.Context())
 		},
 	}
+
+	promoteCmd = &cobra.Command{
+		Use:   "promote",
+		Short: "Promote a project from dev to prod environment",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !checkLogin() {
+				return nil
+			}
+			return deployment(cmd.Context(), "promote")
+		},
+	}
 )
 
 func init() {
@@ -298,5 +309,6 @@ func init() {
 	deploymentCmd.AddCommand(destroyCmd)
 	deploymentCmd.AddCommand(statusCmd)
 	deploymentCmd.AddCommand(resetCmd)
+	deploymentCmd.AddCommand(promoteCmd)
 	BaseCmd.AddCommand(deploymentCmd)
 }


### PR DESCRIPTION
Closes: PLAT-119 & PLAT-103

## Overview

Adding new command `world forge deployment promote` and adding more time for time out on sending request to world forge, and also added the retry mechanism

## Brief Changelog

- Added  `world forge deployment promote` command
- Increase time out for request to world forge, and implemet retry mechanism

## Testing and Verifying

- manually test integrated with world forge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command that lets users seamlessly promote projects from development to production.

- **Refactor**
  - Enhanced network interactions for greater reliability by extending the request timeout and implementing a robust retry mechanism with clearer error feedback.
  - Improved the parsing logic for retrieving the latest Git tags, ensuring only valid tags are considered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->