### PR TITLE
feat: repo path support in project setup

### DIFF
--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -995,6 +995,41 @@ func (s *ForgeTestSuite) TestParseResponse() {
 	}
 }
 
+func (s *ForgeTestSuite) TestValidateRepoPath() {
+	testCases := []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{name: "Good Path",
+			path:          "rampage",
+			expectedError: false,
+		},
+		{name: "Bad Path",
+			path:          "spaces not allowed",
+			expectedError: true,
+		},
+		{name: "Empty Path",
+			path:          "",
+			expectedError: false,
+		},
+		{name: "Multilevel Path",
+			path:          "/this/path/is/fine",
+			expectedError: false,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := validateRepoPath(s.ctx, "fake_repo_url", "fake_token", tc.path)
+			if tc.expectedError {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func (s *ForgeTestSuite) TestValidateRepoToken() {
 	testCases := []struct {
 		name          string

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1469,6 +1469,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 				"testp",        // slug
 				"https://github.com/argus-labs/starter-game-template", // repoURL
 				"",        // repoToken (empty for public repo)
+				"",        // repoPath (empty for default root path of repo)
 				"testenv", // environment
 				"10",      // tick rate
 			},

--- a/cmd/world/forge/repo.go
+++ b/cmd/world/forge/repo.go
@@ -49,6 +49,18 @@ func validateRepoToken(ctx context.Context, repoURL, token string) error {
 	}
 }
 
+// params: ctx, repoURL, token, path
+func validateRepoPath(_ context.Context, _, _, path string) error {
+	if strings.Contains(path, " ") {
+		return fmt.Errorf("invalid path: %s", path)
+	}
+	// I don't think we need to verify that the path actually exists in the repo,
+	// but if we decide to here's where we would do that. If it doesn't exist then
+	// any deploy attempt will fail in the World Forge Worker at the checkout action
+	// Hints at possible GitHub implementation here: https://github.com/orgs/community/discussions/68413
+	return nil
+}
+
 // validateGitHub validates the token and repository for GitHub.
 func validateGitHub(ctx context.Context, repoURL, token, apiBaseURL string) error {
 	// Extract the owner and repo name from the URL


### PR DESCRIPTION
- added inputRepoPath to get the path
- updated successful setup test
- call inputRepoPath when getting project setup
- send the path as part of payload for both create and update calls to backend
- added barebones path validation that just checks for spaces

Closes: PLAT-133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a repository path option for project creation and updates, allowing users to specify where project data is sourced.
  - Added user prompts with validation to ensure the repository path meets format requirements.

- **Tests**
  - Added a new test for validating repository paths with various input cases.
  - Updated tests for project creation to include and verify the new repository path parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->