### PR TITLE
feat: Get Region list from backend call

### DIFF
--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -70,6 +70,8 @@ func (s *ForgeTestSuite) SetupTest() {
 					http.Error(w, "Organization not found", http.StatusNotFound)
 				case "/api/organization/test-org-id/project/invalid-project-id/deploy":
 					http.Error(w, "Project not found", http.StatusNotFound)
+				case "/api/organization/test-org-id/project/00000000-0000-0000-0000-000000000000/regions":
+					s.handleGetRegions(w, r)
 				case "/api/organization/test-org-id/invite":
 					s.handleInvite(w, r)
 				case "/api/organization/test-org-id/role":
@@ -227,6 +229,16 @@ func (s *ForgeTestSuite) handleProjectGet(w http.ResponseWriter, _ *http.Request
 		RepoURL: "https://github.com/test/repo",
 	}
 	s.writeJSON(w, map[string]interface{}{"data": proj})
+}
+
+func (s *ForgeTestSuite) handleGetRegions(w http.ResponseWriter, r *http.Request) {
+	result := map[string]string{
+		"38f46cb3-63a3-4955-ae5f-6c31595fd970": "ap-southeast-1",
+		"4ee8a580-879f-47c8-a183-de6d50329dc1": "us-east-1",
+		"71d61857-f803-4135-80a7-68b3e6f55443": "eu-central-1",
+		"f80a422c-eb8d-4d6d-8244-0f065773cb20": "us-west-2",
+	}
+	s.writeJSON(w, map[string]interface{}{"data": result})
 }
 
 func (s *ForgeTestSuite) handleDeploy(w http.ResponseWriter, r *http.Request) {

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -231,7 +231,7 @@ func (s *ForgeTestSuite) handleProjectGet(w http.ResponseWriter, _ *http.Request
 	s.writeJSON(w, map[string]interface{}{"data": proj})
 }
 
-func (s *ForgeTestSuite) handleGetRegions(w http.ResponseWriter, r *http.Request) {
+func (s *ForgeTestSuite) handleGetRegions(w http.ResponseWriter, _ *http.Request) {
 	result := map[string]string{
 		"38f46cb3-63a3-4955-ae5f-6c31595fd970": "ap-southeast-1",
 		"4ee8a580-879f-47c8-a183-de6d50329dc1": "us-east-1",

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1519,10 +1519,9 @@ func (s *ForgeTestSuite) TestCreateProject() {
 				"Test Project", // name
 				"testp",        // slug
 				"https://github.com/argus-labs/starter-game-template", // repoURL
-				"",        // repoToken (empty for public repo)
-				"",        // repoPath (empty for default root path of repo)
-				"testenv", // environment
-				"10",      // tick rate
+				"",   // repoToken (empty for public repo)
+				"",   // repoPath (empty for default root path of repo)
+				"10", // tick rate
 			},
 			regionSelectActions: []tea.KeyMsg{
 				tea.KeyMsg{Type: tea.KeySpace}, // select region

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -190,7 +190,7 @@ func createProject(ctx context.Context) error {
 	if err != nil {
 		return eris.Wrap(err, "Failed to get available regions")
 	}
-	//fmt.Println(regions)
+	// fmt.Println(regions)
 
 	projectModel, err := projectInput(ctx, regions)
 	if err != nil {

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -35,7 +35,6 @@ type project struct {
 }
 
 type projectConfig struct {
-	EnvName  string   `json:"env_name"`
 	TickRate int      `json:"tick_rate"`
 	Region   []string `json:"region"`
 }
@@ -521,13 +520,6 @@ func projectInput(ctx context.Context) (project, error) {
 	}
 	project.RepoPath = repoPath
 
-	// Env Name
-	envName, err := inputEnvName(ctx)
-	if err != nil {
-		return project, eris.Wrap(err, "Failed to get environment name")
-	}
-	project.Config.EnvName = envName
-
 	// Tick Rate
 	tickRate, err := inputTickRate(ctx)
 	if err != nil {
@@ -543,34 +535,6 @@ func projectInput(ctx context.Context) (project, error) {
 	project.Config.Region = regions
 
 	return project, nil
-}
-
-// inputEnvName prompts the user to enter an environment name (e.g. dev, staging, prod)
-// and validates that it is not empty. Returns error after max attempts or context cancellation.
-func inputEnvName(ctx context.Context) (string, error) {
-	attempts := 0
-	maxAttempts := 5
-	for attempts < maxAttempts {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-			fmt.Print("Enter environment name (e.g. 'dev', 'staging', 'prod'): ")
-			envName, err := getInput()
-			if err != nil {
-				attempts++
-				fmt.Printf("Error: Failed to read environment name\n")
-				continue
-			}
-			if envName == "" {
-				attempts++
-				fmt.Printf("Error: Environment name cannot be empty\n")
-				continue
-			}
-			return envName, nil
-		}
-	}
-	return "", eris.New("Maximum attempts reached for entering environment name")
 }
 
 // inputTickRate prompts the user to enter a tick rate value (default is 1)


### PR DESCRIPTION
Closes: PLAT-146

- fetch region list from backend call
- Remove unused query for environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced project creation tests to validate setups that include public repository details.
  - Introduced a new handler for fetching region data in the test suite.

- **Refactor**
  - Streamlined the project setup flow by removing the environment name input and adding functionality to fetch available regions for new projects, simplifying the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->