### PR TITLE
chore: add discord and slack conf

### DIFF
--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1608,9 +1608,15 @@ func (s *ForgeTestSuite) TestCreateProject() {
 				"Test Project", // name
 				"testp",        // slug
 				"https://github.com/argus-labs/starter-game-template", // repoURL
-				"",   // repoToken (empty for public repo)
-				"",   // repoPath (empty for default root path of repo)
-				"10", // tick rate
+				"",           // repoToken (empty for public repo)
+				"",           // repoPath (empty for default root path of repo)
+				"10",         // tick rate
+				"Y",          // enable discord notifications
+				"test-token", // discord token
+				"1234567890", // discord channel ID
+				"Y",          // enable slack notifications
+				"test-token", // slack token
+				"1234567890", // slack channel ID
 			},
 			regionSelectActions: []tea.KeyMsg{
 				tea.KeyMsg{Type: tea.KeySpace}, // select region


### PR DESCRIPTION
Closes: PLAT-172


## Overview

Adding Discord and Slack notif config

## Brief Changelog

Add prompt for adding docker and slack configuration

## Testing and Verifying

- Manually test integrated with backend
- Adjusted unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced options for configuring Discord and Slack notifications during project creation and updates, allowing users to enable alerts and input necessary details.

- **Tests**
  - Updated validation processes to ensure reliable integration of the new notification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->