### PR TITLE
fix: Misc fixes, especially install related

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ release:
   # replace_existing_artifacts: true
 
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz' ]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -52,7 +52,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
 
 changelog:
   sort: asc

--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -250,7 +250,7 @@ func slugCheck(slug string, minLength int, maxLength int) error {
 // if you are not on a TTY, so you can run the debugger. Call it just as you would call tea.NewProgram().
 func NewTeaProgram(model tea.Model, opts ...tea.ProgramOption) *tea.Program {
 	if !term.IsTerminal(int(os.Stderr.Fd())) {
-		opts = append(opts, tea.WithInput(os.Stdin))
+		opts = append(opts, tea.WithInput(nil))
 		// opts = append(opts, tea.WithoutRenderer())
 	}
 	return tea.NewProgram(model, opts...)

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	// Set default app version in case not provided by ldflags
 	if AppVersion == "" {
-		AppVersion = "v0.0.1-dev"
+		AppVersion = "0.0.1-dev"
 	}
 	root.AppVersion = AppVersion
 

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"pkg.world.dev/world-cli/cmd/world/forge"
 	"pkg.world.dev/world-cli/common/dependency"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/tea/style"
@@ -83,7 +84,7 @@ World CLI requires the following dependencies to be installed:
 - Docker`,
 		GroupID: "starter",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			p := tea.NewProgram(NewWorldDoctorModel(), tea.WithOutput(writer))
+			p := forge.NewTeaProgram(NewWorldDoctorModel(), tea.WithOutput(writer))
 			_, err := p.Run()
 			if err != nil {
 				return err


### PR DESCRIPTION
- default app version shouldn't include "v" prefix
- fixed NewTeaProgram() to pass nil for input
- fixed deprecated format directives in goreleaser yaml
- use NewTeaProgram somewhere it was breaking before as a test.

Closes: PLAT-227
<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced archive packaging to support multiple formats.
  - Updated the default version display for improved consistency.
- **Bug Fixes**
  - Improved input handling in non-interactive scenarios.
- **Refactor**
  - Streamlined command initialization for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->