### PR TITLE
fix: get version from build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,21 @@ Key features:
 
 ## Installation
 
-World CLI has been rigorously tested on macOS and Linux.
-If you are using Windows, you will need
-[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to install and use the CLI.
+Before installing World CLI, you'll need to have Go installed on your system.
+If you haven't installed Go yet, follow the official [Go installation guide](https://go.dev/doc/install) to get started.
+
+### World CLI Installation
 
 **Install latest release:**
 
 ```shell
-curl https://install.world.dev/cli! | bash
+go install pkg.world.dev/world-cli/cmd/world@latest
 ```
 
 **Install a specific release:**
 
 ```shell
-curl https://install.world.dev/cli@<release_tag>! | bash
+go install pkg.world.dev/world-cli/cmd/world@<tag>
 ```
 
 <br/>

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/rs/zerolog/log"
 
@@ -15,32 +16,23 @@ import (
 // This variable will be overridden by ldflags during build
 // Example:
 /*
-	go build -ldflags "-X main.AppVersion=1.0.0 -X main.PosthogAPIKey=<POSTHOG_API_KEY>
-							-X main.SentryDsn=<SENTRY_DSN> -X main.Env=<DEV|PROD>"
+	go build -ldflags "-X main.PosthogAPIKey=<POSTHOG_API_KEY>
+							-X main.SentryDsn=<SENTRY_DSN>>"
 */
 var (
-	AppVersion    string
 	PosthogAPIKey string
 	SentryDsn     string
-	Env           string
 )
 
 func init() {
-	// Set default app version in case not provided by ldflags
-	if AppVersion == "" {
-		AppVersion = "v0.0.1-dev"
-	}
-	root.AppVersion = AppVersion
-
-	if Env == "" {
-		Env = "DEV"
-	}
-	globalconfig.Env = Env
+	env, version := getEnvAndVersion()
+	root.AppVersion = version
+	root.AppEnv = env
 }
 
 func main() {
 	// Sentry initialization
-	telemetry.SentryInit(SentryDsn, Env, AppVersion)
+	telemetry.SentryInit(SentryDsn, root.AppEnv, root.AppVersion)
 	defer telemetry.SentryFlush()
 
 	// Set up config directory "~/.worldcli/"
@@ -56,12 +48,36 @@ func main() {
 
 	// Capture event post installation
 	if len(os.Args) > 1 && os.Args[1] == "post-installation" {
-		telemetry.PosthogCaptureEvent(AppVersion, telemetry.PostInstallationEvent)
+		telemetry.PosthogCaptureEvent(root.AppVersion, telemetry.PostInstallationEvent)
 		return
 	}
 
 	// Capture event running
-	telemetry.PosthogCaptureEvent(AppVersion, telemetry.RunningEvent)
+	telemetry.PosthogCaptureEvent(root.AppVersion, telemetry.RunningEvent)
 
 	root.Execute()
+}
+
+func getEnvAndVersion() (string, string) {
+	env := "unknown env"
+	version := "unknown version"
+
+	// Get the environment and version from the build info
+	info, ok := debug.ReadBuildInfo()
+
+	// If the build info is not available, return the default values
+	if !ok {
+		return env, version
+	}
+
+	// If the version is "(devel)", return the default values
+	if info.Main.Version == "(devel)" {
+		version = "v0.0.1-dev"
+		env = "DEV"
+	} else {
+		version = info.Main.Version
+		env = "PROD"
+	}
+
+	return env, version
 }

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -124,15 +124,9 @@ func checkLatestVersion() error {
 		}
 
 		if currentVersion.LessThan(latestVersion) {
-			cmdStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-
-			updateMessage := fmt.Sprintf("New update available! "+
-				"Version %s is now ready to download and install.", latestVersion.String())
-			fmt.Println(cmdStyle.Render(updateMessage))
-
-			commandMessage := "To install the latest version run:\n\t" +
-				"'go install pkg.world.dev/world-cli/cmd/world@latest'\n"
-			fmt.Println(cmdStyle.Render(commandMessage))
+			notificationStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178")) // Bright yellow, good for notifications
+			fmt.Printf("\n%s\n", notificationStyle.Render(fmt.Sprintf("New version %s is available!", latestVersion.String())))
+			fmt.Printf("%s\n\n", notificationStyle.Render("To update, run: go install pkg.world.dev/world-cli/cmd/world@latest"))
 		}
 	}
 	return nil

--- a/cmd/world/root/version.go
+++ b/cmd/world/root/version.go
@@ -7,6 +7,7 @@ import (
 )
 
 var AppVersion string
+var AppEnv string
 
 // versionCmd print the version number of World CLI
 // Usage: `world version`
@@ -15,6 +16,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of World CLI",
 	Long:  `Print the version number of World CLI`,
 	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("World CLI v%s\n", AppVersion)
+		fmt.Printf("World CLI %s\n", AppVersion)
 	},
 }

--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -1,3 +1,5 @@
+INSTALL_PATH=$(shell go env GOPATH)/bin
+
 clean:
 	@echo "--> Cleaning up"
 	@echo "--> Running go clean"
@@ -10,9 +12,9 @@ clean:
 
 install:
 	@echo "--> Installing World CLI"
-	@mkdir -p /usr/local/bin
-	@echo "--> Building binary, install to /usr/local/bin"
-	@goreleaser build --clean --single-target --snapshot -o /usr/local/bin/$(PKGNAME)
-	@echo "--> Installed $(PKGNAME) to /usr/local/bin"
+	@mkdir -p $(INSTALL_PATH)
+	@echo "--> Building binary, install to $(INSTALL_PATH)"
+	@goreleaser build --clean --single-target --snapshot -o $(INSTALL_PATH)/$(PKGNAME)
+	@echo "--> Installed $(PKGNAME) to $(INSTALL_PATH)"
 
 .PHONY: clean install


### PR DESCRIPTION
Closes: PLAT-210

## Overview

Fix `world version` to get version from build info and change installation instruction on readme

## Brief Changelog

- `world version` get the version from build info
- update readme for installation instruction

## Testing and Verifying

manually tested

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/6df1a3e7-a2c9-406f-85a2-58ffe96fc123.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated World CLI installation instructions: the guide now requires Go installation and uses `go install` commands for both the latest and specific releases, with a reorganized "World CLI Installation" section.
  
- **New Features**
  - Improved version display now outputs “World CLI <version>” for clearer information.
  - Revamped update notifications offer concise, more visible messages.

- **Chores**
  - Adjusted the installation process to dynamically set the binary path based on your Go environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->