### PR TITLE
chore: rearrange commands

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -32,7 +32,7 @@ var (
 	projectURLPattern = "%s/api/organization/%s/project"
 )
 
-var BaseCmd = &cobra.Command{
+var ForgeCmd = &cobra.Command{
 	Use:   "forge",
 	Short: "Forge is a tool for managing World Forge projects",
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -118,6 +118,20 @@ var (
 			}
 			fmt.Println("Switched to organization: ", org.Name)
 			return nil
+		},
+	}
+)
+
+// User Commands
+var (
+	userCmd = &cobra.Command{
+		Use:   "user",
+		Short: "Manage users",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !checkLogin() {
+				return nil
+			}
+			return showOrganizationList(cmd.Context())
 		},
 	}
 
@@ -207,18 +221,6 @@ var (
 
 // Deployment commands
 var (
-	deploymentCmd = &cobra.Command{
-		Use:   "deployment",
-		Short: "Manage deployments",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !checkLogin() {
-				return nil
-			}
-			// TODO: return deployment list and status
-			return cmd.Help()
-		},
-	}
-
 	deployCmd = &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy a project",
@@ -295,30 +297,41 @@ func InitForge() {
 	// Set organization URL
 	organizationURL = fmt.Sprintf("%s/api/organization", baseURL)
 
-	// Add login command
-	BaseCmd.AddCommand(loginCmd)
-
 	// Add organization commands
 	organizationCmd.AddCommand(createOrganizationCmd)
 	organizationCmd.AddCommand(switchOrganizationCmd)
-	organizationCmd.AddCommand(inviteUserToOrganizationCmd)
-	organizationCmd.AddCommand(changeUserRoleInOrganizationCmd)
-	BaseCmd.AddCommand(organizationCmd)
+	ForgeCmd.AddCommand(organizationCmd)
+
+	// Add user commands
+	userCmd.AddCommand(inviteUserToOrganizationCmd)
+	userCmd.AddCommand(changeUserRoleInOrganizationCmd)
 
 	// Add project commands
 	projectCmd.AddCommand(createProjectCmd)
 	projectCmd.AddCommand(switchProjectCmd)
 	projectCmd.AddCommand(deleteProjectCmd)
 	projectCmd.AddCommand(updateProjectCmd)
-	BaseCmd.AddCommand(projectCmd)
+	ForgeCmd.AddCommand(projectCmd)
 
 	// Add deployment commands
 	deployCmd.Flags().Bool("force", false,
 		"Start the deploy even if one is currently running. Cancels current running deploy.")
-	deploymentCmd.AddCommand(deployCmd)
-	deploymentCmd.AddCommand(destroyCmd)
-	deploymentCmd.AddCommand(statusCmd)
-	deploymentCmd.AddCommand(resetCmd)
-	deploymentCmd.AddCommand(promoteCmd)
-	BaseCmd.AddCommand(deploymentCmd)
+}
+
+func AddCommands(rootCmd *cobra.Command) {
+	// Add login command  `world login`
+	rootCmd.AddCommand(loginCmd)
+
+	// deployment and status commands
+	rootCmd.AddCommand(deployCmd)
+	rootCmd.AddCommand(destroyCmd)
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(promoteCmd)
+	rootCmd.AddCommand(resetCmd)
+
+	// user commands
+	rootCmd.AddCommand(userCmd)
+
+	// add all the other 'forge' commands
+	rootCmd.AddCommand(ForgeCmd)
 }

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -71,8 +71,8 @@ func init() {
 	rootCmd.AddCommand(cardinal.BaseCmd)
 	rootCmd.AddCommand(evm.BaseCmd)
 
-	// Register forge subcommand
-	rootCmd.AddCommand(forge.BaseCmd)
+	// Register forge command
+	forge.AddCommands(rootCmd)
 
 	// Remove completion subcommand
 	rootCmd.CompletionOptions.DisableDefaultCmd = true


### PR DESCRIPTION
- moved the commonly used `world forge deployment [deploy|status|(etc..)]` commands to top level so now are just `world deploy`, `world status`, etc...
- moved user invite and role to `world user invite` and `world user role`
- move login to `world login`

Closes: PLAT-255, PLAT-254, PLAT-253, PLAT-253, PLAT-251

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->