### PR TITLE
fix: proper help for `forge`, `user` and other subcommands

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -53,22 +53,19 @@ var ForgeCmd = &cobra.Command{
 		fmt.Printf("ID:   %s\n", globalConfig.Credential.ID)
 		fmt.Printf("Name: %s\n", globalConfig.Credential.Name)
 
+		// Try to show org list and project list
 		// Show organization list
 		err = showOrganizationList(cmd.Context())
-		if err != nil {
-			return eris.Wrap(err, "Failed to show organization list")
-		}
 
-		// Show project list
-		err = showProjectList(cmd.Context())
-		if err != nil {
-			return eris.Wrap(err, "Failed to show project list")
+		if err == nil {
+			// Show project list, if we have an org
+			_ = showProjectList(cmd.Context())
 		}
 
 		// add separator
 		fmt.Println("\n================================================")
 
-		return nil
+		return cmd.Help()
 	},
 }
 
@@ -86,7 +83,12 @@ var (
 		Use:   "organization",
 		Short: "Manage organizations",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return showOrganizationList(cmd.Context())
+			err := showOrganizationList(cmd.Context())
+			if err == nil {
+				// add separator
+				fmt.Println("\n================================================")
+			}
+			return cmd.Help()
 		},
 	}
 
@@ -131,13 +133,18 @@ var (
 			if !checkLogin() {
 				return nil
 			}
-			return showOrganizationList(cmd.Context())
+			err := showOrganizationList(cmd.Context())
+			if err == nil {
+				// add separator
+				fmt.Println("\n================================================")
+			}
+			return cmd.Help()
 		},
 	}
 
 	inviteUserToOrganizationCmd = &cobra.Command{
 		Use:   "invite",
-		Short: "Invite a user to an organization",
+		Short: "Invite a user to selected organization",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return inviteUserToOrganization(cmd.Context())
 		},
@@ -145,7 +152,7 @@ var (
 
 	changeUserRoleInOrganizationCmd = &cobra.Command{
 		Use:   "role",
-		Short: "Change a users role in an organization",
+		Short: "Change a user's role in selected organization",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return updateUserRoleInOrganization(cmd.Context())
 		},
@@ -161,7 +168,12 @@ var (
 			if !checkLogin() {
 				return nil
 			}
-			return showProjectList(cmd.Context())
+			err := showProjectList(cmd.Context())
+			if err == nil {
+				// add separator
+				fmt.Println("\n================================================")
+			}
+			return cmd.Help()
 		},
 	}
 


### PR DESCRIPTION
Closes: PLAT-245, PLAT-246

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->