### PR TITLE
feat(lint): Make file supports windows + updated version

### DIFF
--- a/makefiles/lint.mk
+++ b/makefiles/lint.mk
@@ -1,21 +1,34 @@
-lint_version=v1.56.2
+lint_version = v1.59.1
+GOOS := $(shell go env GOOS)
 
 lint-install:
 	@echo "--> Checking if golangci-lint $(lint_version) is installed"
-	@installed_version=$$(golangci-lint --version 2> /dev/null | awk '{print $$4}') || true; \
+ifeq ($(GOOS),windows)
+	@where golangci-lint >NUL 2>&1 || (echo "--> Installing golangci-lint $(lint_version)" && go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(lint_version))
+else
+	@installed_version=$$(golangci-lint --version 2>/dev/null | awk '{print $$4}') || true; \
 	if [ "$$installed_version" != "$(lint_version)" ]; then \
 		echo "--> Installing golangci-lint $(lint_version)"; \
 		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(lint_version); \
 	else \
 		echo "--> golangci-lint $(lint_version) is already installed"; \
 	fi
+endif
 
 lint:
 	@$(MAKE) lint-install
 	@echo "--> Running linter"
-	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run  --timeout=10m --concurrency 8 -v
+ifeq ($(GOOS),windows)
+	@for /f "delims=" %%d in ('go list -f "{{.Dir}}/..." -m') do (golangci-lint run --timeout=10m --concurrency 8 -v %%d)
+else
+	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run --timeout=10m --concurrency 8 -v
+endif
 
 lint-fix:
 	@$(MAKE) lint-install
-	@echo "--> Running linter"
-	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run  --timeout=10m --fix --concurrency 8 -v
+	@echo "--> Running linter with fix"
+ifeq ($(GOOS),windows)
+	@for /f "delims=" %%d in ('go list -f "{{.Dir}}/..." -m') do (golangci-lint run --timeout=10m --fix --concurrency 8 -v %%d)
+else
+	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run --timeout=10m --fix --concurrency 8 -v
+endif


### PR DESCRIPTION
# Closes: WORLD-XXX

## Overview

This PR updates the golangci-lint version from v1.56.2 to v1.59.1 and adds Windows support for the linting commands in the Makefile.

## Brief Changelog

- Updated golangci-lint version to v1.59.1
- Added Windows-specific commands for lint installation and execution
- Added GOOS detection to determine the appropriate commands to run
- Improved command structure with conditional logic based on operating system
- Fixed formatting and added more descriptive echo messages

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The functionality can be verified by running the lint commands on both Windows and non-Windows environments.

Fixes PLAT-293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved compatibility of linting tasks for Windows users.
  - Updated linting tool to a newer version for enhanced checks and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Updates golangci-lint version and adds Windows support in the lint.mk makefile, enabling cross-platform compatibility for linting commands.

- Updated golangci-lint from v1.56.2 to v1.59.1 in `/makefiles/lint.mk`
- Added Windows-specific command handling using `where` and `for /f` syntax in `/makefiles/lint.mk`
- Implemented version checking for non-Windows systems to prevent unnecessary reinstallation
- Added OS detection via `GOOS` variable for platform-specific command execution
- Enhanced error handling and feedback with descriptive echo messages



<sub>💡 (3/5) Reply to the bot's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->