### PR TITLE
refactor: world CLI misc imporoments 3,5,6

### DIFF
--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -227,8 +227,7 @@ func createOrganization(ctx context.Context) (*organization, error) { //nolint:f
 	attempts := 0
 	maxAttempts := 5
 	for attempts < maxAttempts {
-		fmt.Print("\nEnter organization slug (3-15 characters, " +
-			"lowercase letters, numbers, and underscores allowed): ")
+		fmt.Print("\nEnter organization slug: ")
 		orgSlug, err = getInput()
 		if err != nil {
 			return nil, eris.Wrap(err, "Failed to read organization slug")
@@ -307,8 +306,7 @@ func createOrganization(ctx context.Context) (*organization, error) { //nolint:f
 		return nil, eris.Wrap(err, "Failed to select organization")
 	}
 
-	fmt.Printf("\nOrganization '%s' created successfully!\n", orgName)
-	fmt.Printf("Slug: %s\n", orgSlug)
+	fmt.Printf("\nOrganization '%s' with slug '%s' created successfully!\n", orgName, orgSlug)
 	// fmt.Printf("ID: %s\n", org.ID)
 	return org, nil
 }

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -302,13 +302,6 @@ func (p *project) inputProjectName(ctx context.Context) error {
 	maxAttempts := 5
 	attempts := 0
 
-	fmt.Println("\n   Project Name Configuration")
-	fmt.Println("================================")
-	fmt.Println("\nProject name requirements:")
-	fmt.Println("• Must not be empty")
-	fmt.Printf("• Maximum length: %d characters\n", MaxProjectNameLen)
-	fmt.Println("• Cannot contain: < > : \" / \\ | ? *")
-
 	for {
 		if attempts >= maxAttempts {
 			return eris.New("Maximum attempts reached for entering project name")
@@ -395,9 +388,6 @@ func (p *project) inputProjectSlug(ctx context.Context) error {
 			} else {
 				fmt.Print("\nEnter new project slug")
 			}
-			fmt.Print("\n\nRequirements:")
-			fmt.Print("\n• 3-25 characters")
-			fmt.Print("\n• Lowercase letters, numbers, and underscores allowed")
 			fmt.Print("\n\nSlug: ")
 
 			slug, err := getInput()


### PR DESCRIPTION
# Simplify user prompts for organization and project creation

Closes: WORLD-XXX

## Overview

This PR simplifies the user prompts during organization and project creation by removing detailed validation requirements from the prompt text. This creates a cleaner, more streamlined user experience while maintaining the same validation logic.

## Brief Changelog

- Simplified organization slug prompt by removing validation requirements text
- Combined organization creation success messages into a single line
- Removed project name requirements section from the project creation prompt
- Removed project slug requirements text from the project slug prompt

## Testing and Verifying

This change is a trivial rework of user-facing prompts without any functional changes to the validation logic. The existing validation rules remain in place, only the explanatory text has been removed from the prompts.

<!-- greptile_comment -->

## Greptile Summary

Simplified user prompts in organization and project creation workflows by removing detailed validation requirement text while maintaining the underlying validation logic.

- Removed validation requirement text from organization slug prompt in `cmd/world/forge/organization.go`
- Combined organization creation success messages into a single line in `cmd/world/forge/organization.go`
- Removed project name requirements section from project creation prompt in `cmd/world/forge/project.go`
- Removed project slug validation text from project slug prompt in `cmd/world/forge/project.go`



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Simplified user prompts when creating organizations and projects by removing detailed validation criteria from input messages.
  - Consolidated organization creation success messages into a single, more concise line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->