### PR TITLE
refactor(slug): Default input to sane

### DIFF
--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -236,7 +236,7 @@ func createOrganization(ctx context.Context) (*organization, error) { //nolint:f
 		// Validate slug
 		minLength := 3
 		maxLength := 15
-		err = slugCheck(orgSlug, minLength, maxLength)
+		orgSlug, err = slugToSaneCheck(orgSlug, minLength, maxLength)
 		if err != nil {
 			fmt.Printf("\n❌ Error: %s (attempt %d/%d)\n", err, attempts+1, maxAttempts)
 			attempts++

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -403,7 +403,7 @@ func (p *project) inputProjectSlug(ctx context.Context) error {
 			// Validate slug
 			minLength := 3
 			maxLength := 25
-			err = slugCheck(slug, minLength, maxLength)
+			slug, err = slugToSaneCheck(slug, minLength, maxLength)
 			if err != nil {
 				fmt.Printf("\n❌ Error: %s (attempt %d/%d)\n", err, attempts+1, maxAttempts)
 				attempts++


### PR DESCRIPTION
# feat: Add SlugToSaneDefault helper function for project slug sanitization

Closes: WORLD-XXX

## Overview

This PR adds a new helper function `SlugToSaneDefault` that sanitizes input strings into a standardized slug format, and applies it to project slugs during creation.

## Brief Changelog

- Added `SlugToSaneDefault` helper function in `common.go` that:
  - Converts input to lowercase
  - Trims whitespace
  - Replaces spaces with hyphens
  - Removes non-alphanumeric characters (except hyphens)
  - Replaces multiple consecutive hyphens with a single hyphen
  - Trims hyphens from start and end
- Applied this function to project slugs in `inputProjectSlug` to ensure consistent formatting

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The function implements standard slug sanitization practices that can be manually verified by creating projects with various input formats.

<!-- greptile_comment -->

## Greptile Summary

Added a new helper function `SlugToSaneDefault` to standardize project slug formatting, with automatic sanitization of input strings to lowercase alphanumeric characters with hyphens.

- Added `SlugToSaneDefault` in `cmd/world/forge/common.go` for consistent slug formatting
- Applied sanitization in `cmd/world/forge/project.go` before slug validation
- Function converts input to lowercase, replaces spaces with hyphens, removes special chars
- Potential concern: Order of operations between sanitization and validation could cause issues
- Recommend adding test coverage to verify behavior with edge cases and non-ASCII characters



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced slug input handling with automatic sanitization and normalization, improving consistency and reducing errors during organization and project creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->