### PR TITLE
fix: install makefile for windows support

### DIFF
--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -5,16 +5,27 @@ clean:
 	@echo "--> Running go clean"
 	@go clean
 	@echo "--> Removing build './dist' directory"
+ifeq ($(OS),Windows_NT)
+	@if exist dist rmdir /s /q dist
+	@echo "--> Removing coverage files"
+	@for /r %%i in (*.out) do del %%i
+else
 	@rm -rf ./dist
 	@echo "--> Removing coverage files"
 	@find . -type f -name "*.out" -exec rm -f {} \;
-
+endif
 
 install:
 	@echo "--> Installing World CLI"
+ifeq ($(OS),Windows_NT)
+	@if not exist "$(INSTALL_PATH)" mkdir "$(INSTALL_PATH)"
+	@echo "--> Building binary, install to $(INSTALL_PATH)"
+	@goreleaser build --clean --single-target --snapshot -o "$(INSTALL_PATH)\$(PKGNAME).exe"
+else
 	@mkdir -p $(INSTALL_PATH)
 	@echo "--> Building binary, install to $(INSTALL_PATH)"
-	@goreleaser build --clean --single-target --snapshot -o $(INSTALL_PATH)/$(PKGNAME)
+	@goreleaser build --clean --single-target --snapshot -o "$(INSTALL_PATH)/$(PKGNAME)"
+endif
 	@echo "--> Installed $(PKGNAME) to $(INSTALL_PATH)"
 
 .PHONY: clean install


### PR DESCRIPTION
# Add Windows support to dev.mk

Closes: PLAT-301

## Overview

This PR adds Windows compatibility to the development Makefile, enabling Windows users to run the `clean` and `install` targets.

## Brief Changelog

- Added conditional logic to detect Windows (using `$(OS)` variable)
- Implemented Windows-specific commands for cleaning build artifacts
- Added Windows-specific installation process using appropriate directory creation and file copying
- Maintained existing functionality for non-Windows platforms

## Testing and Verifying

This change is a trivial rework without any test coverage. It can be verified by running `make clean` and `make install` on both Windows and non-Windows platforms to ensure they function correctly.

<!-- greptile_comment -->

## Greptile Summary

Added Windows compatibility to the development Makefile in `makefiles/dev.mk`, enabling Windows users to run the `clean` and `install` targets with platform-specific commands.

- Added Windows detection using `$(OS)` variable with conditional logic for platform-specific commands
- Implemented Windows cleanup using `rmdir /s /q dist` and `del` for coverage files
- Added Windows installation path handling with `mkdir` and `copy` commands for binary installation
- Modified binary output path handling for Windows to support `.exe` extension



<!-- /greptile_comment -->