### PR TITLE
fix(lint): handle new errors from updated version linter

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.2
+          version: v1.64.8
           args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}
           ## skip cache, use Namespace volume cache
           skip-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,7 +69,7 @@ linters-settings:
         # Default: true
         skipRecvDeref: false
 
-  gomnd:
+  mnd:
     # List of function patterns to exclude from analysis.
     # Values always ignored: `time.Date`,
     # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
@@ -113,7 +113,7 @@ linters-settings:
   nolintlint:
     # Exclude following linters from requiring an explanation.
     # Default: []
-    allow-no-explanation: [ funlen, gocognit, lll, exhaustruct, decorder, gomnd ]
+    allow-no-explanation: [ funlen, gocognit, lll, exhaustruct, decorder, mnd ]
     # Enable to require an explanation of nonzero length after each nolint directive.
     # Default: false
     require-explanation: true
@@ -132,7 +132,7 @@ linters-settings:
     packages:
       - github.com/jmoiron/sqlx
 
-  tenv:
+  usetesting:
     # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
     # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
     # Default: false
@@ -223,9 +223,9 @@ linters:
     - durationcheck # checks for two durations multiplied together
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
+    #- execinquery # deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner. 
     - exhaustive # checks exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # checks for pointers to enclosing loop variables
     #- forbidigo # forbids identifiers
     - funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
@@ -238,7 +238,7 @@ linters:
     - gocyclo # computes and checks the cyclomatic complexity of functions
     #- godot # checks if comments end in a period
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - gomnd # detects magic numbers
+    - mnd # detects magic numbers
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     #- gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
     - goprintffuncname # checks that printf-like functions are named with f at the end
@@ -268,7 +268,7 @@ linters:
     - spancheck # checks for mistakes with OpenTelemetry/Census spans
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - stylecheck # is a replacement for golint
-    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - usetesting # detects using os for testing instead of t.
     - testableexamples # checks if examples are testable (have an expected output)
     - testifylint # checks usage of github.com/stretchr/testify
     #- testpackage # makes you use a separate _test package

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -3,6 +3,7 @@ package forge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -215,19 +216,25 @@ func (s *ForgeTestSuite) handleOrganizationGet(w http.ResponseWriter, r *http.Re
 func (s *ForgeTestSuite) handleProjectList(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		parsedBody, err := io.ReadAll(r.Body)
-		s.Require().NoError(err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		defer r.Body.Close()
 
 		body := map[string]interface{}{}
 		err = json.Unmarshal(parsedBody, &body)
-		s.Require().NoError(err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		proj := project{
 			ID:      "test-project-id",
 			OrgID:   "test-org-id",
-			Name:    body["name"].(string),
-			Slug:    body["slug"].(string),
-			RepoURL: body["repo_url"].(string),
+			Name:    fmt.Sprintf("%v", body["name"]),
+			Slug:    fmt.Sprintf("%v", body["slug"]),
+			RepoURL: fmt.Sprintf("%v", body["repo_url"]),
 		}
 		s.writeJSON(w, map[string]interface{}{"data": proj})
 		return

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -164,7 +164,7 @@ func getToken(ctx context.Context, url string, argusid bool, result interface{})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(3 * time.Second): //nolint:gomnd
+		case <-time.After(3 * time.Second): //nolint:mnd
 			fmt.Printf("\r🔄 Logging in... attempt %d", attempts)
 
 			token, err := makeTokenRequest(ctx, url)
@@ -264,7 +264,7 @@ func handleWorldForgeToken(response []byte, result interface{}) error {
 // parseCredential will parse the id and name from the token
 func parseCredential(token string) (globalconfig.Credential, error) {
 	parts := strings.Split(token, ".")
-	if len(parts) != 3 { //nolint:gomnd
+	if len(parts) != 3 { //nolint:mnd
 		return globalconfig.Credential{}, eris.New("invalid token format")
 	}
 
@@ -314,7 +314,7 @@ func parseArgusIDToken(jwtToken string) (globalconfig.Credential, error) {
 	}
 
 	parts := strings.Split(jwtToken, ".")
-	if len(parts) != 3 { //nolint:gomnd
+	if len(parts) != 3 { //nolint:mnd
 		return globalconfig.Credential{}, eris.New("invalid token format")
 	}
 

--- a/cmd/world/forge/repo.go
+++ b/cmd/world/forge/repo.go
@@ -65,7 +65,7 @@ func validateRepoPath(_ context.Context, _, _, path string) error {
 func validateGitHub(ctx context.Context, repoURL, token, apiBaseURL string) error {
 	// Extract the owner and repo name from the URL
 	parts := strings.Split(repoURL, "/")
-	if len(parts) < 2 { //nolint:gomnd
+	if len(parts) < 2 { //nolint:mnd
 		return eris.New("invalid github repository URL")
 	}
 	repo := strings.TrimSuffix(parts[len(parts)-1], ".git")
@@ -103,7 +103,7 @@ func validateGitHub(ctx context.Context, repoURL, token, apiBaseURL string) erro
 func validateGitLab(ctx context.Context, repoURL, token, apiBaseURL string) error {
 	// Extract the project path from the URL
 	parts := strings.Split(repoURL, "/")
-	if len(parts) < 2 { //nolint:gomnd
+	if len(parts) < 2 { //nolint:mnd
 		return eris.New("invalid gitlab repository URL")
 	}
 	projectPath := fmt.Sprintf("%s/%s", parts[len(parts)-2], strings.TrimSuffix(parts[len(parts)-1], ".git"))
@@ -140,7 +140,7 @@ func validateGitLab(ctx context.Context, repoURL, token, apiBaseURL string) erro
 func validateBitbucket(ctx context.Context, repoURL, token, apiBaseURL string) error {
 	// Extract the workspace and repo slug from the URL
 	parts := strings.Split(repoURL, "/")
-	if len(parts) < 2 { //nolint:gomnd
+	if len(parts) < 2 { //nolint:mnd
 		return eris.New("invalid bitbucket repository URL")
 	}
 	workspace := parts[len(parts)-2]

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -91,9 +91,8 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.depStatusErr = msg.Err
 		if msg.Err != nil {
 			return m, tea.Quit
-		} else {
-			return m, nil
 		}
+		return m, nil
 
 	case tea.KeyMsg: //nolint:exhaustive // not applicable
 		switch msg.Type {
@@ -124,7 +123,7 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				teaCmd,
 			)
 		}
-		if msg.Index == 2 { //nolint:gomnd
+		if msg.Index == 2 { //nolint:mnd
 			err := editor.SetupCardinalEditor(".", "cardinal")
 			teaCmd := func() tea.Msg {
 				return teacmd.GitCloneFinishMsg{Err: err}

--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -100,7 +100,7 @@ func TestExecuteDoctorCommand(t *testing.T) {
 
 func TestCreateStartStopRestartPurge(t *testing.T) {
 	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-start")
+	gameDir, err := os.MkdirTemp("", "game-template-start") //nolint:usetesting // Suppress linter error
 	assert.NilError(t, err)
 
 	// Remove dir
@@ -161,7 +161,7 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 func TestDev(t *testing.T) {
 	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-dev")
+	gameDir, err := os.MkdirTemp("", "game-template-dev") //nolint:usetesting // Surppress linter error
 	assert.NilError(t, err)
 
 	// Remove dir
@@ -271,7 +271,7 @@ func ServiceIsDown(name, address string, t *testing.T) bool {
 
 func TestEVMStart(t *testing.T) {
 	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-dev")
+	gameDir, err := os.MkdirTemp("", "game-template-dev") //nolint:usetesting // Surppress linter error
 	assert.NilError(t, err)
 
 	// Remove dir

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -237,7 +237,7 @@ func (c *Client) Exec(ctx context.Context, containerID string, cmd []string) (st
 
 	// Read and demultiplex the output
 	var outputBuf bytes.Buffer
-	header := make([]byte, 8) //nolint:gomnd
+	header := make([]byte, 8) //nolint:mnd
 
 	for {
 		_, err := io.ReadFull(resp.Reader, header)

--- a/common/docker/client_container.go
+++ b/common/docker/client_container.go
@@ -202,7 +202,7 @@ func (c *Client) logMultipleContainers(ctx context.Context, services ...service.
 					err := c.logContainerOutput(ctx, id, i)
 					if err != nil && !errors.Is(err, context.Canceled) {
 						fmt.Printf("Error logging container %s: %v. Reattaching...\n", id, err)
-						time.Sleep(2 * time.Second) //nolint:gomnd // Sleep for 2 seconds before reattaching
+						time.Sleep(2 * time.Second) //nolint:mnd // Sleep for 2 seconds before reattaching
 					}
 				}
 			}
@@ -243,7 +243,7 @@ func (c *Client) logContainerOutput(ctx context.Context, containerID string, sty
 	reader := bufio.NewReader(out)
 	for {
 		// Read the 8-byte header
-		header := make([]byte, 8) //nolint:gomnd // 8 bytes
+		header := make([]byte, 8) //nolint:mnd // 8 bytes
 		if _, err := io.ReadFull(reader, header); err != nil {
 			if err == io.EOF {
 				break
@@ -272,7 +272,7 @@ func (c *Client) logContainerOutput(ctx context.Context, containerID string, sty
 		if streamType == 1 { // Stdout
 			// TODO: what content should be printed for stdout?
 			fmt.Printf("[%s] %s", style.ForegroundPrint(containerID, colors[styleNumber]), cleanLog)
-		} else if streamType == 2 { //nolint:gomnd // Stderr
+		} else if streamType == 2 { //nolint:mnd // Stderr
 			// TODO: what content should be printed for stderr?
 			fmt.Printf("[%s] %s", style.ForegroundPrint(containerID, colors[styleNumber]), cleanLog)
 		}

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -369,6 +369,8 @@ func (c *Client) filterImages(ctx context.Context, images map[string]string, ser
 }
 
 // Pulls the image if it does not exist
+//
+//nolint:funlen // This is a long function, but it is not a problem
 func (c *Client) pullImages(ctx context.Context, services ...service.Service) error { //nolint:gocognit
 	// Filter the images that need to be pulled
 	images := make(map[string]string)
@@ -387,11 +389,11 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 	// Pull each image concurrently
 	for imageName, platform := range images {
 		// Capture imageName and platform in the loop
-		imageName := imageName
-		platform := platform
+		imageName := imageName //nolint:copyloopvar // Project workflow on 1.21.1
+		platform := platform   //nolint:copyloopvar // Project workflow on 1.21.1
 
 		// Create a new progress bar for this image
-		bar := p.AddBar(100, //nolint:gomnd
+		bar := p.AddBar(100, //nolint:mnd
 			mpb.PrependDecorators(
 				decor.Name(fmt.Sprintf("%s %s: ", style.ForegroundPrint("Pulling", "2"), imageName)),
 				decor.Percentage(decor.WCSyncSpace),
@@ -421,7 +423,7 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 			decoder := json.NewDecoder(responseBody)
 			var current int
 			var event map[string]interface{}
-			for decoder.More() { //nolint:dupl // different commands
+			for decoder.More() {
 				select {
 				case <-ctx.Done():
 					// Handle context cancellation
@@ -437,7 +439,7 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 					// Check for errorDetail and error fields
 					if errorDetail, ok := event["errorDetail"]; ok {
 						if errorMessage, ok := errorDetail.(map[string]interface{})["message"]; ok {
-							errChan <- eris.New(errorMessage.(string))
+							errChan <- eris.New(fmt.Sprintf("%v", errorMessage))
 							continue
 						}
 					} else if errorMsg, ok := event["error"]; ok {
@@ -461,7 +463,7 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 			// Finish the progress bar
 			// Handle if the current and total is not available in the response body
 			// Usually, because docker image is already pulled from the cache
-			bar.SetCurrent(100) //nolint:gomnd
+			bar.SetCurrent(100) //nolint:mnd
 		}()
 	}
 
@@ -485,6 +487,8 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 }
 
 // Pulls the image if it does not exist
+//
+//nolint:funlen // This is a long function, but it is not a problem
 func (c *Client) pushImages(ctx context.Context, pushTo string, authString string, //nolint:gocognit
 	services ...service.Service) error {
 	// Create a new progress container with a wait group
@@ -507,7 +511,7 @@ func (c *Client) pushImages(ctx context.Context, pushTo string, authString strin
 				imageName, service.Name, err))
 		}
 
-		bar := p.AddBar(100, //nolint:gomnd
+		bar := p.AddBar(100, //nolint:mnd
 			mpb.PrependDecorators(
 				decor.Name(fmt.Sprintf("%s %s: ", style.ForegroundPrint("Pushing", "2"), imageName)),
 				decor.Percentage(decor.WCSyncSpace),
@@ -538,7 +542,7 @@ func (c *Client) pushImages(ctx context.Context, pushTo string, authString strin
 			decoder := json.NewDecoder(responseBody)
 			var current int
 			var event map[string]interface{}
-			for decoder.More() { //nolint:dupl // different commands
+			for decoder.More() {
 				select {
 				case <-ctx.Done():
 					// Handle context cancellation
@@ -558,7 +562,7 @@ func (c *Client) pushImages(ctx context.Context, pushTo string, authString strin
 							continue
 						}
 					} else if errorMsg, ok := event["error"]; ok {
-						errChan <- eris.New(errorMsg.(string))
+						errChan <- eris.New(fmt.Sprintf("%v", errorMsg))
 						continue
 					}
 
@@ -578,7 +582,7 @@ func (c *Client) pushImages(ctx context.Context, pushTo string, authString strin
 			// Finish the progress bar
 			// Handle if the current and total is not available in the response body
 			// Usually, because docker image is already pulled from the cache
-			bar.SetCurrent(100) //nolint:gomnd
+			bar.SetCurrent(100) //nolint:mnd
 		}()
 	}
 

--- a/common/docker/client_test.go
+++ b/common/docker/client_test.go
@@ -167,7 +167,7 @@ func TestStartUndetach(t *testing.T) {
 
 func TestBuild(t *testing.T) {
 	// Create a temporary directory
-	dir, err := os.MkdirTemp("", "sgt")
+	dir, err := os.MkdirTemp("", "sgt") //nolint:usetesting // Surpress linter error
 	assert.NilError(t, err)
 
 	// Remove dir

--- a/common/docker/service/cardinal.go
+++ b/common/docker/service/cardinal.go
@@ -24,6 +24,7 @@ func getCardinalContainerName(cfg *config.Config) string {
 	return fmt.Sprintf("%s-cardinal", cfg.DockerEnv["CARDINAL_NAMESPACE"])
 }
 
+//nolint:funlen // This is a long function, but it is not a problem
 func Cardinal(cfg *config.Config) Service {
 	// Check cardinal namespace
 	checkCardinalNamespace(cfg)

--- a/common/docker/service/celestia.go
+++ b/common/docker/service/celestia.go
@@ -27,7 +27,7 @@ func CelestiaDevNet(cfg *config.Config) Service {
 				Test:     []string{"CMD", "curl", "-f", "http://127.0.0.1:26659/head"},
 				Interval: 1 * time.Second,
 				Timeout:  1 * time.Second,
-				Retries:  20, //nolint:gomnd
+				Retries:  20, //nolint:mnd
 			},
 		},
 		HostConfig: container.HostConfig{

--- a/common/docker/service/evm.go
+++ b/common/docker/service/evm.go
@@ -72,7 +72,7 @@ func EVM(cfg *config.Config) Service {
 	var platform ocispec.Platform
 	if cfg.DockerEnv["EVM_IMAGE_PLATFORM"] != "" {
 		evmImagePlatform := strings.Split(cfg.DockerEnv["EVM_IMAGE_PLATFORM"], "/")
-		if len(evmImagePlatform) == 2 { //nolint:gomnd //2 is the expected length
+		if len(evmImagePlatform) == 2 { //nolint:mnd //2 is the expected length
 			platform = ocispec.Platform{
 				Architecture: evmImagePlatform[1],
 				OS:           evmImagePlatform[0],

--- a/common/docker/service/nakama.go
+++ b/common/docker/service/nakama.go
@@ -16,6 +16,7 @@ func getNakamaContainerName(cfg *config.Config) string {
 	return fmt.Sprintf("%s-nakama", cfg.DockerEnv["CARDINAL_NAMESPACE"])
 }
 
+//nolint:funlen // This is a long function, but it is not a problem
 func Nakama(cfg *config.Config) Service {
 	// Check cardinal namespace
 	checkCardinalNamespace(cfg)
@@ -65,7 +66,7 @@ func Nakama(cfg *config.Config) Service {
 	}
 	if cfg.DockerEnv["NAKAMA_IMAGE_PLATFORM"] != "" {
 		nakamaImagePlatform := strings.Split(cfg.DockerEnv["NAKAMA_IMAGE_PLATFORM"], "/")
-		if len(nakamaImagePlatform) == 2 { //nolint:gomnd //2 is the expected length
+		if len(nakamaImagePlatform) == 2 { //nolint:mnd //2 is the expected length
 			platform = ocispec.Platform{
 				Architecture: nakamaImagePlatform[1],
 				OS:           nakamaImagePlatform[0],
@@ -113,7 +114,7 @@ func Nakama(cfg *config.Config) Service {
 				Test:     []string{"CMD", "/nakama/nakama", "healthcheck"},
 				Interval: 1 * time.Second,
 				Timeout:  1 * time.Second,
-				Retries:  20, //nolint:gomnd
+				Retries:  20, //nolint:mnd
 			},
 		},
 		HostConfig: container.HostConfig{

--- a/common/docker/service/nakamadb.go
+++ b/common/docker/service/nakamadb.go
@@ -36,9 +36,9 @@ func NakamaDB(cfg *config.Config) Service {
 			ExposedPorts: getExposedPorts(exposedPorts),
 			Healthcheck: &container.HealthConfig{
 				Test:     []string{"CMD", "pg_isready", "-U", "postgres", "-d", "nakama"},
-				Interval: 3 * time.Second, //nolint:gomnd
-				Timeout:  3 * time.Second, //nolint:gomnd
-				Retries:  5,               //nolint:gomnd
+				Interval: 3 * time.Second, //nolint:mnd
+				Timeout:  3 * time.Second, //nolint:mnd
+				Retries:  5,               //nolint:mnd
 			},
 		},
 		HostConfig: container.HostConfig{

--- a/common/editor/editor_test.go
+++ b/common/editor/editor_test.go
@@ -235,33 +235,29 @@ require (
 }
 
 func TestFileExists(t *testing.T) {
-	// Create a temporary file and defer its removal
-	tempFile, err := os.CreateTemp("", "example")
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "example")
+
+	// Create a temporary file
+	file, err := os.Create(tempFile)
 	if err != nil {
 		t.Fatalf("Unable to create temporary file: %s", err)
 	}
-	defer os.Remove(tempFile.Name())
+	file.Close()
 
 	// Test case where the file does exist
-	if exists := fileExists(tempFile.Name()); !exists {
-		t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, true)
+	if exists := fileExists(tempFile); !exists {
+		t.Errorf("fileExists(%s) = %v, want %v", tempFile, exists, true)
 	}
 
 	// Remove the file to simulate it not existing
-	tempFile.Close()
-	os.Remove(tempFile.Name())
+	os.Remove(tempFile)
 
 	// Test case where the file does not exist
-	if exists := fileExists(tempFile.Name()); exists {
-		t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, false)
+	if exists := fileExists(tempFile); exists {
+		t.Errorf("fileExists(%s) = %v, want %v", tempFile, exists, false)
 	}
-
-	// Create a temporary directory and defer its removal
-	tempDir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		t.Fatalf("Unable to create temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
 
 	// Test case where the path is a directory
 	if exists := fileExists(tempDir); exists {

--- a/common/teacmd/git.go
+++ b/common/teacmd/git.go
@@ -70,7 +70,7 @@ func GitCloneCmd(url, targetDir, initMsg string) error {
 		}
 		// Extract tag name from the line
 		fields := strings.Fields(line)
-		if len(fields) >= 2 { //nolint:gomnd // git output is always 2 fields commit hash and tag name
+		if len(fields) >= 2 { //nolint:mnd // git output is always 2 fields commit hash and tag name
 			latestTag = strings.TrimPrefix(fields[1], "refs/tags/")
 			break // Take the first tag (since they're already sorted)
 		}
@@ -213,7 +213,7 @@ func appendToToml(filePath, section string, fields map[string]any) error {
 
 	// Add the fields to the section
 	for key, value := range fields {
-		config[section].(map[string]any)[key] = value
+		config[section].(map[string]any)[key] = value //nolint:errcheck // From
 	}
 
 	// Marshal the updated config back to TOML

--- a/common/teacmd/git_test.go
+++ b/common/teacmd/git_test.go
@@ -75,14 +75,16 @@ func cleanUpDir(targetDir string) {
 }
 
 func TestAppendToToml(t *testing.T) {
-	// Create a temporary TOML file for testing
-	tempFile, err := os.CreateTemp("", "test.toml")
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "test.toml")
+
+	// Create the file
+	file, err := os.Create(tempFile)
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
-	t.Cleanup(func() {
-		os.Remove(tempFile.Name())
-	})
+	file.Close()
 
 	// Define test cases
 	tests := []struct {
@@ -94,7 +96,7 @@ func TestAppendToToml(t *testing.T) {
 	}{
 		{
 			name:     "append first section and fields",
-			filePath: tempFile.Name(),
+			filePath: tempFile,
 			section:  "example_section",
 			fields: map[string]any{
 				"field1": "example_value",
@@ -104,7 +106,7 @@ func TestAppendToToml(t *testing.T) {
 		},
 		{
 			name:     "append fields to existing section",
-			filePath: tempFile.Name(),
+			filePath: tempFile,
 			section:  "example_section",
 			fields: map[string]any{
 				"field1": "replaced_value",
@@ -114,7 +116,7 @@ func TestAppendToToml(t *testing.T) {
 		},
 		{
 			name:     "create new section and append fields",
-			filePath: tempFile.Name(),
+			filePath: tempFile,
 			section:  "new_section",
 			fields: map[string]any{
 				"field3": true,

--- a/tea/component/program/program.go
+++ b/tea/component/program/program.go
@@ -180,7 +180,7 @@ func (m logModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.psqlOutputs = append(m.psqlOutputs, *msg)
 		// set max output length to 5
-		if len(m.psqlOutputs) > 5 { //nolint:gomnd
+		if len(m.psqlOutputs) > 5 { //nolint:mnd
 			m.psqlOutputs = m.psqlOutputs[1:]
 		}
 		return m, nil

--- a/tea/component/status.go
+++ b/tea/component/status.go
@@ -81,8 +81,8 @@ func NewStatusCollection(statuses []*StatusObject, options ...Option) *StatusCol
 		Statuses:          statuses,
 		ShutdownChan:      make(chan bool),
 		ShutdownOnChecked: false,
-		width:             500, //nolint:gomnd
-		height:            500, //nolint:gomnd
+		width:             500, //nolint:mnd
+		height:            500, //nolint:mnd
 	}
 	for _, option := range options {
 		option(&res)
@@ -114,7 +114,7 @@ func (s *StatusCollection) Init() tea.Cmd {
 	go func() {
 	loop:
 		for {
-			time.Sleep(500 * time.Millisecond) //nolint:gomnd
+			time.Sleep(500 * time.Millisecond) //nolint:mnd
 			for _, status := range s.Statuses {
 				status.AutoSetStatus()
 			}

--- a/tea/component/steps/steps.go
+++ b/tea/component/steps/steps.go
@@ -66,11 +66,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if m.index == len(m.Steps)-1 {
 			// Send a signal that all the steps have been finished
 			return m, tea.Sequence(m.SignalStepCompletedCmd(m.index), m.SignalAllStepCompletedCmd())
-		} else {
-			m.index++
-			// Send a signal that the current step has been completed and the next step has started
-			return m, tea.Sequence(m.SignalStepCompletedCmd(m.index-1), m.SignalStepStartedCmd(m.index))
 		}
+		m.index++
+		// Send a signal that the current step has been completed and the next step has started
+		return m, tea.Sequence(m.SignalStepCompletedCmd(m.index-1), m.SignalStepStartedCmd(m.index))
+
 	default:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)

--- a/tea/style/container.go
+++ b/tea/style/container.go
@@ -4,11 +4,11 @@ import "github.com/charmbracelet/lipgloss"
 
 var (
 	Container = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1,
-		2).BorderForeground(lipgloss.Color("#874BFD")) //nolint:gomnd
+		2).BorderForeground(lipgloss.Color("#874BFD")) //nolint:mnd
 	cliHeaderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#874BFD")).
-			Padding(0, 2). //nolint:gomnd
+			Padding(0, 2). //nolint:mnd
 			BorderTop(true).
 			BorderLeft(true).
 			BorderRight(true).
@@ -16,7 +16,7 @@ var (
 			Bold(true).
 			Italic(true).
 			Align(lipgloss.Center).
-			Width(40) //nolint:gomnd
+			Width(40) //nolint:mnd
 )
 
 func CLIHeader(title string, description string) string {

--- a/telemetry/sentry.go
+++ b/telemetry/sentry.go
@@ -42,7 +42,7 @@ func SentryFlush() {
 
 		// Flush buffered events before the program terminates.
 		// Set the timeout to the maximum duration the program can afford to wait.
-		sentry.Flush(5 * time.Second) //nolint:gomnd
+		sentry.Flush(5 * time.Second) //nolint:mnd
 		sentryInitialized = false
 	}
 }


### PR DESCRIPTION
# chore: Update golangci-lint to v1.64.8 and fix linting issues

Closes: PLAT-302

## Overview

This PR updates the golangci-lint version from v1.56.2 to v1.64.8 and fixes various linting issues across the codebase. The main changes include updating linter directive comments from `gomnd` to `mnd` (magic number detector), replacing the deprecated `exportloopref` linter with `copyloopvar`, and removing the deprecated `execinquery` linter. Additionally, the PR improves test resource management by using `t.TempDir()` instead of manually creating and cleaning up temporary directories.

## Brief Changelog

- Updated golangci-lint from v1.56.2 to v1.64.8 in CI workflow
- Updated linter configuration in `.golangci.yaml`:
  - Renamed `gomnd` to `mnd` (magic number detector)
  - Replaced `exportloopref` with `copyloopvar`
  - Removed deprecated `execinquery` linter
  - Renamed `tenv` to `usetesting`
- Fixed linter directive comments across the codebase (e.g., `//nolint:gomnd` to `//nolint:mnd`)
- Improved test resource management using `t.TempDir()` instead of manual cleanup
- Added proper error handling in HTTP handlers
- Simplified control flow in various functions

## Testing and Verifying

This change is a code cleanup to address linting issues without changing functionality. The existing test suite verifies that the code continues to work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated linter directive comments related to numeric literals across multiple components and services.
  - Upgraded Go linting tool version in the CI workflow.
  - Improved test resource management for file existence checks and temporary file handling.
  - Added linter suppression comments to reduce warnings in test and code files.
  - Enhanced HTTP error handling in a test handler method.
  - Simplified control flow in a step completion update method.
  - No changes to functionality or user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Updates linting configuration by removing a magic number suppression directive in the Sentry telemetry code, requiring explicit handling of the 5-second timeout constant.

- Removed `//nolint:gomnd` directive from `telemetry/sentry.go` that was suppressing magic number warning
- The 5-second timeout in `sentry.Flush()` will now need to be addressed to comply with linting rules
- Change is purely for code quality and does not affect functionality

<!-- /greptile_comment -->