### PR TITLE
feat: tea spinner loader indicator

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -382,7 +382,7 @@ func GetCurrentConfigWithContext(ctx context.Context) (*globalconfig.GlobalConfi
 			baseURL, url.QueryEscape(currConfig.CurrRepoURL), url.QueryEscape(currConfig.CurrRepoPath))
 		body, err := sendRequest(ctx, http.MethodGet, deployURL, nil)
 		if err != nil {
-			fmt.Println("⚠️ Warning: Failed to lookup World Forge project for Git Repo",
+			fmt.Println("⚠️ Warning1: Failed to lookup World Forge project for Git Repo",
 				currConfig.CurrRepoURL, "and path", currConfig.CurrRepoPath, ":", err)
 			return &currConfig, err
 		}

--- a/common/teacmd/spinner/spinner.go
+++ b/common/teacmd/spinner/spinner.go
@@ -1,0 +1,110 @@
+package spinner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type errMsg error
+type updateMsg string
+
+type Model struct {
+	spinner  spinner.Model
+	quitting bool
+	err      error
+	message  string
+	msgChan  chan string
+}
+
+func New(message string, msgChan chan string) Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	return Model{
+		spinner: s,
+		message: message,
+		msgChan: msgChan,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		func() tea.Msg {
+			if m.msgChan == nil {
+				return nil
+			}
+			select {
+			case msg := <-m.msgChan:
+				return updateMsg(msg)
+			default:
+				return nil
+			}
+		},
+	)
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		default:
+			return m, nil
+		}
+
+	case errMsg:
+		m.err = msg
+		return m, nil
+
+	case updateMsg:
+		m.message = string(msg)
+		return m, func() tea.Msg {
+			if m.msgChan == nil {
+				return nil
+			}
+			select {
+			case msg := <-m.msgChan:
+				return updateMsg(msg)
+			default:
+				return nil
+			}
+		}
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+}
+
+func (m Model) View() string {
+	if m.err != nil {
+		return m.err.Error()
+	}
+	str := fmt.Sprintf("\r%s %s", m.spinner.View(), m.message)
+	if m.quitting {
+		return str + "\n"
+	}
+	return str
+}
+
+// RunWithContext runs the spinner with a context that can be cancelled
+func RunWithContext(ctx context.Context, message string, msgChan chan string) error {
+	p := tea.NewProgram(New(message, msgChan), tea.WithContext(ctx))
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("failed to run spinner: %w", err)
+	}
+	return nil
+}
+
+// Run runs the spinner without a context
+func Run(message string, msgChan chan string) error {
+	return RunWithContext(context.Background(), message, msgChan)
+}


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a terminal spinner UI for login attempts, providing visual feedback during the login process.
- **Enhancements**
  - Improved login experience by displaying dynamic attempt counts with a spinner instead of static console output.
- **Style**
  - Updated a warning message to clarify its prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Added a loading spinner indicator using the Charmbracelet Bubble Tea framework to improve user feedback during the login process.

- Implemented new `spinner` package in `common/teacmd/spinner/spinner.go` with customizable message updates and context cancellation
- Modified `getToken` function in `cmd/world/forge/login.go` to display spinner during login attempts
- Added `NewTeaProgram` in `cmd/world/forge/common.go` for TTY detection and terminal UI handling
- Improved context handling with proper cancellation throughout spinner lifecycle



<!-- /greptile_comment -->