### PR TITLE
fix: Cannot update user from world-cli

### DIFF
--- a/cmd/world/forge/user.go
+++ b/cmd/world/forge/user.go
@@ -9,7 +9,7 @@ import (
 )
 
 type User struct {
-	ID        string `json:"id"`
+	ID        string `json:"id,omitempty"`
 	Name      string `json:"name"`
 	Email     string `json:"email"`
 	AvatarURL string `json:"avatar_url"`


### PR DESCRIPTION
# fix: Add `omitempty` to User ID JSON tag

Closes: PLAT-299

## Overview

This PR adds the `omitempty` option to the JSON tag for the `ID` field in the `User` struct, allowing the field to be omitted from JSON output when it's empty.

## Brief Changelog

- Added `omitempty` to the `ID` field JSON tag in the `User` struct

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON output for user data by omitting empty user IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the User struct's ID field JSON tag to include `omitempty`, addressing a bug where users cannot be updated via the world-cli tool.

- Added `omitempty` to `ID` field in `User` struct in `/cmd/world/forge/user.go` to prevent empty ID from being sent in JSON
- Potential issue: `updateUser()` creates empty User payload without copying existing user's ID
- Risk: Server-side user updates may fail without proper ID handling
- Recommend: Copy current user's ID to payload in `updateUser()` function to ensure proper updates



<!-- /greptile_comment -->