### PR TITLE
fix: lint error

### DIFF
--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -38,7 +38,7 @@ tasks:
         INSTALLED_VERSION=$(golangci-lint --version 2>/dev/null | awk '{print $4}' || echo "none")
         if [ "$INSTALLED_VERSION" != "{{.LINT_VERSION}}" ]; then
           echo "--> Installing golangci-lint {{.LINT_VERSION}}"
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{.LINT_VERSION}}
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@{{.LINT_VERSION}}
         else
           echo "--> golangci-lint {{.LINT_VERSION}} is already installed"
         fi


### PR DESCRIPTION
Fixes: PLAT-309

# fix: Update golangci-lint import path to v2

## Overview

This PR updates the import path for golangci-lint in the lint task to use the v2 module path.

## Brief Changelog

- Updated the golangci-lint installation command from `github.com/golangci/golangci-lint/cmd/golangci-lint` to `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`

## Testing and Verifying

This change is a trivial update to the import path that can be verified by running the lint task and confirming that golangci-lint is installed correctly.

<!-- greptile_comment -->

## Greptile Summary

Updates the golangci-lint import path to use the v2 module path in the lint task, ensuring compatibility with the latest version of the linting tool.

- Updated import path in `taskfiles/lint.yaml` from `golangci/golangci-lint/cmd/golangci-lint` to `golangci/golangci-lint/v2/cmd/golangci-lint`
- Using `latest` as `LINT_VERSION` could cause inconsistency across environments, consider pinning to specific version
- Verify compatibility with existing golangci-lint configurations in `.golangci.yaml`



<!-- /greptile_comment -->