### PR TITLE
refactor: Use teaspinner for loading

### DIFF
--- a/tea/component/spinner/spinner.go
+++ b/tea/component/spinner/spinner.go
@@ -7,6 +7,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+const completedMsg = "spin: completed"
+
 // Spinner is a component that displays a spinner while updating the logs.
 type Spinner struct {
 	Spinner spinner.Model
@@ -41,7 +43,7 @@ func (s Spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogMsg:
 		// Add the log message to the list of logs and return a spinner tick
 		s.text = string(msg)
-		if string(msg) == "spin: completed" {
+		if string(msg) == completedMsg {
 			s.done = true
 			return s, tea.Quit
 		}
@@ -58,4 +60,8 @@ func (s Spinner) View() string {
 	}
 
 	return fmt.Sprintf("%s %s", s.Spinner.View(), s.text)
+}
+
+func (s *Spinner) SetText(text string) {
+	s.text = text
 }


### PR DESCRIPTION
# Enhance login experience with spinner and extended timeout

Closes: PLAT-278

## Overview

This PR improves the login experience by adding a spinner animation during the login process and extending the maximum login timeout from 1 minute to 11 minutes.

## Brief Changelog

- Added a spinner animation during the login process for better user experience
- Extended maximum login attempts from 12 to 220 (increasing timeout from 1 minute to 11 minutes)
- Improved login status messages with clear success/failure indicators
- Updated the spinner component to use the Text field directly instead of text
- Added proper cleanup of spinner resources when login completes or fails

## Testing and Verifying

This change can be verified by attempting to log in with the CLI and observing:
- The spinner animation appears during login
- Success/failure messages display appropriately
- The login process can continue for up to 11 minutes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved login experience with a terminal spinner animation, providing real-time feedback during the login process.
  - Extended login polling duration for more robust authentication handling.

- **Enhancements**
  - Added detailed status messages and clearer success or failure notifications during login attempts.
  - Enhanced spinner component with customizable text updates for better UI control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Enhanced login experience with spinner animation and extended timeout from 1 to 11 minutes, providing better visual feedback during authentication.

- Extended `maxLoginAttempts` from 12 to 220 in `/cmd/world/forge/login.go` to allow longer login windows
- Added spinner animation with proper cleanup using WaitGroup in `/cmd/world/forge/login.go`
- Changed `text` to `Text` field in `/tea/component/spinner/spinner.go` for public access
- Hardcoded "Build completed!" message in `/tea/component/spinner/spinner.go` needs context-specific updates
- Improved status messages with clear success/failure indicators in `/cmd/world/forge/login.go`



<!-- /greptile_comment -->