### PR TITLE
refactor(organization): trim slug & prompt for redo

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -312,8 +312,8 @@ func checkLogin() bool {
 
 // slugToSaneCheck checks that slug is valid, and returns a sanitized version.
 func slugToSaneCheck(slug string, minLength int, maxLength int) (string, error) {
-	if len(slug) < minLength || len(slug) > maxLength {
-		return slug, eris.Errorf("Slug must be between %d and %d characters", minLength, maxLength)
+	if len(slug) < minLength {
+		return slug, eris.Errorf("Slug must be at least %d characters", minLength)
 	}
 
 	// Check if slug contains only allowed characters.
@@ -330,6 +330,10 @@ func slugToSaneCheck(slug string, minLength int, maxLength int) (string, error) 
 	returnSlug = strings.ReplaceAll(returnSlug, " ", "_")
 	returnSlug = underscoreRegex.ReplaceAllString(returnSlug, "_")
 	returnSlug = strings.Trim(returnSlug, "_")
+
+	if len(returnSlug) > maxLength {
+		return returnSlug[:maxLength], nil
+	}
 
 	return returnSlug, nil
 }


### PR DESCRIPTION
# Improve slug handling in organization creation

Closes: PLAT-280

## Overview

This PR enhances the organization creation flow by improving slug validation and adding a confirmation step before submitting the request.

## Brief Changelog

- Modified slug validation to only enforce minimum length requirement
- Added truncation for slugs exceeding maximum length instead of returning an error
- Added a confirmation step showing organization details before creation
- Added ability to restart the organization creation process
- Refactored organization creation logic by extracting API request into a separate function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation step when creating a new organization, allowing users to review, confirm, cancel, or redo their input before finalizing creation.

- **Improvements**
  - Enhanced slug validation: slugs shorter than the minimum length now show a clearer error, while slugs exceeding the maximum length are automatically truncated.
  - Updated error messaging for avatar URL input to clarify that leaving it empty will skip the avatar.
  - Improved input validation loops to ensure each field is confirmed before proceeding.

- **Bug Fixes**
  - Improved organization creation flow to handle retries of invalid inputs and support cancellation and redo options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Improved organization creation flow with enhanced slug handling and validation, adding user confirmation steps and error handling.

- Critical bug in `slugToSaneCheck`: uses original `slug` instead of sanitized `returnSlug` for length checks and truncation
- Added confirmation step showing organization details before creation with redo option
- Modified slug validation to only enforce minimum length and truncate exceeding slugs
- Improved error messages for invalid URLs and validation failures
- Extracted API request logic into separate `createOrgRequestAndSave` function for better organization



<!-- /greptile_comment -->