### PR TITLE
refactor: attempt public repo access before requesting private token

### DIFF
--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1911,21 +1911,21 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 
 			if len(tc.inputs) > 0 {
 				inputIndex := 0
-				lastPrompt := ""
-				nextToLastPrompt := ""
 				getInput = func(prompt string, defaultVal string) string {
 					fmt.Printf("%s [%s]: ", prompt, defaultVal)
-					if prompt == lastPrompt || prompt == nextToLastPrompt {
-						panic(eris.Errorf("Input %d Failed", inputIndex))
+
+					if inputIndex >= len(tc.inputs) {
+						panic(fmt.Errorf("Input %d Failed", inputIndex))
 					}
-					nextToLastPrompt = lastPrompt
-					lastPrompt = prompt
+
 					input := tc.inputs[inputIndex]
+					inputIndex++
+
 					if input == "" {
 						input = defaultVal
 					}
+
 					fmt.Printf("%s\n", input)
-					inputIndex++
 					return input
 				}
 				defer func() { getInput = originalGetInput }()


### PR DESCRIPTION
# Improve repository setup flow in forge

Closes: PLAT-313

## Overview

This PR enhances the repository setup experience in the forge tool by automatically detecting public repositories and only prompting for tokens when necessary. It also improves the UI formatting and fixes a test issue related to input handling.

## Brief Changelog

- Added automatic detection of public repositories before requesting tokens
- Fixed input handling in forge tests to properly track input index
- Improved UI formatting for repository configuration sections
- Removed redundant project name requirements display
- Simplified token handling logic by removing unnecessary prompts

## Testing and Verifying

This change is covered by existing tests, with fixes to the test suite itself to ensure proper validation of the input handling flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of user input during project creation to prevent unexpected prompt behaviors.
  - Enhanced repository access logic to automatically attempt public access before prompting for a repository token, reducing unnecessary prompts.

- **Style**
  - Updated prompt formatting for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Enhanced repository setup flow by automatically detecting public repositories before requesting access tokens, improving the user experience in the World CLI forge tool.

- Added public repository detection in `inputRepoURLAndToken` to avoid unnecessary token prompts
- Simplified token handling logic in `processRepoToken` by removing redundant prompts and checks
- Improved UI formatting consistency in repository configuration sections
- Fixed input handling in forge tests to properly validate token request flow



<!-- /greptile_comment -->