### PR TITLE
refactor(deploy): Prompt create project if not exist

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -55,9 +55,20 @@ func deployment(ctx context.Context, deployType string) error {
 		return nil
 	}
 
+	// Ensure organization is not nil before this call.
 	if projectID == "" {
-		printNoSelectedProject()
-		return nil
+		org, err := getSelectedOrganization(ctx)
+		if err != nil {
+			return eris.Wrap(err, "Failed on deployment to get selected organization")
+		}
+
+		fmt.Printf("Deploy requires a project created in World Forge: %s\n", org.Name)
+
+		pID, err := createProject(ctx)
+		if err != nil {
+			return eris.Wrap(err, "Failed on deployment to create project")
+		}
+		projectID = pID.ID
 	}
 
 	// preview deployment

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -400,7 +400,7 @@ func (p *project) inputRepoURLAndToken(ctx context.Context) error {
 				repoToken = p.processRepoToken(repoToken)
 
 				if err := validateRepoToken(ctx, repoURL, repoToken); err != nil {
-					fmt.Printf("❌ Error: %v\n", err)
+					fmt.Printf("\n❌ Error: %v\n", err)
 					continue
 				}
 			}
@@ -991,7 +991,7 @@ func handleMultipleProjects(ctx context.Context, projectID string, projects []pr
 func handleNoProjects(ctx context.Context) (string, error) {
 	// Confirmation prompt
 	confirmation := getInput(
-		"You don't have any projects in this organization. Do you want to create a new project now? (y/n)",
+		"\nYou don't have any projects in this organization. Do you want to create a new project now? (y/n)",
 		"y",
 	)
 


### PR DESCRIPTION
# feat: Enhance deployment workflow to automatically create projects when needed

Closes: PLAT-311

## Overview

This PR enhances the deployment workflow by automatically creating a new project when a user attempts to deploy without having a project selected. Previously, the deployment would fail with a message about no selected project, but now it guides the user through project creation to complete the deployment process.

## Brief Changelog

- Modified deployment logic to create a new project when no project is selected
- Updated test cases to support multiple input strings for interactive prompts
- Added test case for the new project creation flow during deployment
- Standardized confirmation inputs in tests to use uppercase "Y"

## Testing and Verifying

This change is covered by the updated test cases, particularly the new test case "Success - No project selected (creates new project)" which validates the automatic project creation flow during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and messaging during deployment when no project is set, including better prompts and error context.
- **Tests**
	- Enhanced deployment tests to support multiple sequential user inputs and simulated region selection.
	- Updated test confirmations to use uppercase input and aligned test configurations for consistency.
- **Style**
	- Improved formatting of user prompts and error messages for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->