### PR TITLE
fix: Login rejection of create org now properly rejects

### DIFF
--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -261,13 +261,13 @@ func createOrganization(ctx context.Context) (*organization, error) {
 		}
 
 		// Get confirmation
-		for redo := false; !redo; {
+		for redo := true; redo; {
 			confirm := getInput("\nCreate organization with these details? (Y/n)", "n")
 			switch confirm {
 			case "Y":
 				return createOrgRequestAndSave(ctx, orgName, orgSlug, orgAvatarURL)
 			case "n":
-				redo = true
+				redo = false
 			default:
 				fmt.Println("\nPlease enter capital 'Y' to confirm, 'n' to cancel, or 'redo' to start over")
 			}
@@ -443,14 +443,20 @@ func handleMultipleOrgs(ctx context.Context, orgID string, orgs []organization) 
 
 // handleNoOrgs handles the case when there are no organizations.
 func handleNoOrgs(ctx context.Context) (string, error) {
-	// Confirmation prompt
-	confirmation := getInput("You don't have any organizations. Create a new one now? (Y/n)", "n")
+	for redo := true; redo; {
+		// Confirmation prompt
+		confirmation := getInput("\nYou don't have any organizations. Create a new one now? (Y/n)", "n")
 
-	if confirmation != "Y" {
-		if confirmation == "y" {
+		switch confirmation {
+		case "Y":
+			redo = false
+		case "y":
 			fmt.Println("You need to enter Y (uppercase) to confirm creation")
-			fmt.Println("\n❌ Organization creation canceled")
+		case "n":
+			fmt.Println("❌ Organization creation canceled")
 			return "", nil
+		default:
+			fmt.Println("❌ Invalid input")
 		}
 	}
 


### PR DESCRIPTION
# fix: Improve organization creation flow with better user feedback

Closes: PLAT-279

## Overview

This PR enhances the organization creation flow by improving the user experience when no organizations exist. It replaces the single-attempt confirmation prompt with a loop that provides clearer feedback and allows users to retry their input.

## Brief Changelog

- Added a loop in `handleNoOrgs` function to allow multiple input attempts
- Improved error messaging for invalid inputs
- Added specific feedback for lowercase 'y' input
- Clarified the cancellation message for 'n' input

## Testing and Verifying

This change is a trivial improvement to the user interface flow without requiring additional test coverage. The functionality can be manually verified by running the organization creation flow when no organizations exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the confirmation prompt when creating a new organization, requiring users to enter an uppercase "Y" to proceed and providing clearer instructions for invalid or lowercase responses.
	- Enhanced input validation by looping prompts until valid responses are received, preventing accidental cancellations or infinite loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->