### PR TITLE
refactor: Don't ask to make project if no org found

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -142,11 +142,14 @@ are organized within organizations.`,
 			if !checkLogin() {
 				return nil
 			}
-			org, err := selectOrganization(cmd.Context())
+			flow := organizationFlow{
+				ShouldPromptForProject: true,
+			}
+			err := flow.selectOrganization(cmd.Context())
 			if err != nil {
 				return eris.Wrap(err, "Failed to select organization")
 			}
-			fmt.Println("Switched to organization: ", org.Name)
+			fmt.Println("Switched to organization: ", flow.Organization.Name)
 			return nil
 		},
 	}

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1486,15 +1486,18 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 				}
 				defer func() { getInput = originalGetInput }()
 
-				org, err := selectOrganization(s.ctx)
+				flow := organizationFlow{
+					ShouldPromptForProject: true,
+				}
+				err = flow.selectOrganization(s.ctx)
 				if tc.expectedError {
 					s.Require().Error(err)
-					s.Empty(org)
+					s.Empty(flow.Organization)
 				} else {
 					s.Require().NoError(err)
-					s.Equal("test-org-id", org.ID)
-					s.Equal("Test Org", org.Name)
-					s.Equal("testo", org.Slug)
+					s.Equal("test-org-id", flow.Organization.ID)
+					s.Equal("Test Org", flow.Organization.Name)
+					s.Equal("testo", flow.Organization.Slug)
 				}
 			}
 		})

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -122,16 +122,25 @@ func handleKnownRepoConfig(ctx context.Context, config *globalconfig.GlobalConfi
 }
 
 func handleNewRepoConfig(ctx context.Context, config *globalconfig.GlobalConfig) error {
+	flow := organizationFlow{
+		ShouldPromptForProject: false,
+	}
+
 	// Handle organization selection
-	orgID, err := handleOrganizationSelection(ctx, config.OrganizationID)
+	err := flow.handleOrganizationSelection(ctx, config.OrganizationID)
 	if err != nil {
-		orgID = ""
+		flow.Organization.ID = ""
 	}
 
 	// Save orgID to config
-	config.OrganizationID = orgID
+	config.OrganizationID = flow.Organization.ID
 	if err := globalconfig.SaveGlobalConfig(*config); err != nil {
 		return eris.Wrap(err, "Failed to save organization information")
+	}
+
+	// If no orgID then we can't continue
+	if flow.Organization.ID == "" {
+		return nil
 	}
 
 	// Handle project selection

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -991,7 +991,7 @@ func handleMultipleProjects(ctx context.Context, projectID string, projects []pr
 func handleNoProjects(ctx context.Context) (string, error) {
 	// Confirmation prompt
 	confirmation := getInput(
-		"You don't have any projects in this organization. Do you want to create a new project now? (y/n)",
+		"\nYou don't have any projects in this organization. Do you want to create a new project now? (y/n)",
 		"y",
 	)
 


### PR DESCRIPTION
Closes: PLAT-324
Closes: PLAT-336

fix: Prevent error when no organization is selected during login

## Overview

This PR adds a check to prevent errors when a user doesn't select an organization during the login process. If no organization ID is provided, the function returns early before attempting to handle project selection.

## Brief Changelog

- Added a check to return early if no organization ID is selected during login
- Prevents errors when trying to handle project selection with no organization context

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling when no organization is selected during configuration, preventing unnecessary prompts.

- **Style**
	- Adjusted indentation in the organization list display for improved alignment.
	- Enhanced formatting of project creation prompt with added spacing for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->