### PR TITLE
fix: Region Selection unselected causes terminal error spam

### DIFF
--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -1936,6 +1936,29 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 			},
 		},
 		{
+			name: "Abort - user presses q in region selector",
+			config: globalconfig.GlobalConfig{
+				OrganizationID: "test-org-id",
+				Credential: globalconfig.Credential{
+					Token: "test-token",
+				},
+				KnownProjects: knownProjects,
+			},
+			inputs: []string{
+				"Test Project", // name
+				"",             // take default slug
+				"https://github.com/argus-labs/starter-game-template", // repoURL
+				"",   // repoToken (empty for public repo)
+				"",   // repoPath
+				"10", // tick rate
+			},
+			regionSelectActions: []tea.KeyMsg{
+				{Type: tea.KeyRunes, Runes: []rune{'q'}, Alt: false}, // simulate pressing 'q'
+			},
+			expectedError:   true,
+			expectedProject: nil,
+		},
+		{
 			name: "Error - private repo bad token",
 			config: globalconfig.GlobalConfig{
 				OrganizationID: "test-org-id",

--- a/tea/component/multiselect/multiselect.go
+++ b/tea/component/multiselect/multiselect.go
@@ -13,6 +13,7 @@ type Model struct {
 	Cursor   int
 	Selected map[int]bool
 	Ctx      context.Context
+	Aborted  bool
 }
 
 // InitialMultiselectModel creates a new Model with the given items and context.
@@ -58,6 +59,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "enter":
 				return m, tea.Quit
 			case "q", "ctrl+c":
+				m.Aborted = true
 				return m, tea.Quit
 			}
 		}
@@ -67,7 +69,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the current state of the region selection menu.
 func (m Model) View() string {
-	s := "Choose regions (space to select/unselect, enter when done):\n\n"
+	s := "\nChoose regions (space to select/unselect, enter when done):\n\n"
 
 	for i, item := range m.Items {
 		cursor := " "


### PR DESCRIPTION
# Add ability to abort region selection in forge

Closes: PLAT-338

## Overview

This PR adds the ability for users to abort the region selection process in the forge command by pressing 'q'. Previously, there was no clean way to exit the region selection UI.

## Brief Changelog

- Modified `runRegionSelector` to return a boolean indicating if the selection was aborted
- Added handling for the abort case in `chooseRegion` with appropriate error messaging
- Updated the `multiselect.Model` to track the aborted state
- Added a test case to verify the abort functionality works correctly
- Improved UI by adding a newline before the region selection prompt

## Testing and Verifying

This change is covered by a new test case that simulates a user pressing 'q' during region selection, verifying that the operation is properly aborted with an appropriate error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit detection and handling of user aborts during region selection in project creation.
- **Bug Fixes**
  - Improved error handling when aborting the region selection process.
- **Tests**
  - Introduced a new test case to verify abort behavior during interactive region selection.
- **Style**
  - Updated the region selection prompt to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->