### PR TITLE
refactor: Convert project to Project struct with ForgeProject interface

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -448,7 +448,7 @@ func GetCurrentConfigWithContext(ctx context.Context) (*globalconfig.GlobalConfi
 		}
 
 		// Parse response
-		proj, err := parseResponse[project](body)
+		proj, err := parseResponse[Project](body)
 		if err != nil && err.Error() != "Missing data field in response" {
 			// missing data field in response just means nothing was found
 			fmt.Println("⚠️ Warning: Failed to parse project lookup response: ", err)

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -64,11 +64,12 @@ func deployment(ctx context.Context, deployType string) error {
 
 		fmt.Printf("Deploy requires a project created in World Forge: %s\n", org.Name)
 
-		pID, err := createProject(ctx)
+		project := &Project{}
+		err = project.CreateProject(ctx)
 		if err != nil {
 			return eris.Wrap(err, "Failed on deployment to create project")
 		}
-		projectID = pID.ID
+		projectID = project.ID
 	}
 
 	// preview deployment

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -257,7 +257,9 @@ All settings can be updated later using the 'update' command.`,
 			if !checkLogin() {
 				return nil
 			}
-			_, err := createProject(cmd.Context())
+
+			project := &Project{}
+			err := project.CreateProject(cmd.Context())
 			if err != nil {
 				return eris.Wrap(err, "Failed to create project")
 			}

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -97,7 +97,7 @@ func (s *ForgeTestSuite) SetupTest() { //nolint: cyclop // test, don't care abou
 				case "/api/user/login/get-token":
 					s.handleGetToken(w, r)
 				case "/api/organization/empty-org-id/project":
-					s.writeJSON(w, map[string]interface{}{"data": []project{}})
+					s.writeJSON(w, map[string]interface{}{"data": []Project{}})
 				case "/api/deployment/test-project-id":
 					s.handleStatusDeployed(w, r)
 				case "/api/deployment/failedbuild-project-id":
@@ -245,7 +245,7 @@ func (s *ForgeTestSuite) handleProjectList(w http.ResponseWriter, r *http.Reques
 		err = json.Unmarshal(parsedBody, &body)
 		s.Require().NoError(err)
 
-		proj := project{
+		proj := Project{
 			ID:      "test-project-id",
 			OrgID:   "test-org-id",
 			Name:    body["name"].(string),
@@ -256,7 +256,7 @@ func (s *ForgeTestSuite) handleProjectList(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	projects := []project{
+	projects := []Project{
 		{
 			ID:      "test-project-id",
 			OrgID:   "test-org-id",
@@ -269,7 +269,7 @@ func (s *ForgeTestSuite) handleProjectList(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *ForgeTestSuite) handleProjectGet(w http.ResponseWriter, _ *http.Request) {
-	proj := project{
+	proj := Project{
 		ID:      "test-project-id",
 		OrgID:   "test-org-id",
 		Name:    "Test Project",
@@ -602,7 +602,7 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 		name          string
 		config        globalconfig.GlobalConfig
 		expectedError bool
-		expectedProj  *project
+		expectedProj  *Project
 	}{
 		{
 			name: "Success - Valid project",
@@ -614,7 +614,7 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 				},
 			},
 			expectedError: false,
-			expectedProj: &project{
+			expectedProj: &Project{
 				ID:      "test-project-id",
 				OrgID:   "test-org-id",
 				Name:    "Test Project",
@@ -1863,7 +1863,7 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 		regionSelectActions []tea.KeyMsg // Simulate region selection
 		expectInputFail     int
 		expectedError       bool
-		expectedProject     *project
+		expectedProject     *Project
 	}{
 		{
 			name: "Success - Public repo default slug",
@@ -1895,7 +1895,7 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 			},
 			expectInputFail: 0,
 			expectedError:   false,
-			expectedProject: &project{
+			expectedProject: &Project{
 				Name: "Test Project",
 				Slug: "test_project",
 			},
@@ -1930,7 +1930,7 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 			},
 			expectInputFail: 0,
 			expectedError:   false,
-			expectedProject: &project{
+			expectedProject: &Project{
 				Name: "Test Project",
 				Slug: "testp",
 			},
@@ -2073,13 +2073,13 @@ func (s *ForgeTestSuite) TestCreateProject() { //nolint:gocognit
 				}
 			}()
 
-			var prj *project
+			var prj *Project = &Project{}
 			if tc.expectInputFail > 0 { //nolint: nestif // it's a test
 				s.PanicsWithError(fmt.Sprintf("Input %d Failed", tc.expectInputFail), func() {
-					prj, err = createProject(s.ctx)
+					err = prj.CreateProject(s.ctx)
 				})
 			} else {
-				prj, err = createProject(s.ctx)
+				err = prj.CreateProject(s.ctx)
 				if tc.expectedError {
 					s.Error(err)
 				} else {
@@ -2101,7 +2101,7 @@ func (s *ForgeTestSuite) TestSelectProject() {
 		config        globalconfig.GlobalConfig
 		input         string
 		expectedError bool
-		expectedProj  *project
+		expectedProj  *Project
 	}{
 		{
 			name: "Success - Valid project selection",
@@ -2113,7 +2113,7 @@ func (s *ForgeTestSuite) TestSelectProject() {
 			},
 			input:         "1",
 			expectedError: false,
-			expectedProj: &project{
+			expectedProj: &Project{
 				ID:      "test-project-id",
 				OrgID:   "test-org-id",
 				Name:    "Test Project",

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -11,6 +11,7 @@ import (
 	"pkg.world.dev/world-cli/cmd/world/root"
 	"pkg.world.dev/world-cli/common/globalconfig"
 	_ "pkg.world.dev/world-cli/common/logger"
+	"pkg.world.dev/world-cli/common/ports"
 	"pkg.world.dev/world-cli/telemetry"
 )
 
@@ -31,6 +32,9 @@ func init() {
 	globalconfig.Env = env
 
 	forge.InitForge()
+
+	// Initialize the project service
+	ports.ProjectService = &forge.Project{}
 }
 
 func main() {

--- a/common/ports/forge_project.go
+++ b/common/ports/forge_project.go
@@ -1,0 +1,12 @@
+package ports
+
+import "context"
+
+// ForgeProject defines the interface for a world forge project.
+type ForgeProject interface {
+	// Create creates a new Forge project.
+	CreateProject(ctx context.Context) error
+}
+
+// ProjectService is the global instance that implements ForgeProject
+var ProjectService ForgeProject


### PR DESCRIPTION
# Refactor: Extract Project into a reusable interface

Closes: PLAT-340

## Overview

This PR refactors the project creation functionality by extracting the `Project` type into a reusable interface. It introduces a new `ForgeProject` interface in the `ports` package, allowing for better dependency injection and testability.

## Brief Changelog

- Renamed `project` struct to `Project` to follow Go naming conventions
- Created a new `ForgeProject` interface in `ports` package
- Modified `createProject` to be a method on the `Project` struct
- Initialized a global `ProjectService` instance in main.go
- Updated all references to use the new interface and method signatures
- Made `Project` implement the `ForgeProject` interface

## Testing and Verifying

This change is covered by existing tests, which have been updated to use the new interface and method signatures. The functionality remains the same, but the code structure is now more modular and testable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified and capitalized the project type across the application for consistency.
  - Converted project creation from a standalone function to a method on the Project object.
  - Updated internal logic to use the new Project type and method signatures throughout the app.

- **Chores**
  - Introduced a new interface for project creation and a global project service variable for improved structure.
  - Updated test references to align with the new Project type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->