### PR TITLE
feat: world create adds name to toml

### DIFF
--- a/common/tomlutil/toml.go
+++ b/common/tomlutil/toml.go
@@ -1,0 +1,97 @@
+package tomlutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ReadTOML reads a TOML file and unmarshals it into the provided interface.
+func ReadTOML(path string, v interface{}) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read TOML file at '%s': %w", path, err)
+	}
+
+	if err := toml.Unmarshal(content, v); err != nil {
+		return fmt.Errorf("failed to parse TOML file at '%s': %w", path, err)
+	}
+
+	return nil
+}
+
+// WriteTOML marshals the provided interface and writes it to a TOML file.
+func WriteTOML(path string, v interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create TOML file at '%s': %w", path, err)
+	}
+	defer f.Close()
+
+	encoder := toml.NewEncoder(f)
+	if err := encoder.Encode(v); err != nil {
+		return fmt.Errorf("failed to write TOML file: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateTOMLSection updates a specific section in a TOML file.
+// If the section doesn't exist, it will be created.
+func UpdateTOMLSection(path string, sectionName string, updates map[string]interface{}) error {
+	// Read the existing config
+	var config map[string]interface{}
+	if err := ReadTOML(path, &config); err != nil {
+		return err
+	}
+
+	// Get or create the section
+	section, ok := config[sectionName].(map[string]interface{})
+	if !ok {
+		section = make(map[string]interface{})
+		config[sectionName] = section
+	}
+
+	// Apply updates
+	for key, value := range updates {
+		section[key] = value
+	}
+
+	// Write back to file
+	return WriteTOML(path, config)
+}
+
+// GetTOMLSection reads a TOML file and returns a specific section.
+func GetTOMLSection(path string, sectionName string) (map[string]interface{}, error) {
+	var config map[string]interface{}
+	if err := ReadTOML(path, &config); err != nil {
+		return nil, err
+	}
+
+	section, ok := config[sectionName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("section '%s' not found in TOML file", sectionName)
+	}
+
+	return section, nil
+}
+
+// CreateTOMLFile creates a new TOML file with the given sections if it doesn't exist.
+// If the file already exists, it does nothing.
+func CreateTOMLFile(path string, sections map[string]map[string]interface{}) error {
+	// Check if file exists
+	if _, err := os.Stat(path); err == nil {
+		return nil // File exists, nothing to do
+	}
+
+	// Create parent directories if they don't exist
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory for TOML file: %w", err)
+	}
+
+	// Create the file with the given sections
+	return WriteTOML(path, sections)
+}

--- a/common/tomlutil/toml_test.go
+++ b/common/tomlutil/toml_test.go
@@ -1,0 +1,186 @@
+package tomlutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type TOMLTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func (s *TOMLTestSuite) SetupTest() {
+	s.tempDir = s.T().TempDir()
+}
+
+// createTestFile is a helper function that creates a temporary TOML file with given content
+func (s *TOMLTestSuite) createTestFile(content string) string {
+	tmpFile := filepath.Join(s.tempDir, "test.toml")
+	err := os.WriteFile(tmpFile, []byte(content), 0644)
+	require.NoError(s.T(), err, "Failed to create test file")
+	return tmpFile
+}
+
+func (s *TOMLTestSuite) TestReadTOML() {
+	// Create a temporary test file
+	content := `
+[test]
+key = "value"
+number = 42
+
+[nested]
+string = "nested value"
+`
+	tmpFile := s.createTestFile(content)
+
+	// Test successful read
+	var config map[string]any
+	err := ReadTOML(tmpFile, &config)
+	s.Require().NoError(err)
+	s.Equal("value", config["test"].(map[string]any)["key"])
+	s.Equal(int64(42), config["test"].(map[string]any)["number"])
+
+	// Test reading non-existent file
+	err = ReadTOML("nonexistent.toml", &config)
+	s.Error(err)
+}
+
+func (s *TOMLTestSuite) TestWriteTOML() {
+	tmpFile := filepath.Join(s.tempDir, "write_test.toml")
+
+	// Test writing new file
+	config := map[string]any{
+		"section": map[string]any{
+			"key":    "value",
+			"number": int64(42),
+		},
+	}
+
+	err := WriteTOML(tmpFile, config)
+	s.Require().NoError(err)
+
+	// Verify written content
+	var readConfig map[string]any
+	err = ReadTOML(tmpFile, &readConfig)
+	s.Require().NoError(err)
+	s.Equal(config, readConfig)
+
+	// Test writing to invalid path
+	err = WriteTOML("/invalid/path/test.toml", config)
+	s.Error(err)
+}
+
+func (s *TOMLTestSuite) TestUpdateTOMLSection() {
+	// Create initial test file
+	initialContent := `
+[existing]
+key = "value"
+
+[update]
+keep = "kept"
+change = "old"
+`
+	tmpFile := s.createTestFile(initialContent)
+
+	// Test updating existing section
+	updates := map[string]any{
+		"change": "new",
+		"add":    "added",
+	}
+	err := UpdateTOMLSection(tmpFile, "update", updates)
+	s.Require().NoError(err)
+
+	// Verify updates
+	var config map[string]any
+	err = ReadTOML(tmpFile, &config)
+	s.Require().NoError(err)
+
+	updateSection := config["update"].(map[string]any)
+	s.Equal("kept", updateSection["keep"])
+	s.Equal("new", updateSection["change"])
+	s.Equal("added", updateSection["add"])
+
+	// Test creating new section
+	newUpdates := map[string]any{
+		"new": "value",
+	}
+	err = UpdateTOMLSection(tmpFile, "newsection", newUpdates)
+	s.Require().NoError(err)
+
+	err = ReadTOML(tmpFile, &config)
+	s.Require().NoError(err)
+	s.Equal("value", config["newsection"].(map[string]any)["new"])
+}
+
+func (s *TOMLTestSuite) TestGetTOMLSection() {
+	// Create test file
+	content := `
+[section]
+key = "value"
+number = 42
+
+[empty]
+`
+	tmpFile := s.createTestFile(content)
+
+	// Test getting existing section
+	section, err := GetTOMLSection(tmpFile, "section")
+	s.Require().NoError(err)
+	s.Equal("value", section["key"])
+	s.Equal(int64(42), section["number"])
+
+	// Test getting non-existent section
+	_, err = GetTOMLSection(tmpFile, "nonexistent")
+	s.Error(err)
+
+	// Test getting empty section
+	emptySection, err := GetTOMLSection(tmpFile, "empty")
+	s.Require().NoError(err)
+	s.Empty(emptySection)
+}
+
+func (s *TOMLTestSuite) TestCreateTOMLFile() {
+	tmpFile := filepath.Join(s.tempDir, "nested", "create_test.toml")
+
+	// Test creating new file with sections
+	sections := map[string]map[string]any{
+		"section1": {
+			"key": "value",
+		},
+		"section2": {
+			"number": int64(42),
+		},
+	}
+
+	err := CreateTOMLFile(tmpFile, sections)
+	s.Require().NoError(err)
+
+	// Verify file was created with correct content
+	var config map[string]any
+	err = ReadTOML(tmpFile, &config)
+	s.Require().NoError(err)
+	s.Equal("value", config["section1"].(map[string]any)["key"])
+	s.Equal(int64(42), config["section2"].(map[string]any)["number"])
+
+	// Test creating file that already exists (should do nothing)
+	newSections := map[string]map[string]any{
+		"different": {"key": "value"},
+	}
+	err = CreateTOMLFile(tmpFile, newSections)
+	s.Require().NoError(err)
+
+	// Verify original content wasn't changed
+	err = ReadTOML(tmpFile, &config)
+	s.Require().NoError(err)
+	s.Equal("value", config["section1"].(map[string]any)["key"])
+}
+
+// TestTOMLSuite runs the test suite
+func TestTOMLSuite(t *testing.T) {
+	suite.Run(t, new(TOMLTestSuite))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module pkg.world.dev/world-cli
 go 1.24.0
 
 require (
+	github.com/BurntSushi/toml v1.3.2
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.1.0
 	github.com/denisbrodbeck/machineid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=


### PR DESCRIPTION
# feat: Update world.toml with project name during world creation

Closes: PLAT-314

## Overview

This PR enhances the world creation process by automatically updating the world.toml configuration file with the user-provided project name. It adds a new step in the creation workflow that writes the project name to the forge section of the world.toml file.

## Brief Changelog

- Added a new step "Update world.toml configuration" to the world creation process
- Implemented `updateWorldToml()` function to modify the world.toml file with the project name
- Added BurntSushi/toml dependency for TOML file parsing and writing
- Updated the step progression logic to include the new configuration step

## Testing and Verifying

This change can be verified by creating a new world with the CLI and checking that the world.toml file contains the correct project name in the forge section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Update world.toml configuration" step to the world creation process, which automatically updates the project name in the configuration file.
  - Introduced utilities for managing TOML configuration files, enabling reading, writing, updating, and creating TOML files with ease.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->