### PR TITLE
fix: Enable govet linter and fix shadowing issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,7 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
-    # - govet
+    - govet
     - iface
     - ineffassign
     - intrange

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -200,13 +200,13 @@ func status(ctx context.Context, cmdState *ForgeCommandState) error {
 		}
 		switch deployType {
 		case DeploymentTypeDeploy:
-			bnf, ok := data["build_number"].(float64)
-			if !ok {
+			bnf, okInner := data["build_number"].(float64)
+			if !okInner {
 				return eris.New("Failed to unmarshal deployment build_number")
 			}
 			buildNumber := int(bnf)
-			buildStartTimeStr, ok := data["build_start_time"].(string)
-			if !ok {
+			buildStartTimeStr, okInner := data["build_start_time"].(string)
+			if !okInner {
 				return eris.New("Failed to unmarshal deployment build_start_time")
 			}
 			bst, bte := time.Parse(time.RFC3339, buildStartTimeStr)
@@ -216,8 +216,8 @@ func status(ctx context.Context, cmdState *ForgeCommandState) error {
 			if bst.Before(dt) {
 				bst = dt // we don't have a real build start time yet because build kite hasn't run yet
 			}
-			buildEndTimeStr, ok := data["build_end_time"].(string)
-			if !ok {
+			buildEndTimeStr, okInner := data["build_end_time"].(string)
+			if !okInner {
 				buildEndTimeStr = buildStartTimeStr // we don't know how long this took
 			}
 			bet, bte := time.Parse(time.RFC3339, buildEndTimeStr)
@@ -311,14 +311,14 @@ func status(ctx context.Context, cmdState *ForgeCommandState) error {
 		if !shouldShowHealth[env] {
 			continue
 		}
-		data, ok := val.(map[string]any)
-		if !ok {
+		data, okay := val.(map[string]any)
+		if !okay {
 			return eris.Errorf("Failed to unmarshal response for environment %s", env)
 		}
-		instances, ok := data["deployed_instances"].([]any)
-		if !ok {
+		instances, okay := data["deployed_instances"].([]any)
+		if !okay {
 			return eris.Errorf("Failed to unmarshal health data: expected array, got %T",
-				response["deployed_instances"])
+				data["deployed_instances"])
 		}
 		// ok will be true if everything is up. offline will be true if everything is down
 		// neither will be set if status is mixed
@@ -337,61 +337,61 @@ func status(ctx context.Context, cmdState *ForgeCommandState) error {
 		printer.Infof("(%d deployed instances)\n", len(instances))
 		currRegion := ""
 		for _, instance := range instances {
-			info, ok := instance.(map[string]any)
-			if !ok {
+			info, okayInner := instance.(map[string]any)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d info", instance)
 			}
-			region, ok := info["region"].(string)
-			if !ok {
+			region, okayInner := info["region"].(string)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d region", instance)
 			}
-			instancef, ok := info["instance"].(float64)
-			if !ok {
+			instancef, okayInner := info["instance"].(float64)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d instance number", instance)
 			}
 			instanceNum := int(instancef)
-			cardinalInfo, ok := info["cardinal"].(map[string]any)
-			if !ok {
+			cardinalInfo, okayInner := info["cardinal"].(map[string]any)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d cardinal data", instance)
 			}
-			nakamaInfo, ok := info["nakama"].(map[string]any)
-			if !ok {
+			nakamaInfo, okayInner := info["nakama"].(map[string]any)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d nakama data", instance)
 			}
-			cardinalURL, ok := cardinalInfo["url"].(string)
-			if !ok {
+			cardinalURL, okayInner := cardinalInfo["url"].(string)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d cardinal url", instance)
 			}
 			cardinalHost := strings.Split(cardinalURL, "/")[2]
-			cardinalOK, ok := cardinalInfo["ok"].(bool)
-			if !ok {
+			cardinalOK, okayInner := cardinalInfo["ok"].(bool)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d cardinal ok flag", instance)
 			}
-			cardinalResultCodef, ok := cardinalInfo["result_code"].(float64)
-			if !ok {
+			cardinalResultCodef, okayInner := cardinalInfo["result_code"].(float64)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d cardinal result_code", instance)
 			}
 			cardinalResultCode := int(cardinalResultCodef)
-			cardinalResultStr, ok := cardinalInfo["result_str"].(string)
-			if !ok {
+			cardinalResultStr, okayInner := cardinalInfo["result_str"].(string)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d cardinal result_str", instance)
 			}
-			nakamaURL, ok := nakamaInfo["url"].(string)
-			if !ok {
+			nakamaURL, okayInner := nakamaInfo["url"].(string)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d nakama url", instance)
 			}
 			nakamaHost := strings.Split(nakamaURL, "/")[2]
-			nakamaOK, ok := nakamaInfo["ok"].(bool)
-			if !ok {
+			nakamaOK, okayInner := nakamaInfo["ok"].(bool)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d nakama ok", instance)
 			}
-			nakamaResultCodef, ok := nakamaInfo["result_code"].(float64)
-			if !ok {
+			nakamaResultCodef, okayInner := nakamaInfo["result_code"].(float64)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d result_code", instance)
 			}
 			nakamaResultCode := int(nakamaResultCodef)
-			nakamaResultStr, ok := nakamaInfo["result_str"].(string)
-			if !ok {
+			nakamaResultStr, okayInner := nakamaInfo["result_str"].(string)
+			if !okayInner {
 				return eris.Errorf("Failed to unmarshal deployment instance %d result_str", instance)
 			}
 			if region != currRegion {

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -313,6 +313,7 @@ func (s *ForgeTestSuite) handleDeploy(w http.ResponseWriter, r *http.Request) {
 	// check if preview flag is set
 	preview := r.URL.Query().Get("preview")
 	if preview == "true" {
+		//nolint:govet // test
 		deploymentPreview := deploymentPreview{
 			ProjectName:    "Test Project",
 			ProjectSlug:    "testp",
@@ -465,6 +466,7 @@ func (s *ForgeTestSuite) handleDestroy(w http.ResponseWriter, r *http.Request) {
 	// check if preview flag is set
 	preview := r.URL.Query().Get("preview")
 	if preview == "true" {
+		//nolint:govet // test
 		deploymentPreview := deploymentPreview{
 			ProjectName:    "Test Project",
 			ProjectSlug:    "testp",
@@ -518,7 +520,7 @@ func (s *ForgeTestSuite) handleReset(w http.ResponseWriter, r *http.Request) {
 	// check if preview flag is set
 	preview := r.URL.Query().Get("preview")
 	if preview == "true" {
-		deploymentPreview := deploymentPreview{
+		deploymentPreview := deploymentPreview{ //nolint:govet // test
 			ProjectName:    "Test Project",
 			ProjectSlug:    "testp",
 			OrgName:        "Test Org",
@@ -1398,7 +1400,7 @@ func (s *ForgeTestSuite) TestLogin() {
 			// Mock organization creation inputs if provided
 			if len(tc.orgInputs) > 0 {
 				inputIndex := 0
-				originalGetInput := getInput
+				originalGetInput := getInput //nolint:govet // test
 				getInput = func(prompt string, defaultVal string) string {
 					if inputIndex >= len(tc.orgInputs) {
 						return defaultVal

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -447,14 +447,14 @@ func loginWithArgusID(ctx context.Context) (Credential, error) {
 	}
 
 	// Wait for user to login
-	var tokenStruct tokenStruct
-	err = getToken(ctx, loginLink.CallBackURL, true, &tokenStruct)
+	var token tokenStruct
+	err = getToken(ctx, loginLink.CallBackURL, true, &token)
 	if err != nil {
 		return Credential{}, eris.Wrap(err, "Failed to get token")
 	}
 
 	// Parse jwt token to get name from metadata
-	cred, err := parseArgusIDToken(tokenStruct.JWT)
+	cred, err := parseArgusIDToken(token.JWT)
 	if err != nil {
 		return Credential{}, eris.Wrap(err, "Failed to get name from token")
 	}

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -30,7 +30,7 @@ type createOrgRequest struct {
 }
 
 func showOrganizationList(ctx context.Context) error {
-	organization, err := getSelectedOrganization(ctx)
+	selectedOrg, err := getSelectedOrganization(ctx)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get organization")
 	}
@@ -42,7 +42,7 @@ func showOrganizationList(ctx context.Context) error {
 
 	printer.NewLine(1)
 	printer.Headerln("  Organization Information  ")
-	if organization.Name == "" {
+	if selectedOrg.Name == "" {
 		printer.NewLine(1)
 		printer.Errorln("No organization selected")
 		printer.NewLine(1)
@@ -52,7 +52,7 @@ func showOrganizationList(ctx context.Context) error {
 		printer.Infoln(" Available Organizations: ")
 		printer.SectionDivider("-", 26)
 		for _, org := range organizations {
-			if org.ID == organization.ID {
+			if org.ID == selectedOrg.ID {
 				printer.Infof("• %s (%s) [SELECTED]\n", org.Name, org.Slug)
 			} else {
 				printer.Infof("  %s (%s)\n", org.Name, org.Slug)

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -79,14 +79,14 @@ func showProjectList(ctx context.Context) error {
 		return nil
 	}
 
-	project, err := getSelectedProject(ctx)
+	selectedProject, err := getSelectedProject(ctx)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get selected project")
 	}
 
 	printer.NewLine(1)
 	printer.Headerln("   Project Information   ")
-	if project.Name == "" {
+	if selectedProject.Name == "" {
 		printer.NewLine(1)
 		printer.Errorln("No project selected")
 		printer.NewLine(1)
@@ -96,7 +96,7 @@ func showProjectList(ctx context.Context) error {
 		printer.Infoln("  Available Projects:")
 		printer.SectionDivider("-", 23)
 		for _, prj := range projects {
-			if prj.ID == project.ID {
+			if prj.ID == selectedProject.ID {
 				printer.Infof("• %s (%s) [SELECTED]\n", prj.Name, prj.Slug)
 			} else {
 				printer.Infof("  %s (%s)\n", prj.Name, prj.Slug)
@@ -599,7 +599,7 @@ func selectProject(ctx context.Context) (*project, error) {
 }
 
 func deleteProject(ctx context.Context) error {
-	project, err := getSelectedProject(ctx)
+	selectedProject, err := getSelectedProject(ctx)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get project")
 	}
@@ -609,8 +609,8 @@ func deleteProject(ctx context.Context) error {
 	printer.Headerln("   Project Deletion   ")
 	printer.NewLine(1)
 	printer.Infoln("Project Details:")
-	printer.Infof("• Name: %s\n", project.Name)
-	printer.Infof("• Slug: %s\n", project.Slug)
+	printer.Infof("• Name: %s\n", selectedProject.Name)
+	printer.Infof("• Slug: %s\n", selectedProject.Slug)
 
 	// Warning message with fancy formatting
 	printer.NewLine(1)
@@ -622,7 +622,7 @@ func deleteProject(ctx context.Context) error {
 	printer.NewLine(1)
 
 	// Confirmation prompt with fancy formatting
-	deletePrompt := fmt.Sprintf("Type 'Yes' to confirm deletion of '%s': ", project.Name)
+	deletePrompt := fmt.Sprintf("Type 'Yes' to confirm deletion of '%s': ", selectedProject.Name)
 	confirmation := getInput(deletePrompt, "")
 
 	if confirmation != "Yes" {
@@ -636,7 +636,7 @@ func deleteProject(ctx context.Context) error {
 	}
 
 	// Send request
-	url := fmt.Sprintf(projectURLPattern, baseURL, project.OrgID) + "/" + project.ID
+	url := fmt.Sprintf(projectURLPattern, baseURL, selectedProject.OrgID) + "/" + selectedProject.ID
 	body, err := sendRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return eris.Wrap(err, "Failed to delete project")
@@ -651,7 +651,7 @@ func deleteProject(ctx context.Context) error {
 	printer.NewLine(1)
 	printer.Infoln("  Success!  ")
 	printer.SectionDivider("-", 12)
-	printer.Successf("Project deleted: %s (%s)\n", project.Name, project.Slug)
+	printer.Successf("Project deleted: %s (%s)\n", selectedProject.Name, selectedProject.Slug)
 
 	// Remove project from config
 	config, err := GetCurrentForgeConfig()

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -134,7 +134,7 @@ func loadConfigFromFile(filename string) (*Config, error) {
 			continue
 		}
 		for key, val := range m.(map[string]any) {
-			if _, ok := cfg.DockerEnv[key]; ok {
+			if _, okay := cfg.DockerEnv[key]; okay {
 				return nil, eris.Errorf("duplicate env variable %q", key)
 			}
 			cfg.DockerEnv[key] = fmt.Sprintf("%v", val)

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -117,7 +117,7 @@ func makeTempDir(t *testing.T) string {
 func TestConfigFromLocalFile(t *testing.T) {
 	tempdir := makeTempDir(t)
 
-	configFile := path.Join(tempdir, WorldCLIConfigFilename)
+	configFile := path.Join(tempdir, WorldCLIConfigFilename) //nolint:govet // test
 	makeConfigAtPath(t, configFile, "alpha")
 
 	cfg, err := GetConfig()
@@ -135,7 +135,7 @@ func TestLoadConfigLooksInParentDirectories(t *testing.T) {
 	assert.NilError(t, os.MkdirAll(deepPath, 0755))
 	assert.NilError(t, os.Chdir(deepPath))
 
-	configFile := path.Join(deepPath, WorldCLIConfigFilename)
+	configFile := path.Join(deepPath, WorldCLIConfigFilename) //nolint:govet // test
 	// The eventual call to LoadConfig should find this config file
 	makeConfigAtPath(t, configFile, "alpha")
 

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -432,18 +432,18 @@ func (c *Client) pullImages(ctx context.Context, services ...service.Service) er
 
 					// Check for errorDetail and error fields
 					if errorDetail, ok := event["errorDetail"]; ok {
-						if errorMessage, ok := errorDetail.(map[string]interface{})["message"]; ok {
+						if errorMessage, okay := errorDetail.(map[string]interface{})["message"]; okay {
 							errChan <- eris.New(errorMessage.(string))
 							continue
 						}
-					} else if errorMsg, ok := event["error"]; ok {
+					} else if errorMsg, okay := event["error"]; okay {
 						errChan <- eris.New(errorMsg.(string))
 						continue
 					}
 
 					// Handle progress updates
 					if progressDetail, ok := event["progressDetail"].(map[string]interface{}); ok {
-						if total, ok := progressDetail["total"].(float64); ok && total > 0 {
+						if total, okay := progressDetail["total"].(float64); okay && total > 0 {
 							calculatedCurrent := int(progressDetail["current"].(float64) * 100 / total)
 							if calculatedCurrent > current {
 								bar.SetCurrent(int64(calculatedCurrent))
@@ -549,18 +549,18 @@ func (c *Client) pushImages(ctx context.Context, pushTo string, authString strin
 
 					// Check for errorDetail and error fields
 					if errorDetail, ok := event["errorDetail"]; ok {
-						if errorMessage, ok := errorDetail.(map[string]interface{})["message"]; ok {
+						if errorMessage, okay := errorDetail.(map[string]interface{})["message"]; okay {
 							errChan <- eris.New(errorMessage.(string))
 							continue
 						}
-					} else if errorMsg, ok := event["error"]; ok {
+					} else if errorMsg, okay := event["error"]; okay {
 						errChan <- eris.New(errorMsg.(string))
 						continue
 					}
 
 					// Handle progress updates
 					if progressDetail, ok := event["progressDetail"].(map[string]interface{}); ok {
-						if total, ok := progressDetail["total"].(float64); ok && total > 0 {
+						if total, okay := progressDetail["total"].(float64); okay && total > 0 {
 							calculatedCurrent := int(progressDetail["current"].(float64) * 100 / total)
 							if calculatedCurrent > current {
 								bar.SetCurrent(int64(calculatedCurrent))


### PR DESCRIPTION
# Enable govet linter and fix variable shadowing issues

Closes: PLAT-365

## Overview

This PR enables the `govet` linter in the golangci configuration and fixes all the variable shadowing issues identified by the linter. Variable shadowing occurs when a variable in an inner scope has the same name as a variable in an outer scope, which can lead to subtle bugs.

## Brief Changelog

- Enabled the `govet` linter in `.golangci.yaml`
- Fixed variable shadowing issues by renaming variables:
  - Renamed shadowed `ok` variables to `okInner` or `okay` to avoid conflicts
  - Renamed shadowed object variables like `project`, `organization`, and `tokenStruct` to more descriptive names like `selectedProject`, `selectedOrg`, and `token`
- Added `//nolint:govet // test` comments to test files where shadowing is intentional

## Testing and Verifying

This change is a code cleanup that fixes potential bugs related to variable shadowing. The existing tests verify that the functionality remains unchanged after these fixes.

<!-- greptile_comment -->

## Greptile Summary

Enabled govet linter and fixed variable shadowing issues across the codebase to improve code clarity and prevent potential bugs from variable name conflicts.

- Added govet linter configuration in `.golangci.yaml` with strict shadow checking enabled
- Renamed shadowed variables like `ok` to `okInner`/`okay` in nested scopes across multiple files
- Renamed shadowed object variables to more descriptive names (e.g., `organization` -> `selectedOrg`)
- Added `//nolint:govet // test` comments for intentional shadowing in test files
- Excluded common err/ctx shadowing patterns in test files via linter configuration



<!-- /greptile_comment -->