### PR TITLE
feat: Enable reassign linter and add appropriate nolint directives

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -55,7 +55,7 @@ linters:
     - predeclared
     - promlinter
     - protogetter
-    # - reassign
+    - reassign
     # - recvcheck
     # - revive
     - rowserrcheck

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -135,6 +135,7 @@ func (s *ForgeTestSuite) SetupTest() { //nolint: cyclop, gocyclo // test, don't 
 
 	// Create temp config dir
 	tempDir = filepath.Join(os.TempDir(), "worldcli")
+	//nolint:reassign // Might cause issues with parallel tests
 	config.GetCLIConfigDir = func() (string, error) {
 		return tempDir, nil
 	}
@@ -159,7 +160,7 @@ func (s *ForgeTestSuite) TearDownTest() {
 	os.RemoveAll(tempDir)
 
 	// Restore original functions
-	config.GetCLIConfigDir = originalGetConfigDir
+	config.GetCLIConfigDir = originalGetConfigDir //nolint:reassign // Might cause issues with parallel tests
 }
 
 func (s *ForgeTestSuite) handleGetUser(w http.ResponseWriter, _ *http.Request) {
@@ -2404,11 +2405,13 @@ func (s *ForgeTestSuite) TestGetRoleInput() {
 			s.Require().NoError(err)
 
 			// Save original stdin
+
 			oldStdin := os.Stdin
+			//nolint:reassign // Might cause issues with parallel tests
 			defer func() { os.Stdin = oldStdin }()
 
 			// Set stdin to our test file
-			os.Stdin = tmpfile
+			os.Stdin = tmpfile //nolint:reassign // Might cause issues with parallel tests
 
 			// Test getInput
 			result := getRoleInput(tc.allowNone)
@@ -2480,9 +2483,10 @@ func (s *ForgeTestSuite) TestGetInput() {
 
 			// Save original stdin
 			oldStdin := os.Stdin
+			//nolint:reassign // Might cause issues with parallel tests
 			defer func() { os.Stdin = oldStdin }()
 			// Set stdin to our test file
-			os.Stdin = tmpfile
+			os.Stdin = tmpfile //nolint:reassign // Might cause issues with parallel tests
 
 			// Test getInput
 			result := getInput("test-prompt: ", tc.defaultInput)

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -29,7 +29,7 @@ var (
 
 func EnvVersionInit() {
 	env, version := getEnvAndVersion()
-	root.AppVersion = version
+	root.SetAppVersion(version)
 	// Initialize forge base environment
 	forge.InitForgeBase(env)
 }

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -51,7 +51,7 @@ type Release struct {
 // RootCmdInit initializes the root command.
 func RootCmdInit() {
 	// Enable case-insensitive commands
-	cobra.EnableCaseInsensitive = true
+	cobra.EnableCaseInsensitive = true //nolint:reassign // intentionally setting cobra global config as designed
 
 	// Disable printing usage help text when command returns a non-nil error
 	rootCmd.SilenceUsage = true

--- a/cmd/world/root/testing/root_test.go
+++ b/cmd/world/root/testing/root_test.go
@@ -244,17 +244,17 @@ func TestDev(t *testing.T) {
 
 func TestCheckLatestVersion(t *testing.T) {
 	t.Cleanup(func() {
-		root.AppVersion = ""
+		root.AppVersion = "" //nolint:reassign // Might cause issues with parallel tests
 	})
 
 	t.Run("success scenario", func(t *testing.T) {
-		root.AppVersion = "v1.0.0"
+		root.AppVersion = "v1.0.0" //nolint:reassign // Might cause issues with parallel tests
 		err := root.CheckLatestVersionTesting()
 		assert.NilError(t, err)
 	})
 
 	t.Run("error version format", func(t *testing.T) {
-		root.AppVersion = "wrong format"
+		root.AppVersion = "wrong format" //nolint:reassign // Might cause issues with parallel tests
 		err := root.CheckLatestVersionTesting()
 		assert.Error(t, err, "error parsing current version: Malformed version: wrong format")
 	})

--- a/cmd/world/root/version.go
+++ b/cmd/world/root/version.go
@@ -20,3 +20,7 @@ or verifying compatibility with World Engine features.`,
 		printer.Infof("World CLI %s\n", AppVersion)
 	},
 }
+
+func SetAppVersion(version string) {
+	AppVersion = version
+}

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -56,7 +56,7 @@ func NewClient(cfg *config.Config) (*Client, error) {
 	}
 
 	// Set BuildkitSupport
-	service.BuildkitSupport = checkBuildkitSupport(cli)
+	service.SetBuildkitSupport(checkBuildkitSupport(cli))
 
 	return &Client{
 		client: cli,

--- a/common/docker/service/service.go
+++ b/common/docker/service/service.go
@@ -35,6 +35,10 @@ type Service struct {
 	BuildTarget string
 }
 
+func SetBuildkitSupport(buildkitSupport bool) {
+	BuildkitSupport = buildkitSupport
+}
+
 func getExposedPorts(ports []int) nat.PortSet {
 	exposedPorts := make(nat.PortSet)
 	for _, port := range ports {

--- a/common/logger/init.go
+++ b/common/logger/init.go
@@ -1,3 +1,4 @@
+//nolint:reassign // customizing zerolog globals is safe and intentional for this CLI
 package logger
 
 import (


### PR DESCRIPTION
# Enable reassign linter and fix related issues

Closes: PLAT-367

## Overview

This PR enables the `reassign` linter in golangci-lint configuration and adds appropriate annotations to suppress warnings in test files where reassignment is necessary. It also introduces proper setter functions to avoid direct reassignment of package variables.

## Brief Changelog

- Enabled the `reassign` linter in `.golangci.yaml`
- Added `//nolint:reassign` annotations to test files where reassignment is necessary
- Created setter functions for global variables:
  - `SetAppVersion` in root package
  - `SetEnv` in globalconfig package
  - `SetBuildkitSupport` in docker service package
- Used the new setter functions instead of direct reassignment
- Fixed a typo in a comment in repo.go (GitHub → GitHb)

## Testing and Verifying

This change is a code cleanup that ensures we follow best practices by avoiding reassignment of package variables. The existing tests continue to pass with the new linter enabled.

<!-- greptile_comment -->

## Greptile Summary

Here's my review of the pull request:

Enables the reassign linter and introduces proper setter functions to manage package-level variables, improving code safety and maintainability across the world-cli codebase.

- Added `SetAppVersion`, `SetEnv`, and `SetBuildkitSupport` setter functions in `/cmd/world/root/version.go`, `/common/globalconfig/globalconfig.go`, and `/common/docker/service/service.go` respectively to properly encapsulate package variable modifications
- Added `//nolint:reassign` directives in test files with clear explanations for necessary test-specific reassignments
- Enabled reassign linter in `.golangci.yaml` with pattern `.*` to catch all variable reassignments
- Fixed typo in `/cmd/world/forge/repo.go` comment (GitHb → GitHub)
- Updated direct package variable assignments to use new setter functions throughout codebase



<!-- /greptile_comment -->