### PR TITLE
fix: Use pointer receivers for methods to avoid copying

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,7 +56,7 @@ linters:
     - promlinter
     - protogetter
     - reassign
-    # - recvcheck
+    - recvcheck
     # - revive
     - rowserrcheck
     - sloglint

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -175,7 +175,7 @@ func getToken(ctx context.Context, url string, argusid bool, result interface{})
 		Cancel:  cancel,
 	}
 	spin.SetText("Logging in...")
-	p := tea.NewProgram(spin)
+	p := tea.NewProgram(&spin)
 
 	// Run the spinner in a goroutine
 	go func() {

--- a/common/login/login.go
+++ b/common/login/login.go
@@ -49,12 +49,12 @@ func (enc *Encryption) generateKeys() error {
 }
 
 // encodedPublicKey returns the public key as a hex string.
-func (enc Encryption) EncodedPublicKey() string {
+func (enc *Encryption) EncodedPublicKey() string {
 	return hex.EncodeToString(enc.publicKey.Bytes())
 }
 
 // decryptAccessToken decrypts the access token using the private key and nonce.
-func (enc Encryption) DecryptAccessToken(accessToken string, publicKey string, nonce string) (string, error) {
+func (enc *Encryption) DecryptAccessToken(accessToken string, publicKey string, nonce string) (string, error) {
 	decodedAccessToken, err := hex.DecodeString(accessToken)
 	if err != nil {
 		return "", eris.Wrap(err, decryptionErrorMsg)

--- a/tea/component/spinner/spinner.go
+++ b/tea/component/spinner/spinner.go
@@ -21,13 +21,13 @@ type Spinner struct {
 type LogMsg string
 
 // Init is called when the program starts and returns the initial command.
-func (s Spinner) Init() tea.Cmd {
+func (s *Spinner) Init() tea.Cmd {
 	// Start the spinner
 	return s.Spinner.Tick
 }
 
 // Update handles incoming messages.
-func (s Spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (s *Spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// case ctrl + c
@@ -54,7 +54,7 @@ func (s Spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // View renders the UI.
-func (s Spinner) View() string {
+func (s *Spinner) View() string {
 	if s.done {
 		return "Build completed!"
 	}


### PR DESCRIPTION
# Enable `recvcheck` linter and fix receiver type issues

Closes: PLAT-368

## Overview

This PR enables the `recvcheck` linter in golangci-lint configuration and fixes several receiver type issues in the codebase where value receivers should be pointer receivers.

## Brief Changelog

- Enabled the `recvcheck` linter in `.golangci.yaml`
- Fixed receiver types in `common/login/login.go` to use pointer receivers for `EncodedPublicKey` and `DecryptAccessToken` methods
- Fixed receiver types in `tea/component/spinner/spinner.go` to use pointer receivers for all methods
- Updated `tea.NewProgram` call in `cmd/world/forge/login.go` to pass a pointer to the spinner

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The changes ensure that methods that should use pointer receivers do so, which improves performance by avoiding unnecessary copying of structs.

<!-- greptile_comment -->

## Greptile Summary

Enabled the `recvcheck` linter and fixed receiver type issues across multiple files to improve performance by avoiding unnecessary struct copying.

- Enabled `recvcheck` linter in `.golangci.yaml` configuration
- Changed `EncodedPublicKey` and `DecryptAccessToken` methods to use pointer receivers in `common/login/login.go`
- Updated all `Spinner` methods to use pointer receivers in `tea/component/spinner/spinner.go`
- Modified `tea.NewProgram` to pass spinner pointer in `cmd/world/forge/login.go`



<!-- /greptile_comment -->