### PR TITLE
refactor: Enable revive linter and clean up code style issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,7 +57,7 @@ linters:
     - protogetter
     - reassign
     - recvcheck
-    # - revive
+    - revive
     - rowserrcheck
     - sloglint
     - spancheck

--- a/cmd/world/evm/start.go
+++ b/cmd/world/evm/start.go
@@ -73,7 +73,7 @@ to run with a local development data availability layer.`,
 	},
 }
 
-func EvmInit() {
+func Init() {
 	startCmd.Flags().String(FlagDAAuthToken, "",
 		"DA Auth Token that allows the rollup to communicate with the Celestia client.")
 	startCmd.Flags().Bool(FlagUseDevDA, false, "Use a locally running DA layer")

--- a/cmd/world/forge/config.go
+++ b/cmd/world/forge/config.go
@@ -18,7 +18,7 @@ const (
 	forgeConfigFileName = "forgeconfig.json"
 )
 
-type ForgeConfig struct {
+type Config struct {
 	OrganizationID string         `json:"organization_id"`
 	ProjectID      string         `json:"project_id"`
 	Credential     Credential     `json:"credential"`
@@ -31,8 +31,8 @@ type ForgeConfig struct {
 	CurrProjectName string `json:"-"`
 }
 
-func GetForgeConfig() (ForgeConfig, error) {
-	var config ForgeConfig
+func GetForgeConfig() (Config, error) {
+	var config Config
 
 	fullConfigDir, err := commonConfig.GetCLIConfigDir()
 	if err != nil {
@@ -60,7 +60,7 @@ func GetForgeConfig() (ForgeConfig, error) {
 	return config, nil
 }
 
-func GetCurrentForgeConfig() (ForgeConfig, error) {
+func GetCurrentForgeConfig() (Config, error) {
 	currConfig, err := GetForgeConfig()
 	// we deliberately ignore any error here and just return it at the end
 	// so that we can fill out and much info as we do have
@@ -104,7 +104,7 @@ func FindGitPathAndURL() (string, string, error) {
 	return path, url, nil
 }
 
-func SaveForgeConfig(globalConfig ForgeConfig) error {
+func SaveForgeConfig(globalConfig Config) error {
 	fullConfigDir, err := commonConfig.GetCLIConfigDir()
 	if err != nil {
 		return eris.Wrap(err, "failed to get config dir")

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -42,7 +42,7 @@ type deploymentPreview struct {
 }
 
 // Deployment a project.
-func deployment(ctx context.Context, cmdState *ForgeCommandState, deployType string) error {
+func deployment(ctx context.Context, cmdState *CommandState, deployType string) error {
 	if cmdState.Organization == nil || cmdState.Organization.ID == "" {
 		printNoSelectedOrganization()
 		return nil
@@ -115,7 +115,7 @@ func deployment(ctx context.Context, cmdState *ForgeCommandState, deployType str
 }
 
 //nolint:funlen, gocognit, gocyclo, cyclop // this is actually a straightforward function with a lot of error handling
-func status(ctx context.Context, cmdState *ForgeCommandState) error {
+func status(ctx context.Context, cmdState *CommandState) error {
 	if cmdState.Project == nil || cmdState.Project.ID == "" {
 		printNoSelectedProject()
 		return nil

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -143,7 +143,7 @@ func (s *ForgeTestSuite) SetupTest() { //nolint: cyclop, gocyclo // test, don't 
 	s.Require().NoError(err)
 
 	// Create config file
-	err = SaveForgeConfig(ForgeConfig{
+	err = SaveForgeConfig(Config{
 		OrganizationID: "test-org-id",
 		ProjectID:      "test-project-id",
 		Credential: Credential{
@@ -554,13 +554,13 @@ func (s *ForgeTestSuite) writeJSONString(w http.ResponseWriter, data string) {
 func (s *ForgeTestSuite) TestGetSelectedOrganization() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		expectedError bool
 		expectedOrg   *organization
 	}{
 		{
 			name: "Success - Valid organization",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -575,7 +575,7 @@ func (s *ForgeTestSuite) TestGetSelectedOrganization() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -586,7 +586,7 @@ func (s *ForgeTestSuite) TestGetSelectedOrganization() {
 		},
 		{
 			name:          "Error - No organization selected",
-			config:        ForgeConfig{},
+			config:        Config{},
 			expectedError: false,
 			expectedOrg:   nil,
 		},
@@ -618,13 +618,13 @@ func (s *ForgeTestSuite) TestGetSelectedOrganization() {
 func (s *ForgeTestSuite) TestGetSelectedProject() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		expectedError bool
 		expectedProj  *project
 	}{
 		{
 			name: "Success - Valid project",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				ProjectID:      "test-project-id",
 				Credential: Credential{
@@ -642,7 +642,7 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 		},
 		{
 			name: "Error - Invalid project ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				ProjectID:      "invalid-project-id",
 				Credential: Credential{
@@ -654,7 +654,7 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 		},
 		{
 			name: "Error - No organization selected",
-			config: ForgeConfig{
+			config: Config{
 				ProjectID: "test-project-id",
 			},
 			expectedError: false,
@@ -662,7 +662,7 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 		},
 		{
 			name: "Error - No project selected",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 			},
 			expectedError: false,
@@ -753,14 +753,14 @@ func (s *ForgeTestSuite) TestIsAlphanumeric() {
 func (s *ForgeTestSuite) TestDeploy() {
 	testCases := []struct {
 		name                string
-		state               *ForgeCommandState
+		state               *CommandState
 		inputs              []string     // For name, slug, repoURL, repoToken
 		regionSelectActions []tea.KeyMsg // Simulate region selection
 		expectedError       bool
 	}{
 		{
 			name: "Success - Valid deployment",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -776,7 +776,7 @@ func (s *ForgeTestSuite) TestDeploy() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "invalid-org-id",
 				},
@@ -792,7 +792,7 @@ func (s *ForgeTestSuite) TestDeploy() {
 		},
 		{
 			name: "Error - Invalid project ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -808,7 +808,7 @@ func (s *ForgeTestSuite) TestDeploy() {
 		},
 		{
 			name: "Error - No organization selected",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "test-project-id",
 				},
@@ -820,7 +820,7 @@ func (s *ForgeTestSuite) TestDeploy() {
 		},
 		{
 			name: "Success - No project selected (creates new project)",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -903,12 +903,12 @@ func (s *ForgeTestSuite) TestDeploy() {
 func (s *ForgeTestSuite) TestStatus() {
 	testCases := []struct {
 		name          string
-		state         *ForgeCommandState
+		state         *CommandState
 		expectedError bool
 	}{
 		{
 			name: "Success - Valid deployment",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "test-project-id",
 				},
@@ -920,7 +920,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Success - Valid undeployed project",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "undeployed-project-id",
 				},
@@ -932,7 +932,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Success - Valid failed build project",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "failedbuild-project-id",
 				},
@@ -944,7 +944,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Success - Valid destroyed project",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "destroyed-project-id",
 				},
@@ -956,7 +956,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Success - Valid reset project",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "reset-project-id",
 				},
@@ -968,7 +968,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Error - Invalid project ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "invalid-project-id",
 				},
@@ -980,7 +980,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Error - No organization selected",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "test-project-id",
 				},
@@ -992,7 +992,7 @@ func (s *ForgeTestSuite) TestStatus() {
 		},
 		{
 			name: "Error - No project selected",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -1019,13 +1019,13 @@ func (s *ForgeTestSuite) TestStatus() {
 func (s *ForgeTestSuite) TestDestroy() {
 	testCases := []struct {
 		name          string
-		state         *ForgeCommandState
+		state         *CommandState
 		input         string // Simulated user input for confirmation
 		expectedError bool
 	}{
 		{
 			name: "Success - Valid destroy with confirmation",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -1041,7 +1041,7 @@ func (s *ForgeTestSuite) TestDestroy() {
 		},
 		{
 			name: "Success - Cancelled destroy",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -1057,7 +1057,7 @@ func (s *ForgeTestSuite) TestDestroy() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "invalid-org-id",
 				},
@@ -1073,7 +1073,7 @@ func (s *ForgeTestSuite) TestDestroy() {
 		},
 		{
 			name: "Error - No organization selected",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "test-project-id",
 				},
@@ -1120,13 +1120,13 @@ func (s *ForgeTestSuite) TestDestroy() {
 func (s *ForgeTestSuite) TestReset() {
 	testCases := []struct {
 		name          string
-		state         *ForgeCommandState
+		state         *CommandState
 		input         string
 		expectedError bool
 	}{
 		{
 			name: "Success",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -1142,7 +1142,7 @@ func (s *ForgeTestSuite) TestReset() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "invalid-org-id",
 				},
@@ -1158,7 +1158,7 @@ func (s *ForgeTestSuite) TestReset() {
 		},
 		{
 			name: "Error - Invalid project ID",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Organization: &organization{
 					ID: "test-org-id",
 				},
@@ -1174,7 +1174,7 @@ func (s *ForgeTestSuite) TestReset() {
 		},
 		{
 			name: "Error - No organization selected",
-			state: &ForgeCommandState{
+			state: &CommandState{
 				Project: &project{
 					ID: "test-project-id",
 				},
@@ -1426,13 +1426,13 @@ func (s *ForgeTestSuite) TestLogin() {
 func (s *ForgeTestSuite) TestGetListOfProjects() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		expectedError bool
 		expectedLen   int
 	}{
 		{
 			name: "Success - Valid organization with projects",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1443,7 +1443,7 @@ func (s *ForgeTestSuite) TestGetListOfProjects() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1454,7 +1454,7 @@ func (s *ForgeTestSuite) TestGetListOfProjects() {
 		},
 		{
 			name:          "Error - No organization selected",
-			config:        ForgeConfig{},
+			config:        Config{},
 			expectedError: false,
 			expectedLen:   0,
 		},
@@ -1481,7 +1481,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 	testCases := []struct {
 		name          string
 		operation     string // "list", "get", "select"
-		config        ForgeConfig
+		config        Config
 		input         string // for select operation
 		expectedError bool
 		expectedOrgs  int // for list operation
@@ -1489,7 +1489,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 		{
 			name:      "Success - List organizations",
 			operation: "list",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -1500,7 +1500,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 		{
 			name:      "Success - Get selected organization",
 			operation: "get",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1511,7 +1511,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 		{
 			name:      "Success - Select organization",
 			operation: "select",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -1522,7 +1522,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 		{
 			name:      "Error - Get invalid organization",
 			operation: "get",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1544,7 +1544,7 @@ func (s *ForgeTestSuite) TestOrganizationOperations() {
 		{
 			name:      "Error - Select cancelled",
 			operation: "select",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -1780,12 +1780,12 @@ func (s *ForgeTestSuite) TestCreateOrganization() {
 func (s *ForgeTestSuite) TestShowOrganizationList() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		expectedError bool
 	}{
 		{
 			name: "Success - Show organization list with selected org",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1795,7 +1795,7 @@ func (s *ForgeTestSuite) TestShowOrganizationList() {
 		},
 		{
 			name: "Success - Show organization list without selected org",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -1804,7 +1804,7 @@ func (s *ForgeTestSuite) TestShowOrganizationList() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1832,12 +1832,12 @@ func (s *ForgeTestSuite) TestShowOrganizationList() {
 func (s *ForgeTestSuite) TestShowProjectList() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		expectedError bool
 	}{
 		{
 			name: "Success - Show project list with selected project",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				ProjectID:      "test-project-id",
 				Credential: Credential{
@@ -1848,7 +1848,7 @@ func (s *ForgeTestSuite) TestShowProjectList() {
 		},
 		{
 			name: "Success - Show project list without selected project",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1858,7 +1858,7 @@ func (s *ForgeTestSuite) TestShowProjectList() {
 		},
 		{
 			name: "Success - Empty project list",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "empty-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1868,7 +1868,7 @@ func (s *ForgeTestSuite) TestShowProjectList() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				ProjectID:      "test-project-id",
 				Credential: Credential{
@@ -1879,7 +1879,7 @@ func (s *ForgeTestSuite) TestShowProjectList() {
 		},
 		{
 			name: "Error - Invalid project ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				ProjectID:      "invalid-project-id",
 				Credential: Credential{
@@ -1908,7 +1908,7 @@ func (s *ForgeTestSuite) TestShowProjectList() {
 func (s *ForgeTestSuite) TestCreateProject() {
 	testCases := []struct {
 		name                string
-		config              ForgeConfig
+		config              Config
 		inputs              []string     // For name, slug, repoURL, repoToken
 		regionSelectActions []tea.KeyMsg // Simulate region selection
 		expectInputFail     int
@@ -1918,7 +1918,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 	}{
 		{
 			name: "Success - Public repo default slug",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1953,7 +1953,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Success - public repo custom slug",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -1988,7 +1988,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Abort - user presses q in region selector",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2011,7 +2011,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Error - private repo bad token",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2028,7 +2028,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Error - No organization selected",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2039,7 +2039,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2056,7 +2056,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Error - Invalid project slug",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2072,7 +2072,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Error - Invalid repo URL",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2090,7 +2090,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		},
 		{
 			name: "Success - Project name from world.toml",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2230,14 +2230,14 @@ PROJECT_NAME = "test-project-from-toml"
 func (s *ForgeTestSuite) TestSelectProject() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		input         string
 		expectedError bool
 		expectedProj  *project
 	}{
 		{
 			name: "Success - Valid project selection",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2255,7 +2255,7 @@ func (s *ForgeTestSuite) TestSelectProject() {
 		},
 		{
 			name: "Success - Cancel selection with 'q'",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2267,7 +2267,7 @@ func (s *ForgeTestSuite) TestSelectProject() {
 		},
 		{
 			name: "Error - Empty project list",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "empty-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2291,7 +2291,7 @@ func (s *ForgeTestSuite) TestSelectProject() {
 		}, */
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2498,14 +2498,14 @@ func (s *ForgeTestSuite) TestGetInput() {
 func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 	testCases := []struct {
 		name            string
-		config          ForgeConfig
+		config          Config
 		inputs          []string // For user id, role
 		expectInputFail int
 		expectedError   bool
 	}{
 		{
 			name: "Success - Default role",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2520,7 +2520,7 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 		},
 		{
 			name: "Success - admin role",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2535,7 +2535,7 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 		},
 		{
 			name: "Error - No organization selected",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2546,7 +2546,7 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2561,7 +2561,7 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 		},
 		{
 			name: "Error - Invalid Role: None",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2622,14 +2622,14 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 	testCases := []struct {
 		name            string
-		config          ForgeConfig
+		config          Config
 		inputs          []string // For user id, role
 		expectInputFail int
 		expectedError   bool
 	}{
 		{
 			name: "Success - Default role",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2644,7 +2644,7 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 		},
 		{
 			name: "Success - admin role",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2659,7 +2659,7 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 		},
 		{
 			name: "Success - none with confirm remove",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2675,7 +2675,7 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 		},
 		{
 			name: "Error - No organization selected",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2686,7 +2686,7 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 		},
 		{
 			name: "Error - Invalid organization ID",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "invalid-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2701,7 +2701,7 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 		},
 		{
 			name: "Error - Role none dont confirm remove",
-			config: ForgeConfig{
+			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
 					Token: "test-token",
@@ -2939,16 +2939,16 @@ func (s *ForgeTestSuite) TestFindGitPathAndURL() {
 func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 	testCases := []struct {
 		name          string
-		config        ForgeConfig
+		config        Config
 		loginReq      LoginStepRequirement
 		orgReq        StepRequirement
 		projectReq    StepRequirement
 		expectedError bool
-		checkState    func(*ForgeCommandState)
+		checkState    func(*CommandState)
 	}{
 		{
 			name: "Success - Ignore all requirements",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2957,7 +2957,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        Ignore,
 			projectReq:    Ignore,
 			expectedError: false,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.Nil(state.User)
 				s.Nil(state.Organization)
 				s.Nil(state.Project)
@@ -2965,7 +2965,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Success - Need login and have token",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2974,7 +2974,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        Ignore,
 			projectReq:    Ignore,
 			expectedError: false,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.Nil(state.Organization)
 				s.Nil(state.Project)
@@ -2982,7 +2982,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Success - Need org ID and have it",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -2992,7 +2992,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        NeedIDOnly,
 			projectReq:    Ignore,
 			expectedError: false,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.NotNil(state.Organization)
 				s.Equal("test-org-id", state.Organization.ID)
@@ -3001,7 +3001,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Success - Need project ID and have it",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -3013,7 +3013,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        NeedIDOnly,
 			projectReq:    NeedIDOnly,
 			expectedError: false,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.NotNil(state.Organization)
 				s.Equal("test-org-id", state.Organization.ID)
@@ -3024,7 +3024,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Error - Need login but no token",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "",
 				},
@@ -3033,7 +3033,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        Ignore,
 			projectReq:    Ignore,
 			expectedError: true,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.Nil(state.User)
 				s.Nil(state.Organization)
 				s.Nil(state.Project)
@@ -3041,7 +3041,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Error - Must not have org but have org ID",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -3051,7 +3051,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        MustNotExist,
 			projectReq:    Ignore,
 			expectedError: true,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.Nil(state.Organization)
 				s.Nil(state.Project)
@@ -3059,7 +3059,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Error - Must not have project but have project ID",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -3070,7 +3070,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        NeedIDOnly,
 			projectReq:    MustNotExist,
 			expectedError: true,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.Nil(state.Organization)
 				s.Nil(state.Project)
@@ -3078,7 +3078,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 		},
 		{
 			name: "Success - Need repo lookup and have URL",
-			config: ForgeConfig{
+			config: Config{
 				Credential: Credential{
 					Token: "test-token",
 				},
@@ -3091,7 +3091,7 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 			orgReq:        NeedIDOnly,
 			projectReq:    NeedIDOnly,
 			expectedError: false,
-			checkState: func(state *ForgeCommandState) {
+			checkState: func(state *CommandState) {
 				s.NotNil(state.User)
 				s.NotNil(state.Organization)
 				s.NotNil(state.Project)
@@ -3132,7 +3132,7 @@ func (s *ForgeTestSuite) TestGetForgeCommandState() {
 	})
 
 	// Test that GetForgeCommandState returns the correct state after setup
-	config := ForgeConfig{
+	config := Config{
 		Credential: Credential{
 			Token: "test-token",
 		},
@@ -3148,7 +3148,7 @@ func (s *ForgeTestSuite) TestGetForgeCommandState() {
 }
 
 func (s *ForgeTestSuite) TestAddKnownProject() {
-	config := &ForgeConfig{
+	config := &Config{
 		KnownProjects: []KnownProject{},
 	}
 

--- a/cmd/world/forge/initflow.go
+++ b/cmd/world/forge/initflow.go
@@ -13,8 +13,8 @@ import (
 
 // initFlow represents the initialization flow for the forge system.
 type initFlow struct {
-	config               ForgeConfig
-	State                ForgeCommandState
+	config               Config
+	State                CommandState
 	requiredLogin        LoginStepRequirement
 	requiredOrganization StepRequirement
 	requiredProject      StepRequirement
@@ -67,7 +67,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 	loginReq LoginStepRequirement,
 	orgReq StepRequirement,
 	projectReq StepRequirement,
-) (*ForgeCommandState, error) {
+) (*CommandState, error) {
 	config, err := GetCurrentForgeConfig()
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 		loginStepDone:        false,
 		organizationStepDone: false,
 		projectStepDone:      false,
-		State: ForgeCommandState{
+		State: CommandState{
 			Command:      cmd,
 			User:         nil,
 			Organization: nil,
@@ -120,19 +120,19 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 			return &flow.State, err
 		}
 	}
-	needOrgIdOnly := flow.requiredOrganization == NeedIDOnly || flow.requiredOrganization == NeedExistingIDOnly
-	needProjectIdOnly := flow.requiredProject == NeedIDOnly || flow.requiredProject == NeedExistingIDOnly
-	haveOrgId := flow.config.OrganizationID != ""
-	haveProjectId := flow.config.ProjectID != ""
+	needOrgIDOnly := flow.requiredOrganization == NeedIDOnly || flow.requiredOrganization == NeedExistingIDOnly
+	needProjectIDOnly := flow.requiredProject == NeedIDOnly || flow.requiredProject == NeedExistingIDOnly
+	haveOrgID := flow.config.OrganizationID != ""
+	haveProjectID := flow.config.ProjectID != ""
 
 	switch {
 	// check for conditions where we can exit early without asking the user for anything
 
-	case flow.requiredOrganization == MustNotExist && haveOrgId:
+	case flow.requiredOrganization == MustNotExist && haveOrgID:
 		// ERROR: we have an org id, but we need to not belong to any org
 		return &flow.State, errors.New("organization already exists")
 
-	case flow.requiredProject == MustNotExist && haveProjectId:
+	case flow.requiredProject == MustNotExist && haveProjectID:
 		// ERROR: we have a project id, but we need to not belong to any project
 		return &flow.State, errors.New("project already exists")
 
@@ -142,7 +142,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 		return &flow.State, nil // everything is as it should be
 
 		// check for only needing IDs and we have them
-	case needOrgIdOnly && haveOrgId && needProjectIdOnly && haveProjectId:
+	case needOrgIDOnly && haveOrgID && needProjectIDOnly && haveProjectID:
 		flow.State.Organization = &organization{
 			ID: flow.config.OrganizationID,
 		}
@@ -157,7 +157,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 
 	// FIXME: handle the errors coming back from the handleX() functions
 	// now make sure we get the org info
-	if haveOrgId && needOrgIdOnly {
+	if haveOrgID && needOrgIDOnly {
 		flow.State.Organization = &organization{
 			ID: flow.config.OrganizationID,
 		}
@@ -176,7 +176,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 	}
 
 	// now get the project info
-	if haveProjectId && needProjectIdOnly {
+	if haveProjectID && needProjectIDOnly {
 		flow.State.Project = &project{
 			ID:   flow.config.ProjectID,
 			Name: flow.config.CurrProjectName,
@@ -196,7 +196,7 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 }
 
 // so you can get the state from anywhere.
-func GetForgeCommandState() *ForgeCommandState {
+func GetForgeCommandState() *CommandState {
 	if flow == nil {
 		// this is a logic error so we want to have it fail fast and loudly
 		panic("SetupForgeCommandState must be called before GetForgeCommandState")
@@ -209,7 +209,7 @@ func GetForgeCommandState() *ForgeCommandState {
 // it returns nil if the project is found and the config is updated
 // if the lookup worked but there is no matching project, it will return nil
 // and the config will not be changed.
-func doRepoLookup(ctx context.Context, config *ForgeConfig) error {
+func doRepoLookup(ctx context.Context, config *Config) error {
 	// needed a repo lookup, and we are logged in, so try to lookup the project
 	deployURL := fmt.Sprintf("%s/api/project/?url=%s&path=%s",
 		baseURL, url.QueryEscape(config.CurrRepoURL), url.QueryEscape(config.CurrRepoPath))
@@ -244,7 +244,7 @@ func doRepoLookup(ctx context.Context, config *ForgeConfig) error {
 	return nil
 }
 
-func AddKnownProject(config *ForgeConfig, proj *project) {
+func AddKnownProject(config *Config, proj *project) {
 	config.KnownProjects = append(config.KnownProjects, KnownProject{
 		ProjectID:      proj.ID,
 		OrganizationID: proj.OrgID,

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -60,7 +60,7 @@ func login(ctx context.Context) error {
 	return nil
 }
 
-func performLogin(ctx context.Context, config *ForgeConfig) error {
+func performLogin(ctx context.Context, config *Config) error {
 	var err error
 	if argusid {
 		config.Credential, err = loginWithArgusID(ctx)
@@ -82,7 +82,7 @@ func performLogin(ctx context.Context, config *ForgeConfig) error {
 	return nil
 }
 
-func handleArgusIDPostLogin(ctx context.Context, config *ForgeConfig) error {
+func handleArgusIDPostLogin(ctx context.Context, config *Config) error {
 	user, err := getUser(ctx)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get user")
@@ -92,14 +92,14 @@ func handleArgusIDPostLogin(ctx context.Context, config *ForgeConfig) error {
 	return SaveForgeConfig(*config)
 }
 
-func handlePostLoginConfig(ctx context.Context, config *ForgeConfig) error {
+func handlePostLoginConfig(ctx context.Context, config *Config) error {
 	if config.CurrRepoKnown {
 		return handleKnownRepoConfig(ctx, config)
 	}
 	return handleNewRepoConfig(ctx, config)
 }
 
-func handleKnownRepoConfig(ctx context.Context, config *ForgeConfig) error {
+func handleKnownRepoConfig(ctx context.Context, config *Config) error {
 	proj, err := getSelectedProject(ctx)
 	if err != nil {
 		printer.Infof("⚠️ Warning: Failed to get project %s: %s", config.ProjectID, err.Error())
@@ -116,7 +116,7 @@ func handleKnownRepoConfig(ctx context.Context, config *ForgeConfig) error {
 	return nil
 }
 
-func handleNewRepoConfig(ctx context.Context, config *ForgeConfig) error {
+func handleNewRepoConfig(ctx context.Context, config *Config) error {
 	// Handle organization selection
 	orgID, err := handleOrganizationSelection(ctx, config.OrganizationID)
 	if err != nil {
@@ -148,7 +148,7 @@ func handleNewRepoConfig(ctx context.Context, config *ForgeConfig) error {
 	return showProjectList(ctx)
 }
 
-func displayLoginSuccess(config ForgeConfig) {
+func displayLoginSuccess(config Config) {
 	printer.NewLine(1)
 	printer.Headerln("   Login successful!  ")
 	printer.NewLine(1)

--- a/cmd/world/forge/types.go
+++ b/cmd/world/forge/types.go
@@ -10,7 +10,7 @@ type Credential struct {
 	Name  string `json:"name"`
 }
 
-type ForgeCommandState struct {
+type CommandState struct {
 	Command      *cobra.Command
 	User         *User
 	Organization *organization

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -79,10 +79,10 @@ func main() {
 	telemetry.PosthogCaptureEvent(root.AppVersion, telemetry.RunningEvent)
 
 	// Initialize packages
-	evm.EvmInit()
+	evm.Init()
 	cardinal.Init()
 	forge.InitForgeCmds()
-	root.RootCmdInit()
+	root.CmdInit()
 	root.Execute()
 }
 

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -97,9 +97,8 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.depStatusErr = msg.Err
 		if msg.Err != nil {
 			return m, tea.Quit
-		} else {
-			return m, nil
 		}
+		return m, nil
 
 	case tea.KeyMsg: //nolint:exhaustive // not applicable
 		switch msg.Type {

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -48,8 +48,8 @@ type Release struct {
 	HTMLURL string `json:"html_url"`
 }
 
-// RootCmdInit initializes the root command.
-func RootCmdInit() {
+// CmdInit initializes the root command.
+func CmdInit() {
 	// Enable case-insensitive commands
 	cobra.EnableCaseInsensitive = true //nolint:reassign // intentionally setting cobra global config as designed
 

--- a/cmd/world/root/testing/root_test.go
+++ b/cmd/world/root/testing/root_test.go
@@ -31,8 +31,8 @@ type testEnvironment struct {
 func setupTestEnv() *testEnvironment {
 	// Initialize all commands
 	cardinal.Init()
-	evm.EvmInit()
-	root.RootCmdInit()
+	evm.Init()
+	root.CmdInit()
 
 	return &testEnvironment{
 		rootCmd: root.RootCmdTesting,

--- a/tea/component/steps/steps.go
+++ b/tea/component/steps/steps.go
@@ -65,11 +65,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if m.index == len(m.Steps)-1 {
 			// Send a signal that all the steps have been finished
 			return m, tea.Sequence(m.SignalStepCompletedCmd(m.index), m.SignalAllStepCompletedCmd())
-		} else {
-			m.index++
-			// Send a signal that the current step has been completed and the next step has started
-			return m, tea.Sequence(m.SignalStepCompletedCmd(m.index-1), m.SignalStepStartedCmd(m.index))
 		}
+		m.index++
+		// Send a signal that the current step has been completed and the next step has started
+		return m, tea.Sequence(m.SignalStepCompletedCmd(m.index-1), m.SignalStepStartedCmd(m.index))
+
 	default:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)


### PR DESCRIPTION
# Enable revive linter and refactor code to fix style issues

Closes: PLAT-369

## Overview

This PR enables the `revive` linter in the golangci configuration and refactors code to address style issues identified by the linter.

## Brief Changelog

- Enabled the `revive` linter in `.golangci.yaml`
- Renamed functions to follow consistent naming conventions:
  - `EvmInit()` → `Init()` in evm package
  - `RootCmdInit()` → `CmdInit()` in root package
- Simplified conditional logic by removing unnecessary else blocks in:
  - `cmd/world/root/create.go`
  - `tea/component/steps/steps.go`

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The changes maintain the same functionality while improving code style.

<!-- greptile_comment -->

## Greptile Summary

Enabled the revive linter in golangci configuration and refactored code to improve style consistency across the World CLI codebase.

- Enabled `revive` linter in `.golangci.yaml` with appropriate test file exclusions
- Renamed initialization functions for consistency: `EvmInit()` → `Init()` and `RootCmdInit()` → `CmdInit()`
- Removed unnecessary else blocks in `cmd/world/root/create.go` and `tea/component/steps/steps.go` for better readability
- Updated test files to match renamed function calls while maintaining existing test coverage



<!-- /greptile_comment -->