### PR TITLE
feat: Enable testifylint and fix test assertions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,7 +64,7 @@ linters:
     - sqlclosecheck
     - staticcheck
     - testableexamples
-    # - testifylint
+    - testifylint
     # - testpackage
     - tparallel
     - unconvert

--- a/cmd/world/forge/forge_test.go
+++ b/cmd/world/forge/forge_test.go
@@ -254,12 +254,12 @@ func (s *ForgeTestSuite) handleOrganizationGet(w http.ResponseWriter, r *http.Re
 func (s *ForgeTestSuite) handleProjectList(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		parsedBody, err := io.ReadAll(r.Body)
-		s.Require().NoError(err)
+		s.NoError(err)
 		defer r.Body.Close()
 
 		body := map[string]interface{}{}
 		err = json.Unmarshal(parsedBody, &body)
-		s.Require().NoError(err)
+		s.NoError(err)
 
 		proj := project{
 			ID:      "test-project-id",
@@ -3114,9 +3114,9 @@ func (s *ForgeTestSuite) TestSetupForgeCommandState() {
 
 			// Check error
 			if tc.expectedError {
-				s.Error(err)
+				s.Require().Error(err)
 			} else {
-				s.NoError(err)
+				s.Require().NoError(err)
 			}
 
 			// Check state

--- a/common/tomlutil/toml_test.go
+++ b/common/tomlutil/toml_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,7 +21,7 @@ func (s *TOMLTestSuite) SetupTest() {
 func (s *TOMLTestSuite) createTestFile(content string) string {
 	tmpFile := filepath.Join(s.tempDir, "test.toml")
 	err := os.WriteFile(tmpFile, []byte(content), 0644)
-	require.NoError(s.T(), err, "Failed to create test file")
+	s.Require().NoError(err, "Failed to create test file")
 	return tmpFile
 }
 
@@ -136,7 +135,7 @@ number = 42
 
 	// Test getting non-existent section
 	_, err = GetTOMLSection(tmpFile, "nonexistent")
-	s.Error(err)
+	s.Require().Error(err)
 
 	// Test getting empty section
 	emptySection, err := GetTOMLSection(tmpFile, "empty")


### PR DESCRIPTION
# Enable testifylint and fix test assertions

Closes: PLAT-370

## Overview

This PR enables the `testifylint` linter in our golangci configuration and fixes test assertions to comply with the linter's recommendations.

## Brief Changelog

- Enabled `testifylint` in `.golangci.yaml`
- Updated test assertions in `cmd/world/forge/forge_test.go` to use `NoError` instead of `Require().NoError` where appropriate
- Fixed assertions in `common/tomlutil/toml_test.go` to use `Require().NoError` and `Require().Error` for consistent error handling
- Removed unused import of `github.com/stretchr/testify/require` in `common/tomlutil/toml_test.go`

## Testing and Verifying

This change is already covered by existing tests. The modifications only affect how assertions are made in tests, not the actual test logic.

<!-- greptile_comment -->

## Greptile Summary

Enabled testifylint linter and standardized test assertions across the codebase to improve consistency in error handling and validation patterns.

- Enabled `testifylint` in `.golangci.yaml` configuration
- Updated `cmd/world/forge/forge_test.go` to use `NoError` instead of `Require().NoError` where appropriate
- Standardized error assertions in `common/tomlutil/toml_test.go` using `Require().NoError` and `Require().Error`
- Removed unused `github.com/stretchr/testify/require` import from `common/tomlutil/toml_test.go`



<!-- /greptile_comment -->