### PR TITLE
refactor(root): Remove testing-specific functions and move tests to same package

### DIFF
--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -255,7 +255,3 @@ that directory. Otherwise, you'll be prompted to enter a name for your new proje
 
 	return createCmd
 }
-
-func GetCreateCmdTesting(writer io.Writer) *cobra.Command {
-	return getCreateCmd(writer)
-}

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -98,7 +98,3 @@ If any dependencies are missing, you'll receive guidance on how to install them.
 
 	return doctorCmd
 }
-
-func GetDoctorCmdTesting(writer io.Writer) *cobra.Command {
-	return getDoctorCmd(writer)
-}

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -39,7 +39,6 @@ var rootCmd = &cobra.Command{
 		return checkLatestVersion()
 	},
 }
-var RootCmdTesting = rootCmd
 
 // Release structure to hold the data of the latest release.
 type Release struct {
@@ -143,10 +142,6 @@ func checkLatestVersion() error {
 		}
 	}
 	return nil
-}
-
-func CheckLatestVersionTesting() error {
-	return checkLatestVersion()
 }
 
 // contextWithSigterm provides a context that automatically terminates when either the parent context is canceled or

--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -14,7 +14,6 @@ import (
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-cli/cmd/world/cardinal"
 	"pkg.world.dev/world-cli/cmd/world/evm"
-	"pkg.world.dev/world-cli/cmd/world/root"
 )
 
 var (
@@ -32,10 +31,10 @@ func setupTestEnv() *testEnvironment {
 	// Initialize all commands
 	cardinal.Init()
 	evm.Init()
-	root.CmdInit()
+	CmdInit()
 
 	return &testEnvironment{
-		rootCmd: root.RootCmdTesting,
+		rootCmd: rootCmd,
 	}
 }
 
@@ -108,7 +107,7 @@ func TestSubcommandsHaveHelpText(t *testing.T) {
 
 func TestExecuteDoctorCommand(t *testing.T) {
 	teaOut := &bytes.Buffer{}
-	_, err := outputFromCmd(root.GetDoctorCmdTesting(teaOut), "")
+	_, err := outputFromCmd(getDoctorCmd(teaOut), "")
 	assert.NilError(t, err)
 
 	seenDependencies := map[string]int{
@@ -154,7 +153,7 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
-	createCmd := root.GetCreateCmdTesting(teaOut)
+	createCmd := getCreateCmd(teaOut)
 
 	// checkout the repo
 	sgtDir := gameDir + "/sgt"
@@ -215,7 +214,7 @@ func TestDev(t *testing.T) {
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
-	createCmd := root.GetCreateCmdTesting(teaOut)
+	createCmd := getCreateCmd(teaOut)
 	createCmd.SetArgs([]string{gameDir})
 
 	// checkout the repo
@@ -244,18 +243,18 @@ func TestDev(t *testing.T) {
 
 func TestCheckLatestVersion(t *testing.T) {
 	t.Cleanup(func() {
-		root.AppVersion = "" //nolint:reassign // Might cause issues with parallel tests
+		AppVersion = ""
 	})
 
 	t.Run("success scenario", func(t *testing.T) {
-		root.AppVersion = "v1.0.0" //nolint:reassign // Might cause issues with parallel tests
-		err := root.CheckLatestVersionTesting()
+		AppVersion = "v1.0.0"
+		err := checkLatestVersion()
 		assert.NilError(t, err)
 	})
 
 	t.Run("error version format", func(t *testing.T) {
-		root.AppVersion = "wrong format" //nolint:reassign // Might cause issues with parallel tests
-		err := root.CheckLatestVersionTesting()
+		AppVersion = "wrong format"
+		err := checkLatestVersion()
 		assert.Error(t, err, "error parsing current version: Malformed version: wrong format")
 	})
 }
@@ -325,7 +324,7 @@ func TestEVMStart(t *testing.T) {
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
-	createCmd := root.GetCreateCmdTesting(teaOut)
+	createCmd := getCreateCmd(teaOut)
 	createCmd.SetArgs([]string{gameDir})
 
 	// checkout the repo


### PR DESCRIPTION
# Refactor: Remove testing-specific functions and relocate test file

Closes: PLAT-375

## Overview

This PR refactors the testing approach by removing dedicated testing-specific functions and moving the test file to the same package as the code being tested.

## Brief Changelog

- Removed `GetCreateCmdTesting`, `GetDoctorCmdTesting`, `RootCmdTesting`, and `CheckLatestVersionTesting` functions
- Moved `root_test.go` from `cmd/world/root/testing/` to `cmd/world/root/`
- Updated test code to use internal package functions directly instead of exported testing functions

## Testing and Verifying

This change is already covered by existing tests, which continue to pass with the updated structure. The tests now access package-level functions and variables directly since they're in the same package.

<!-- greptile_comment -->

## Greptile Summary

Refactored testing structure by moving test files into the same package as the code being tested and removing redundant testing-specific functions.

- Moved `root_test.go` from `cmd/world/root/testing/` to `cmd/world/root/` for direct access to package internals
- Removed testing-specific functions (`GetCreateCmdTesting`, `GetDoctorCmdTesting`, `RootCmdTesting`, `CheckLatestVersionTesting`)
- Updated tests to use internal package functions directly, reducing code duplication
- Maintained all existing test coverage and functionality while improving code organization



<!-- /greptile_comment -->