### PR TITLE
feat: Enable usetesting linter and use t.TempDir/t.Context in tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,7 +71,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    # - usetesting
+    - usetesting
     - wastedassign
     - whitespace
   settings:

--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -137,19 +137,12 @@ func TestExecuteDoctorCommand(t *testing.T) {
 }
 
 func TestCreateStartStopRestartPurge(t *testing.T) {
+	var err error
+
 	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-start")
-	assert.NilError(t, err)
+	gameDir := t.TempDir()
 
-	// Remove dir
-	defer func() {
-		err = os.RemoveAll(gameDir)
-		assert.NilError(t, err)
-	}()
-
-	// Change dir
-	err = os.Chdir(gameDir)
-	assert.NilError(t, err)
+	t.Chdir(gameDir)
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
@@ -162,8 +155,7 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Change dir
-	err = os.Chdir(sgtDir)
-	assert.NilError(t, err)
+	t.Chdir(sgtDir)
 
 	// Start cardinal
 	testEnv.rootCmd.SetArgs([]string{"cardinal", "start", "--detach", "--editor=false"})
@@ -198,19 +190,11 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 }
 
 func TestDev(t *testing.T) {
-	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-dev")
-	assert.NilError(t, err)
+	// Use t.TempDir(), which also auto-cleans the dir
+	gameDir := t.TempDir()
 
-	// Remove dir
-	defer func() {
-		err = os.RemoveAll(gameDir)
-		assert.NilError(t, err)
-	}()
-
-	// Change dir
-	err = os.Chdir(gameDir)
-	assert.NilError(t, err)
+	// Change working directory
+	t.Chdir(gameDir)
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
@@ -220,11 +204,13 @@ func TestDev(t *testing.T) {
 	// checkout the repo
 	sgtDir := gameDir + "/sgt"
 	createCmd.SetArgs([]string{sgtDir})
-	err = createCmd.Execute()
+	err := createCmd.Execute()
 	assert.NilError(t, err)
 
 	// Start cardinal dev
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
 	testEnv.rootCmd.SetArgs([]string{"cardinal", "dev", "--editor=false"})
 	go func() {
 		err := testEnv.rootCmd.ExecuteContext(ctx)
@@ -308,19 +294,11 @@ func ServiceIsDown(name, address string, t *testing.T) bool {
 }
 
 func TestEVMStart(t *testing.T) {
-	// Create Cardinal
-	gameDir, err := os.MkdirTemp("", "game-template-dev")
-	assert.NilError(t, err)
+	// Create temp working dir (auto-cleans up)
+	gameDir := t.TempDir()
 
-	// Remove dir
-	defer func() {
-		err = os.RemoveAll(gameDir)
-		assert.NilError(t, err)
-	}()
-
-	// Change dir
-	err = os.Chdir(gameDir)
-	assert.NilError(t, err)
+	// Change to temp dir (auto-resets after test)
+	t.Chdir(gameDir)
 
 	// set tea output to variable
 	teaOut := &bytes.Buffer{}
@@ -330,11 +308,12 @@ func TestEVMStart(t *testing.T) {
 	// checkout the repo
 	sgtDir := gameDir + "/sgt"
 	createCmd.SetArgs([]string{sgtDir})
-	err = createCmd.Execute()
+	err := createCmd.Execute()
 	assert.NilError(t, err)
 
 	// Start evn dev
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	testEnv.rootCmd.SetArgs([]string{"evm", "start", "--dev"})
 	go func() {
 		err := testEnv.rootCmd.ExecuteContext(ctx)

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -34,7 +34,7 @@ func getNamespace(t *testing.T, cfg *Config) string {
 }
 
 func makeConfigAtTemp(t *testing.T, namespace string) string {
-	file, err := os.CreateTemp("", "config*.toml")
+	file, err := os.CreateTemp(t.TempDir(), "config*.toml")
 	assert.NilError(t, err)
 	defer file.Close()
 	t.Cleanup(func() {
@@ -70,10 +70,6 @@ func TestCanSetNamespaceWithFilename(t *testing.T) {
 }
 
 func replaceEnvVarForTest(t *testing.T, env, value string) {
-	original := os.Getenv(env)
-	t.Cleanup(func() {
-		assert.NilError(t, os.Setenv(env, original))
-	})
 	t.Setenv(env, value)
 }
 
@@ -97,20 +93,16 @@ func TestConfigPreference(t *testing.T) {
 }
 
 func makeTempDir(t *testing.T) string {
-	tempdir, err := os.MkdirTemp("", "")
-	assert.NilError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tempdir)
-	})
+	tempdir := t.TempDir()
 
-	// cd over to the temporary directory. Make sure to jump back to the current directory
-	// at the end of the test
+	// Save current dir and restore later
 	currDir, err := os.Getwd()
 	assert.NilError(t, err)
 	t.Cleanup(func() {
-		_ = os.Chdir(currDir)
+		t.Chdir(currDir)
 	})
-	assert.NilError(t, os.Chdir(tempdir))
+
+	t.Chdir(tempdir)
 	return tempdir
 }
 
@@ -133,7 +125,8 @@ func TestLoadConfigLooksInParentDirectories(t *testing.T) {
 
 	deepPath = path.Join(deepPath, "/h/i/j/k/l/m/n")
 	assert.NilError(t, os.MkdirAll(deepPath, 0755))
-	assert.NilError(t, os.Chdir(deepPath))
+
+	t.Chdir(deepPath)
 
 	configFile := path.Join(deepPath, WorldCLIConfigFilename) //nolint:govet // test
 	// The eventual call to LoadConfig should find this config file
@@ -145,7 +138,7 @@ func TestLoadConfigLooksInParentDirectories(t *testing.T) {
 }
 
 func makeTempConfigWithContent(t *testing.T, content string) string {
-	file, err := os.CreateTemp("", "config*.toml")
+	file, err := os.CreateTemp(t.TempDir(), "config*.toml")
 	assert.NilError(t, err)
 	defer file.Close()
 	t.Cleanup(func() {

--- a/common/editor/editor_test.go
+++ b/common/editor/editor_test.go
@@ -236,7 +236,7 @@ require (
 
 func TestFileExists(t *testing.T) {
 	// Create a temporary file and defer its removal
-	tempFile, err := os.CreateTemp("", "example")
+	tempFile, err := os.CreateTemp(t.TempDir(), "example")
 	if err != nil {
 		t.Fatalf("Unable to create temporary file: %s", err)
 	}
@@ -257,11 +257,7 @@ func TestFileExists(t *testing.T) {
 	}
 
 	// Create a temporary directory and defer its removal
-	tempDir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		t.Fatalf("Unable to create temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Test case where the path is a directory
 	if exists := fileExists(tempDir); exists {

--- a/common/teacmd/git_test.go
+++ b/common/teacmd/git_test.go
@@ -76,7 +76,7 @@ func cleanUpDir(targetDir string) {
 
 func TestAppendToToml(t *testing.T) {
 	// Create a temporary TOML file for testing
-	tempFile, err := os.CreateTemp("", "test.toml")
+	tempFile, err := os.CreateTemp(t.TempDir(), "test.toml")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}


### PR DESCRIPTION
# Enable `usetesting` linter and use testing helpers

Closes: WORLD-XXX

## Overview

This PR enables the `usetesting` linter and updates tests to use the testing package's helper methods instead of manually managing test resources.

## Brief Changelog

- Enabled the `usetesting` linter in `.golangci.yaml`
- Replaced manual temporary directory creation with `t.TempDir()`
- Used `t.Chdir()` instead of manually changing directories
- Replaced `context.Background()` with `t.Context()` in tests
- Updated temporary file creation to use `t.TempDir()`

## Testing and Verifying

This change is already covered by existing tests, as it only modifies how test resources are managed without changing test behavior.

<!-- greptile_comment -->

## Greptile Summary

This PR enables the `usetesting` linter and updates test files to use Go's testing package helper methods for better resource management.

- Enabled `usetesting` linter in `.golangci.yaml` to enforce usage of testing package helpers
- Replaced manual temp directory creation with `t.TempDir()` across test files for automatic cleanup
- Updated context creation to use `t.Context()` instead of `context.Background()` in tests
- Switched to `t.Cleanup()` for resource cleanup in `client_test.go`
- Inconsistent implementation where some tests still use manual resource management while others use testing helpers



<!-- /greptile_comment -->