### PR TITLE
refactor: Enable errcheck linter and fix error handling issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     # - depguard
     - dupl
     - durationcheck
-    # - errcheck
+    - errcheck
     - errname
     - errorlint
     - exhaustive

--- a/cmd/world/forge/initflow.go
+++ b/cmd/world/forge/initflow.go
@@ -184,9 +184,15 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 	} else {
 		switch flow.requiredProject { //nolint:exhaustive // don't need to handle all cases
 		case NeedData, NeedIDOnly:
-			flow.handleNeedProjectData()
+			err = flow.handleNeedProjectData()
+			if err != nil {
+				return &flow.State, err
+			}
 		case NeedExistingData, NeedExistingIDOnly:
-			flow.handleNeedExistingProjectData()
+			err = flow.handleNeedExistingProjectData()
+			if err != nil {
+				return &flow.State, err
+			}
 		}
 	}
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -133,7 +133,13 @@ func loadConfigFromFile(filename string) (*Config, error) {
 		if !ok {
 			continue
 		}
-		for key, val := range m.(map[string]any) {
+
+		typedMap, ok := m.(map[string]any)
+		if !ok {
+			return nil, eris.Errorf("expected %q section to be a map[string]any", header)
+		}
+
+		for key, val := range typedMap {
 			if _, okay := cfg.DockerEnv[key]; okay {
 				return nil, eris.Errorf("duplicate env variable %q", key)
 			}

--- a/common/teacmd/git.go
+++ b/common/teacmd/git.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -213,7 +214,11 @@ func appendToToml(filePath, section string, fields map[string]any) error {
 
 	// Add the fields to the section
 	for key, value := range fields {
-		config[section].(map[string]any)[key] = value
+		sectionMap, ok := config[section].(map[string]any)
+		if !ok {
+			return fmt.Errorf("expected config[%q] to be a map[string]any", section)
+		}
+		sectionMap[key] = value
 	}
 
 	// Marshal the updated config back to TOML


### PR DESCRIPTION
# fix: Enable errcheck linter and fix error handling issues

Closes: PLAT-361

## Overview

This PR enables the `errcheck` linter in the golangci configuration and fixes several error handling issues throughout the codebase. It properly propagates errors in various functions and adds type checking to prevent potential type assertion panics.

## Brief Changelog

- Enabled the `errcheck` linter in `.golangci.yaml`
- Fixed error handling in `forge/initflow.go` by properly propagating errors from handler functions
- Added type assertion checks in `config.go` to prevent potential panics
- Refactored Docker client code to improve error handling and reduce code duplication:
  - Added helper functions for progress bar creation and event handling
  - Added proper type checking for Docker API responses
  - Improved error detection and propagation in image operations
- Fixed type assertion in `teacmd/git.go` to prevent potential panics

## Testing and Verifying

This change is already covered by existing tests. The modifications ensure proper error handling without changing the core functionality.

<!-- greptile_comment -->

## Greptile Summary

Enabled the errcheck linter and improved error handling across the codebase, focusing on type safety and proper error propagation in Docker client operations and configuration management.

- Added type assertion checks in `common/config/config.go` to prevent panics when loading TOML configurations
- Refactored Docker client code in `common/docker/client_image.go` with helper functions for progress bars and event handling
- Enabled errcheck linter in `.golangci.yaml` with type assertion checking
- Added error propagation in `cmd/world/forge/initflow.go` for handler functions
- Implemented type safety checks in `common/teacmd/git.go` for TOML section access



<!-- /greptile_comment -->