### PR TITLE
refactor: Make tests parallel and use test-specific resources

### DIFF
--- a/common/login/login_internal_test.go
+++ b/common/login/login_internal_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDecryptAccessToken(t *testing.T) {
+	t.Parallel()
 	// Initialize encryption
 	enc, err := NewEncryption()
 	require.NoError(t, err)

--- a/common/teacmd/git_internal_test.go
+++ b/common/teacmd/git_internal_test.go
@@ -14,6 +14,7 @@ import (
 const templateURLTest = "https://github.com/Argus-Labs/starter-game-template.git"
 
 func TestGitCloneCmd(t *testing.T) {
+	t.Parallel()
 	type param struct {
 		url       string
 		targetDir string
@@ -49,6 +50,7 @@ func TestGitCloneCmd(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// clean up before test
 			cleanUpDir(tt.param.targetDir)
 
@@ -75,27 +77,17 @@ func cleanUpDir(targetDir string) {
 }
 
 func TestAppendToToml(t *testing.T) {
-	// Create a temporary TOML file for testing
-	tempFile, err := os.CreateTemp(t.TempDir(), "test.toml")
-	if err != nil {
-		t.Fatalf("failed to create temporary file: %v", err)
-	}
-	t.Cleanup(func() {
-		os.Remove(tempFile.Name())
-	})
-
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name          string
-		filePath      string
 		section       string
 		fields        map[string]any
 		expectedError error
 	}{
 		{
-			name:     "append first section and fields",
-			filePath: tempFile.Name(),
-			section:  "example_section",
+			name:    "append first section and fields",
+			section: "example_section",
 			fields: map[string]any{
 				"field1": "example_value",
 				"field2": 123,
@@ -103,9 +95,8 @@ func TestAppendToToml(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:     "append fields to existing section",
-			filePath: tempFile.Name(),
-			section:  "example_section",
+			name:    "append fields to existing section",
+			section: "example_section",
 			fields: map[string]any{
 				"field1": "replaced_value",
 				"field2": 321,
@@ -113,9 +104,8 @@ func TestAppendToToml(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:     "create new section and append fields",
-			filePath: tempFile.Name(),
-			section:  "new_section",
+			name:    "create new section and append fields",
+			section: "new_section",
 			fields: map[string]any{
 				"field3": true,
 				"field4": 3.14,
@@ -127,8 +117,30 @@ func TestAppendToToml(t *testing.T) {
 
 	// Run test cases
 	for _, tt := range tests {
+		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			err := appendToToml(tt.filePath, tt.section, tt.fields)
+			t.Parallel()
+			// Create a temporary file for this subtest
+			tempFile, err := os.CreateTemp(t.TempDir(), "test.toml")
+			if err != nil {
+				t.Fatalf("failed to create temporary file: %v", err)
+			}
+			t.Cleanup(func() {
+				os.Remove(tempFile.Name())
+			})
+
+			// For tests that need to append to existing content, create the initial content
+			if tt.name == "append fields to existing section" {
+				initialContent := `[example_section]
+field1 = "old_value"
+field2 = 0
+`
+				if err := os.WriteFile(tempFile.Name(), []byte(initialContent), 0644); err != nil {
+					t.Fatalf("failed to write initial content: %v", err)
+				}
+			}
+
+			err = appendToToml(tempFile.Name(), tt.section, tt.fields)
 			if !errors.Is(err, tt.expectedError) {
 				t.Errorf("unexpected error: got %v, want %v", err, tt.expectedError)
 			}
@@ -137,6 +149,7 @@ func TestAppendToToml(t *testing.T) {
 }
 
 func TestGenerateRandomHexString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		length int
@@ -157,6 +170,7 @@ func TestGenerateRandomHexString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := generateRandomHexString(tt.length)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/common/tomlutil/toml_internal_test.go
+++ b/common/tomlutil/toml_internal_test.go
@@ -4,28 +4,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/suite"
 )
 
-type TOMLTestSuite struct {
-	suite.Suite
-	tempDir string
-}
-
-func (s *TOMLTestSuite) SetupTest() {
-	s.tempDir = s.T().TempDir()
-}
-
 // createTestFile is a helper function that creates a temporary TOML file with given content.
-func (s *TOMLTestSuite) createTestFile(content string) string {
-	tmpFile := filepath.Join(s.tempDir, "test.toml")
+func createTestFile(t *testing.T, content string) string {
+	tempDir := t.TempDir()
+	tmpFile := filepath.Join(tempDir, "test.toml")
 	err := os.WriteFile(tmpFile, []byte(content), 0644)
-	s.Require().NoError(err, "Failed to create test file")
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
 	return tmpFile
 }
 
-func (s *TOMLTestSuite) TestReadTOML() {
+func TestReadTOML(t *testing.T) {
+	t.Parallel()
 	// Create a temporary test file
 	content := `
 [test]
@@ -35,22 +28,36 @@ number = 42
 [nested]
 string = "nested value"
 `
-	tmpFile := s.createTestFile(content)
+	tmpFile := createTestFile(t, content)
 
 	// Test successful read
 	var config map[string]any
 	err := ReadTOML(tmpFile, &config)
-	s.Require().NoError(err)
-	s.Equal("value", config["test"].(map[string]any)["key"])
-	s.Equal(int64(42), config["test"].(map[string]any)["number"])
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
+	testSection, ok := config["test"].(map[string]any)
+	if !ok {
+		t.Fatal("test section should exist and be a map")
+	}
+	if testSection["key"] != "value" {
+		t.Error("Expected key to be 'value'")
+	}
+	if testSection["number"] != int64(42) {
+		t.Error("Expected number to be 42")
+	}
 
 	// Test reading non-existent file
 	err = ReadTOML("nonexistent.toml", &config)
-	s.Error(err)
+	if err == nil {
+		t.Error("Expected error when reading non-existent file")
+	}
 }
 
-func (s *TOMLTestSuite) TestWriteTOML() {
-	tmpFile := filepath.Join(s.tempDir, "write_test.toml")
+func TestWriteTOML(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	tmpFile := filepath.Join(tempDir, "write_test.toml")
 
 	// Test writing new file
 	config := map[string]any{
@@ -61,20 +68,36 @@ func (s *TOMLTestSuite) TestWriteTOML() {
 	}
 
 	err := WriteTOML(tmpFile, config)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("WriteTOML failed: %v", err)
+	}
 
 	// Verify written content
 	var readConfig map[string]any
 	err = ReadTOML(tmpFile, &readConfig)
-	s.Require().NoError(err)
-	s.Equal(config, readConfig)
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
+	section, ok := readConfig["section"].(map[string]any)
+	if !ok {
+		t.Fatal("section should exist and be a map")
+	}
+	if section["key"] != "value" {
+		t.Error("Expected key to be 'value'")
+	}
+	if section["number"] != int64(42) {
+		t.Error("Expected number to be 42")
+	}
 
 	// Test writing to invalid path
 	err = WriteTOML("/invalid/path/test.toml", config)
-	s.Error(err)
+	if err == nil {
+		t.Error("Expected error when writing to invalid path")
+	}
 }
 
-func (s *TOMLTestSuite) TestUpdateTOMLSection() {
+func TestUpdateTOMLSection(t *testing.T) {
+	t.Parallel()
 	// Create initial test file
 	initialContent := `
 [existing]
@@ -84,7 +107,7 @@ key = "value"
 keep = "kept"
 change = "old"
 `
-	tmpFile := s.createTestFile(initialContent)
+	tmpFile := createTestFile(t, initialContent)
 
 	// Test updating existing section
 	updates := map[string]any{
@@ -92,31 +115,55 @@ change = "old"
 		"add":    "added",
 	}
 	err := UpdateTOMLSection(tmpFile, "update", updates)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("UpdateTOMLSection failed: %v", err)
+	}
 
 	// Verify updates
 	var config map[string]any
 	err = ReadTOML(tmpFile, &config)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
 
-	updateSection := config["update"].(map[string]any)
-	s.Equal("kept", updateSection["keep"])
-	s.Equal("new", updateSection["change"])
-	s.Equal("added", updateSection["add"])
+	updateSection, ok := config["update"].(map[string]any)
+	if !ok {
+		t.Fatal("update section should exist and be a map")
+	}
+	if updateSection["keep"] != "kept" {
+		t.Error("Expected keep to be 'kept'")
+	}
+	if updateSection["change"] != "new" {
+		t.Error("Expected change to be 'new'")
+	}
+	if updateSection["add"] != "added" {
+		t.Error("Expected add to be 'added'")
+	}
 
 	// Test creating new section
 	newUpdates := map[string]any{
 		"new": "value",
 	}
 	err = UpdateTOMLSection(tmpFile, "newsection", newUpdates)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("UpdateTOMLSection failed: %v", err)
+	}
 
 	err = ReadTOML(tmpFile, &config)
-	s.Require().NoError(err)
-	s.Equal("value", config["newsection"].(map[string]any)["new"])
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
+	newSection, ok := config["newsection"].(map[string]any)
+	if !ok {
+		t.Fatal("newsection should exist and be a map")
+	}
+	if newSection["new"] != "value" {
+		t.Error("Expected new to be 'value'")
+	}
 }
 
-func (s *TOMLTestSuite) TestGetTOMLSection() {
+func TestGetTOMLSection(t *testing.T) {
+	t.Parallel()
 	// Create test file
 	content := `
 [section]
@@ -125,26 +172,40 @@ number = 42
 
 [empty]
 `
-	tmpFile := s.createTestFile(content)
+	tmpFile := createTestFile(t, content)
 
 	// Test getting existing section
 	section, err := GetTOMLSection(tmpFile, "section")
-	s.Require().NoError(err)
-	s.Equal("value", section["key"])
-	s.Equal(int64(42), section["number"])
+	if err != nil {
+		t.Errorf("GetTOMLSection failed: %v", err)
+	}
+	if section["key"] != "value" {
+		t.Error("Expected key to be 'value'")
+	}
+	if section["number"] != int64(42) {
+		t.Error("Expected number to be 42")
+	}
 
 	// Test getting non-existent section
 	_, err = GetTOMLSection(tmpFile, "nonexistent")
-	s.Require().Error(err)
+	if err == nil {
+		t.Error("Expected error when getting non-existent section")
+	}
 
 	// Test getting empty section
 	emptySection, err := GetTOMLSection(tmpFile, "empty")
-	s.Require().NoError(err)
-	s.Empty(emptySection)
+	if err != nil {
+		t.Errorf("GetTOMLSection failed: %v", err)
+	}
+	if len(emptySection) != 0 {
+		t.Error("Expected empty section to be empty")
+	}
 }
 
-func (s *TOMLTestSuite) TestCreateTOMLFile() {
-	tmpFile := filepath.Join(s.tempDir, "nested", "create_test.toml")
+func TestCreateTOMLFile(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	tmpFile := filepath.Join(tempDir, "nested", "create_test.toml")
 
 	// Test creating new file with sections
 	sections := map[string]map[string]any{
@@ -157,29 +218,38 @@ func (s *TOMLTestSuite) TestCreateTOMLFile() {
 	}
 
 	err := CreateTOMLFile(tmpFile, sections)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("CreateTOMLFile failed: %v", err)
+	}
 
 	// Verify file was created with correct content
 	var config map[string]any
 	err = ReadTOML(tmpFile, &config)
-	s.Require().NoError(err)
-	s.Equal("value", config["section1"].(map[string]any)["key"])
-	s.Equal(int64(42), config["section2"].(map[string]any)["number"])
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
+	if config["section1"].(map[string]any)["key"] != "value" {
+		t.Error("Expected key to be 'value'")
+	}
+	if config["section2"].(map[string]any)["number"] != int64(42) {
+		t.Error("Expected number to be 42")
+	}
 
 	// Test creating file that already exists (should do nothing)
 	newSections := map[string]map[string]any{
 		"different": {"key": "value"},
 	}
 	err = CreateTOMLFile(tmpFile, newSections)
-	s.Require().NoError(err)
+	if err != nil {
+		t.Errorf("CreateTOMLFile failed: %v", err)
+	}
 
 	// Verify original content wasn't changed
 	err = ReadTOML(tmpFile, &config)
-	s.Require().NoError(err)
-	s.Equal("value", config["section1"].(map[string]any)["key"])
-}
-
-// TestTOMLSuite runs the test suite.
-func TestTOMLSuite(t *testing.T) {
-	suite.Run(t, new(TOMLTestSuite))
+	if err != nil {
+		t.Errorf("ReadTOML failed: %v", err)
+	}
+	if config["section1"].(map[string]any)["key"] != "value" {
+		t.Error("Expected key to be 'value'")
+	}
 }


### PR DESCRIPTION
Closes: PLAT-377

feat: Parallelize tests and make them isolated

## Overview

This PR improves test reliability by making tests run in parallel and ensuring they use isolated resources. Tests now use unique ports, namespaces, and temporary directories to prevent interference between concurrent test executions.

## Brief Changelog

- Added `t.Parallel()` to all test functions to enable parallel execution
- Introduced unique port generation for Redis tests with `getUniquePort()`
- Created unique namespace generation with `getUniqueNamespace()`
- Replaced hardcoded test directories with `t.TempDir()` for isolated file operations
- Modified helper functions to accept test-specific parameters
- Refactored TOML tests to use standard testing instead of test suite

## Testing and Verifying

This change is already covered by existing tests. The tests themselves have been modified to run in parallel and use isolated resources, which verifies the changes work correctly. The PR can be verified by running the test suite and confirming all tests pass when executed in parallel.

<!-- greptile_comment -->

## Greptile Summary

Refactored test files to enable parallel execution and resource isolation across the world-cli repository, improving test reliability and performance.

- Added `t.Parallel()` to all test functions enabling concurrent execution
- Introduced atomic counter-based unique port/namespace generation in `client_internal_test.go` to prevent resource conflicts
- Replaced hardcoded directories with `t.TempDir()` for isolated file operations
- Refactored TOML tests from testify/suite to standard Go testing with proper cleanup
- Modified helper functions to accept test-specific parameters ensuring thread safety



<!-- /greptile_comment -->