### PR TITLE
feat: Implement organization/Project selection flow

### DIFF
--- a/cmd/world/forge/organization_flow.go
+++ b/cmd/world/forge/organization_flow.go
@@ -1,0 +1,156 @@
+package forge
+
+import (
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var (
+	ErrOrganizationSelectionCanceled = eris.New("Organization selection canceled")
+	ErrOrganizationCreationCanceled  = eris.New("Organization creation canceled")
+)
+
+///////////////////////
+// Need Organization //
+///////////////////////
+
+func (flow *initFlow) handleNeedOrgData() error {
+	orgs, err := getListOfOrganizations(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organizations")
+	}
+
+	switch len(orgs) {
+	case 0: // No organizations found
+		return flow.handleNeedOrganizationCaseNoOrgs()
+	case 1: // One organization found
+		return flow.handleNeedOrganizationCaseOneOrg(orgs)
+	default: // Multiple organizations found
+		return flow.handleNeedOrganizationCaseMultipleOrgs(orgs)
+	}
+}
+
+func (flow *initFlow) handleNeedOrganizationCaseNoOrgs() error {
+	for {
+		printer.NewLine(1)
+		printer.Infoln("No organizations found.")
+		choice := getInput("Would you like to create one? (Y/n)", "Y")
+
+		switch choice {
+		case "Y":
+			org, err := createOrganization(flow.State.Command.Context())
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create organization in no-orgs case")
+			}
+			flow.updateOrganization(org)
+			return nil
+		case "n":
+			return ErrOrganizationCreationCanceled
+		default:
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'")
+			printer.NewLine(1)
+		}
+	}
+}
+
+func (flow *initFlow) handleNeedOrganizationCaseOneOrg(orgs []organization) error {
+	printer.NewLine(1)
+	printer.Infof("Found one organization: %s [%s]\n", orgs[0].Name, orgs[0].Slug)
+
+	for {
+		choice := getInput("Use this organization? (Y/n/c to create new)", "Y")
+
+		switch choice {
+		case "Y":
+			flow.updateOrganization(&orgs[0])
+			return nil
+		case "n":
+			return ErrOrganizationSelectionCanceled
+		case "c":
+			org, err := createOrganization(flow.State.Command.Context())
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create organization in one-org case")
+			}
+			flow.updateOrganization(org)
+			return nil
+		default:
+			printer.NewLine(1)
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'/'c'")
+		}
+	}
+}
+
+func (flow *initFlow) handleNeedOrganizationCaseMultipleOrgs(orgs []organization) error {
+	org, err := promptForOrganization(flow.State.Command.Context(), orgs, true)
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to prompt for organization in multiple-orgs case")
+	}
+	flow.updateOrganization(&org)
+	return nil
+}
+
+////////////////////////////////
+// Need Existing Organization //
+////////////////////////////////
+
+func (flow *initFlow) handleNeedExistingOrgData() error {
+	// First check if we already have a selected organization
+	selectedOrg, err := getSelectedOrganization(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get selected organization")
+	}
+
+	// If we have a selected org, use it
+	if selectedOrg.ID != "" {
+		flow.updateOrganization(&selectedOrg)
+		return nil
+	}
+
+	// No org selected, get list of organizations
+	orgs, err := getListOfOrganizations(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organizations")
+	}
+
+	switch len(orgs) {
+	case 0: // No organizations found
+		return flow.handleNeedExistingOrganizationCaseNoOrgs()
+	case 1: // One organization found
+		return flow.handleNeedExistingOrganizationCaseOneOrg(orgs)
+	default: // Multiple organizations found
+		return flow.handleNeedExistingOrganizationCaseMultipleOrgs(orgs)
+	}
+}
+
+func (flow *initFlow) handleNeedExistingOrganizationCaseNoOrgs() error {
+	printer.NewLine(1)
+	printer.Errorln("No organizations found.")
+	printer.Infoln("You must be a member of an organization to proceed.")
+	return ErrOrganizationSelectionCanceled
+}
+
+func (flow *initFlow) handleNeedExistingOrganizationCaseOneOrg(orgs []organization) error {
+	printer.NewLine(1)
+	printer.Infof("Organization: %s [%s]\n", orgs[0].Name, orgs[0].Slug)
+	flow.updateOrganization(&orgs[0])
+	return nil
+}
+
+func (flow *initFlow) handleNeedExistingOrganizationCaseMultipleOrgs(orgs []organization) error {
+	org, err := promptForOrganization(flow.State.Command.Context(), orgs, false)
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to prompt for organization in existing multiple-orgs case")
+	}
+	flow.updateOrganization(&org)
+	return nil
+}
+
+////////////////////////////////
+// Helper Functions           //
+////////////////////////////////
+
+// updateOrganization updates the organization in the flow state.
+func (flow *initFlow) updateOrganization(org *organization) {
+	flow.State.Organization = org
+	flow.organizationStepDone = true
+}

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -1,0 +1,200 @@
+package forge
+
+import (
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/common/logger"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var (
+	ErrProjectSelectionCanceled = eris.New("Project selection canceled")
+	ErrProjectCreationCanceled  = eris.New("Project creation canceled")
+)
+
+/////////////////////
+// Need Project    //
+/////////////////////
+
+func (flow *initFlow) handleNeedProjectData() error {
+	projects, err := getListOfProjects(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get projects")
+	}
+
+	found := flow.getProjectByID(projects)
+	if found {
+		return nil
+	}
+
+	switch len(projects) {
+	case 0: // No projects found
+		return flow.handleNeedProjectCaseNoProjects()
+	case 1: // One project found
+		return flow.handleNeedProjectCaseOneProject(projects)
+	default: // Multiple projects found
+		return flow.handleNeedProjectCaseMultipleProjects()
+	}
+}
+
+func (flow *initFlow) handleNeedProjectCaseNoProjects() error {
+	for {
+		printer.NewLine(1)
+		printer.Infoln("No projects found.")
+		choice := getInput("Would you like to create one? (Y/n)", "Y")
+
+		switch choice {
+		case "Y":
+			proj, err := createProject(flow.State.Command.Context())
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create project in no-projects case")
+			}
+			flow.updateProject(proj)
+			return nil
+		case "n":
+			return ErrProjectCreationCanceled
+		default:
+			printer.NewLine(1)
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'")
+		}
+	}
+}
+
+func (flow *initFlow) handleNeedProjectCaseOneProject(projects []project) error {
+	printer.NewLine(1)
+	printer.Infof("Project: %s [%s]\n", projects[0].Name, projects[0].Slug)
+
+	for {
+		choice := getInput("Use this project? (Y/n/c to create new)", "Y")
+
+		switch choice {
+		case "Y":
+			flow.updateProject(&projects[0])
+			return nil
+		case "n":
+			return ErrProjectSelectionCanceled
+		case "c":
+			proj, err := createProject(flow.State.Command.Context())
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create project in one-project case")
+			}
+			flow.updateProject(proj)
+			return nil
+		default:
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'/'c'")
+			printer.NewLine(1)
+		}
+	}
+}
+
+func (flow *initFlow) handleNeedProjectCaseMultipleProjects() error {
+	proj, err := selectProject(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to select project in multiple-projects case")
+	}
+	if proj == nil {
+		return ErrProjectSelectionCanceled
+	}
+	flow.updateProject(proj)
+	return nil
+}
+
+////////////////////////////////
+// Need Existing Project      //
+////////////////////////////////
+
+func (flow *initFlow) handleNeedExistingProjectData() error {
+	projects, err := getListOfProjects(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get projects")
+	}
+
+	found := flow.getProjectByID(projects)
+	if found {
+		return nil
+	}
+
+	// First check if we already have a selected project
+	selectedProj, err := getSelectedProject(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Failed to get selected project")
+	}
+
+	// If we have a selected project, use it
+	if selectedProj.ID != "" {
+		flow.updateProject(&selectedProj)
+		return nil
+	}
+
+	switch len(projects) {
+	case 0: // No projects found
+		return flow.handleNeedExistingProjectCaseNoProjects()
+	case 1: // One project found
+		return flow.handleNeedExistingProjectCaseOneProject(projects)
+	default: // Multiple projects found
+		return flow.handleNeedExistingProjectCaseMultipleProjects()
+	}
+}
+
+func (flow *initFlow) handleNeedExistingProjectCaseNoProjects() error {
+	printer.NewLine(1)
+	printer.Errorln("No projects found.")
+	printer.Infoln("You must have at least one project to proceed.")
+	return ErrProjectSelectionCanceled
+}
+
+func (flow *initFlow) handleNeedExistingProjectCaseOneProject(projects []project) error {
+	printer.NewLine(1)
+	printer.Infof("Project: %s [%s]\n", projects[0].Name, projects[0].ID)
+	flow.updateProject(&projects[0])
+	return nil
+}
+
+func (flow *initFlow) handleNeedExistingProjectCaseMultipleProjects() error {
+	proj, err := selectProject(flow.State.Command.Context())
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to select project in existing multiple-projects case")
+	}
+	if proj == nil {
+		return ErrProjectSelectionCanceled
+	}
+	flow.updateProject(proj)
+	return nil
+}
+
+////////////////////////////////
+// Helper Functions           //
+////////////////////////////////
+
+// getProjectByID checks if a project with the ID from config exists in the provided list.
+// If found, it sets the project in the flow state and returns true.
+func (flow *initFlow) getProjectByID(projects []project) bool {
+	if flow.config.ProjectID == "" {
+		return false
+	}
+
+	for _, project := range projects {
+		if flow.config.ProjectID == project.ID {
+			flow.updateProject(&project)
+			return true
+		}
+	}
+	return false
+}
+
+// updateProject updates the project in the flow state and saves the config.
+func (flow *initFlow) updateProject(project *project) {
+	flow.State.Project = project
+	flow.projectStepDone = true
+	flow.AddKnownProject(project)
+
+	flow.config.ProjectID = project.ID
+	flow.config.CurrProjectName = project.Name
+	flow.config.CurrRepoKnown = true
+
+	err := SaveForgeConfig(flow.config)
+	if err != nil {
+		printer.Notificationf("Warning: Failed to save config: %s", err)
+		logger.Error(eris.Wrap(err, "Project flow failed to save config"))
+		// continue on, this is not fatal
+	}
+}


### PR DESCRIPTION
# Implement Organization Selection Flow for World CLI

Closes: PLAT-383

## Overview

This PR implements the organization selection flow for the World CLI, allowing users to select or create organizations during initialization. It handles various scenarios such as when a user has no organizations, one organization, or multiple organizations.

## Brief Changelog

- Implemented `handleNeedOrgData()` to manage organization selection when creating new projects
- Implemented `handleNeedExistingOrgData()` to handle organization selection for existing projects
- Added error handling for organization selection cancellation
- Enhanced `promptForOrganization()` to support creating new organizations during selection
- Created dedicated organization flow handlers for different scenarios (no orgs, one org, multiple orgs)
- Moved project-related flow handlers to a separate file for better code organization

## Testing and Verifying

This change can be verified by running the World CLI initialization flow and testing the organization selection process in different scenarios:
- When a user has no organizations
- When a user has one organization
- When a user has multiple organizations
- When a user cancels organization selection
- When a user creates a new organization during the flow

<!-- greptile_comment -->

## Greptile Summary

Implemented organization selection flow in the World CLI with comprehensive handling of various organization management scenarios.

- Added `organization_flow.go` with dedicated handlers for no-org, single-org, and multi-org cases
- Enhanced `organization.go` with improved organization selection logic and role management functionality
- Added placeholder `project_flow.go` with TODO stubs for project selection implementation
- Modified `initflow.go` to support complete organization/project selection flow with proper state management
- Potential issue: Project flow implementation is incomplete with only TODO stubs



<!-- /greptile_comment -->