### PR TITLE
fix: config fixes

### DIFF
--- a/cmd/world/cardinal/build.go
+++ b/cmd/world/cardinal/build.go
@@ -15,18 +15,19 @@ import (
 )
 
 type BuildCmd struct {
-	LogLevel  string `flag:"" help:"Set the log level for Cardinal"`
-	Debug     bool   `flag:"" help:"Enable debugging"`
-	Telemetry bool   `flag:"" help:"Enable tracing, metrics, and profiling"`
-	Push      string `flag:"" help:"Push your cardinal image to a given image repository"`
-	Auth      string `flag:"" help:"Auth token for the given image repository"`
-	User      string `flag:"" help:"User for the given image repository"`
-	Pass      string `flag:"" help:"Password for the given image repository"`
-	RegToken  string `flag:"" help:"Registry token for the given image repository"`
+	Parent    *CardinalCmd `kong:"-"`
+	LogLevel  string       `         flag:"" help:"Set the log level for Cardinal"`
+	Debug     bool         `         flag:"" help:"Enable debugging"`
+	Telemetry bool         `         flag:"" help:"Enable tracing, metrics, and profiling"`
+	Push      string       `         flag:"" help:"Push your cardinal image to a given image repository" hidden:"true"`
+	Auth      string       `         flag:"" help:"Auth token for the given image repository"            hidden:"true"`
+	User      string       `         flag:"" help:"User for the given image repository"                  hidden:"true"`
+	Pass      string       `         flag:"" help:"Password for the given image repository"              hidden:"true"`
+	RegToken  string       `         flag:"" help:"Registry token for the given image repository"        hidden:"true"`
 }
 
 func (c *BuildCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/cardinal/cardinal.go
+++ b/cmd/world/cardinal/cardinal.go
@@ -12,7 +12,7 @@ var CardinalCmdPlugin struct {
 
 //nolint:lll, revive // needed to put all the help text in the same line
 type CardinalCmd struct {
-	Config string `flag:"" help:"A TOML config file"`
+	Config string `flag:"" type:"existingfile" help:"A TOML config file"`
 
 	Start   *StartCmd   `cmd:"" group:"Cardinal Commands:" help:"Launch your Cardinal game environment"`
 	Stop    *StopCmd    `cmd:"" group:"Cardinal Commands:" help:"Gracefully shut down your Cardinal game environment"`

--- a/cmd/world/cardinal/dev.go
+++ b/cmd/world/cardinal/dev.go
@@ -33,13 +33,14 @@ const (
 )
 
 type DevCmd struct {
-	Editor    bool            `flag:"" help:"Enable Cardinal Editor"`
-	PrettyLog bool            `flag:"" help:"Run Cardinal with pretty logging" default:"true"`
+	Parent    *CardinalCmd    `kong:"-"`
+	Editor    bool            `         flag:"" help:"Enable Cardinal Editor"`
+	PrettyLog bool            `         flag:"" help:"Run Cardinal with pretty logging" default:"true"`
 	Context   context.Context `kong:"-"`
 }
 
 func (c *DevCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/cardinal/purge.go
+++ b/cmd/world/cardinal/purge.go
@@ -10,10 +10,11 @@ import (
 )
 
 type PurgeCmd struct {
+	Parent *CardinalCmd `kong:"-"`
 }
 
 func (c *PurgeCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -8,12 +8,13 @@ import (
 )
 
 type RestartCmd struct {
-	Detach bool `flag:"" help:"Run in detached mode"`
-	Debug  bool `flag:"" help:"Enable debugging"`
+	Parent *CardinalCmd `kong:"-"`
+	Detach bool         `         flag:"" help:"Run in detached mode"`
+	Debug  bool         `         flag:"" help:"Enable debugging"`
 }
 
 func (c *RestartCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -34,18 +34,20 @@ var (
 	ErrGracefulExit = eris.New("Process gracefully exited")
 )
 
+//nolint:lll // needed to put all the help text in the same line
 type StartCmd struct {
-	Build      bool   `flag:"" help:"Rebuild Docker images before starting"`
-	Detach     bool   `flag:"" help:"Run in detached mode"`
-	LogLevel   string `flag:"" help:"Set the log level for Cardinal"`
-	Debug      bool   `flag:"" help:"Enable delve debugging"`
-	Telemetry  bool   `flag:"" help:"Enable tracing, metrics, and profiling"`
-	Editor     bool   `flag:"" help:"Run Cardinal Editor, useful for prototyping and debugging"`
-	EditorPort string `flag:"" help:"Port for Cardinal Editor"                                  default:"auto"`
+	Parent     *CardinalCmd `kong:"-"`
+	Build      bool         `         flag:"" help:"Rebuild Docker images before starting"`
+	Detach     bool         `         flag:"" help:"Run in detached mode"`
+	LogLevel   string       `         flag:"" help:"Set the log level for Cardinal"`
+	Debug      bool         `         flag:"" help:"Enable delve debugging"`
+	Telemetry  bool         `         flag:"" help:"Enable tracing, metrics, and profiling"`
+	Editor     bool         `         flag:"" help:"Run Cardinal Editor, useful for prototyping and debugging"`
+	EditorPort string       `         flag:"" help:"Port for Cardinal Editor"                                  default:"auto"`
 }
 
 func (c *StartCmd) Run() error { //nolint:gocognit // this is a naturally complex command
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/cardinal/stop.go
+++ b/cmd/world/cardinal/stop.go
@@ -10,10 +10,11 @@ import (
 )
 
 type StopCmd struct {
+	Parent *CardinalCmd `kong:"-"`
 }
 
 func (c *StopCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/evm/start.go
+++ b/cmd/world/evm/start.go
@@ -16,13 +16,14 @@ import (
 
 //nolint:lll // needed to put all the help text in the same line
 type StartCmd struct {
-	DAAuthToken string          `flag:"" optional:"" help:"The DA Auth Token that allows the rollup to communicate with the Celestia client."`
-	UseDevDA    bool            `flag:"" optional:"" name:"dev" help:"Use a locally running DA layer"`
+	Parent      *EvmCmd         `kong:"-"`
+	DAAuthToken string          `         flag:"" optional:"" help:"The DA Auth Token that allows the rollup to communicate with the Celestia client."`
+	UseDevDA    bool            `         flag:"" optional:"" help:"Use a locally running DA layer"                                                    name:"dev"`
 	Context     context.Context `kong:"-"`
 }
 
 func (c *StartCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/evm/stop.go
+++ b/cmd/world/evm/stop.go
@@ -10,10 +10,11 @@ import (
 )
 
 type StopCmd struct {
+	Parent *EvmCmd `kong:"-"`
 }
 
 func (c *StopCmd) Run() error {
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(&c.Parent.Config)
 	if err != nil {
 		return err
 	}

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -221,7 +221,8 @@ func updateWorldToml(projectName string) error {
 }
 
 type CreateCmd struct {
-	Directory string `arg:"" optional:"" type:"path" help:"The directory to create the project in"`
+	Parent    *RootCmd `kong:"-"`
+	Directory string   `         arg:"" optional:"" type:"path" help:"The directory to create the project in"`
 }
 
 func (c *CreateCmd) Run() error {

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -63,6 +63,7 @@ func (m WorldDoctorModel) View() string {
 }
 
 type DoctorCmd struct {
+	Parent *RootCmd `kong:"-"`
 }
 
 func (c *DoctorCmd) Run() error {

--- a/cmd/world/root/root.go
+++ b/cmd/world/root/root.go
@@ -3,14 +3,10 @@ package root
 import (
 	"context"
 	"net/http"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/hashicorp/go-version"
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-cli/common/logger"
@@ -25,14 +21,17 @@ const (
 	httpTimeout = 2 * time.Second
 )
 
-var CLI struct {
-	Create       *CreateCmd  `cmd:"" group:"Getting Started:" help:"Create a new World Engine project"`
-	Doctor       *DoctorCmd  `cmd:"" group:"Getting Started:" help:"Check your development environment"`
+//nolint:revive // this is the natural name for the root command
+type RootCmd struct {
+	Create       *CreateCmd  `cmd:"" group:"Getting Started:"     help:"Create a new World Engine project"`
+	Doctor       *DoctorCmd  `cmd:"" group:"Getting Started:"     help:"Check your development environment"`
 	kong.Plugins             // put this here so tools will be in the right place
 	Version      *VersionCmd `cmd:"" group:"Additional Commands:" help:"Show the version of the CLI"`
 	// Help    *root.HelpCmd    `cmd:"" default:"1" group:"Additional Commands:" help:"Show more detailed help"`
-	Verbose bool `flag:"" short:"v" help:"Enable World CLI Debug logs"`
+	Verbose bool `                                    help:"Enable World CLI Debug logs"        flag:"" short:"v"`
 }
+
+var CLI RootCmd
 
 type HelpCmd struct {
 }
@@ -103,29 +102,4 @@ func checkLatestVersion() error {
 		}
 	}
 	return nil
-}
-
-// contextWithSigterm provides a context that automatically terminates when either the parent context is canceled or
-// when a termination signal is received.
-//
-//nolint:unused // we will want to use this in the future I think
-func contextWithSigterm(ctx context.Context) context.Context {
-	ctx, cancel := context.WithCancel(ctx)
-	textStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-
-	go func() {
-		defer cancel()
-
-		signalCh := make(chan os.Signal, 1)
-		signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-
-		select {
-		case <-signalCh:
-			printer.Infoln(textStyle.Render("Interrupt signal received. Terminating..."))
-		case <-ctx.Done():
-			printer.Infoln(textStyle.Render("Cancellation signal received. Terminating..."))
-		}
-	}()
-
-	return ctx
 }

--- a/cmd/world/root/root_internal_test.go
+++ b/cmd/world/root/root_internal_test.go
@@ -92,8 +92,10 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 	// Create a new Kong parser with our CLI struct
 	createCmd := CreateCmd{
+		Parent:    &CLI,
 		Directory: gameDir + "/sgt",
 	}
+
 	err = createCmd.Run()
 	assert.NilError(t, err)
 
@@ -102,6 +104,7 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 	// Start cardinal
 	startCmd := cardinal.StartCmd{ // cardinal start --detach --editor=false
+		Parent: &cardinal.CardinalCmd{},
 		Editor: false,
 		Detach: true,
 	}
@@ -110,7 +113,9 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 	defer func() {
 		// Purge cardinal
-		purgeCmd := cardinal.PurgeCmd{}
+		purgeCmd := cardinal.PurgeCmd{
+			Parent: &cardinal.CardinalCmd{},
+		}
 		err = purgeCmd.Run()
 		assert.NilError(t, err)
 	}()
@@ -120,6 +125,7 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 
 	// Restart cardinal
 	restartCmd := cardinal.RestartCmd{ // cardinal restart --detach
+		Parent: &cardinal.CardinalCmd{},
 		Detach: true,
 	}
 	err = restartCmd.Run()
@@ -129,7 +135,9 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 	assert.Assert(t, cardinalIsUp(t), "Cardinal is not running")
 
 	// Stop cardinal
-	stopCmd := cardinal.StopCmd{}
+	stopCmd := cardinal.StopCmd{
+		Parent: &cardinal.CardinalCmd{},
+	}
 	err = stopCmd.Run()
 	assert.NilError(t, err)
 
@@ -146,6 +154,7 @@ func TestDev(t *testing.T) {
 
 	// Create a new Kong parser with our CLI struct
 	createCmd := CreateCmd{
+		Parent:    &CLI,
 		Directory: gameDir + "/sgt",
 	}
 	err := createCmd.Run() // cardinal create {dir}/sgt
@@ -156,6 +165,7 @@ func TestDev(t *testing.T) {
 	defer cancel()
 
 	devCmd := cardinal.DevCmd{ // cardinal dev --editor=false
+		Parent:  &cardinal.CardinalCmd{},
 		Editor:  false,
 		Context: ctx,
 	}
@@ -254,6 +264,7 @@ func TestEVMStart(t *testing.T) {
 	t.Chdir(gameDir)
 
 	createCmd := CreateCmd{
+		Parent:    &CLI,
 		Directory: gameDir + "/sgt",
 	}
 	err := createCmd.Run() // evm create {dir}/sgt
@@ -264,6 +275,7 @@ func TestEVMStart(t *testing.T) {
 	defer cancel()
 
 	startCmd := evm.StartCmd{
+		Parent:   &evm.EvmCmd{},
 		UseDevDA: true,
 		Context:  ctx,
 	}

--- a/cmd/world/root/version.go
+++ b/cmd/world/root/version.go
@@ -8,7 +8,8 @@ var AppVersion string
 
 // VersionCmd is the command to show the version of the CLI.
 type VersionCmd struct {
-	Check bool `help:"Check for the latest version of the CLI"`
+	Parent *RootCmd `kong:"-"`
+	Check  bool     `help:"Check for the latest version of the CLI"`
 }
 
 func (c *VersionCmd) Run() error {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -37,7 +37,12 @@ type Config struct {
 	DockerEnv map[string]string
 }
 
-func GetConfig() (*Config, error) {
+// GetConfig returns a Config object. If a filename is provided, it will be used as the config file.
+// Otherwise, the config file will be searched for in the current directory and all parent directories.
+func GetConfig(filename *string) (*Config, error) {
+	if filename != nil && *filename != "" {
+		return loadConfigFromFile(*filename)
+	}
 	cfg, err := findAndLoadConfigFile()
 	if err != nil {
 		return nil, err

--- a/common/config/config_internal_test.go
+++ b/common/config/config_internal_test.go
@@ -113,7 +113,7 @@ func TestLoadConfigLooksInParentDirectories(t *testing.T) {
 	// The eventual call to LoadConfig should find this config file
 	makeConfigAtPath(t, configFilePath, "alpha")
 
-	cfg, err := GetConfig(&configFilePath)
+	cfg, err := GetConfig(nil)
 	assert.NilError(t, err)
 	assert.Equal(t, "alpha", getNamespace(t, cfg))
 }


### PR DESCRIPTION
- create Parent link in Kong command hierarchy so shared flags can be accessed
- make use of shared --config={path} flag for all cardinal commands
- hide flags for pushing build from `cardinal build` command since it isn't working, and isn't needed right now.
- make sure --config points to an existing file
- moved contextWithSigterm into main, and set it as context for any commands that have a Context field
- updated config.GetConfig() to take a filename to directly handle the cmd.Parent.Config value if one is passed in via the `--config` flag
- fixed all tests

There was no ticket for this, just found work.

<!-- greptile_comment -->

## Greptile Summary

This PR improves configuration handling and command structure across the World CLI by adding Parent fields for shared flag access and standardizing config file handling. 

- Added `Parent` fields to command structs with `kong:"-"` tags to enable shared flag access while preventing Kong processing
- Modified `GetConfig()` in `common/config/config.go` to accept an optional filename parameter for explicit config loading
- Moved `contextWithSigterm` to `main.go` and propagated context through command hierarchy
- Hidden registry-related flags in `cmd/world/cardinal/build.go` that aren't currently needed
- Potential issue: Auth token logic in `build.go` appears to overwrite input token when credentials are provided



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->