### PR TITLE
refactor: Login to use command state

### DIFF
--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -43,14 +43,10 @@ func showOrganizationList(ctx context.Context) error {
 	printer.NewLine(1)
 	printer.Headerln("  Organization Information  ")
 	if selectedOrg.Name == "" {
-		printer.NewLine(1)
 		printer.Errorln("No organization selected")
 		printer.NewLine(1)
 		printer.Infoln("Use 'world forge organization switch' to choose an organization")
 	} else {
-		printer.NewLine(1)
-		printer.Infoln(" Available Organizations: ")
-		printer.SectionDivider("-", 26)
 		for _, org := range organizations {
 			if org.ID == selectedOrg.ID {
 				printer.Infof("• %s (%s) [SELECTED]\n", org.Name, org.Slug)
@@ -440,66 +436,4 @@ func getRoleInput(allowNone bool) string {
 		printer.NewLine(1)
 		printer.Errorf("Error: Role must be one of %s\n", opts)
 	}
-}
-
-// handleOrganizationSelection manages the organization selection logic.
-func handleOrganizationSelection(ctx context.Context, orgID string) (string, error) {
-	orgs, err := getListOfOrganizations(ctx)
-	if err != nil {
-		return "", eris.Wrap(err, "Failed to get orgs")
-	}
-
-	switch numOrgs := len(orgs); {
-	case numOrgs == 1:
-		return orgs[0].ID, nil
-	case numOrgs > 1:
-		return handleMultipleOrgs(ctx, orgID, orgs)
-	default:
-		return handleNoOrgs(ctx)
-	}
-}
-
-// handleMultipleOrgs handles the case when there are multiple organizations.
-func handleMultipleOrgs(ctx context.Context, orgID string, orgs []organization) (string, error) {
-	for _, org := range orgs {
-		if org.ID == orgID {
-			return orgID, nil
-		}
-	}
-
-	org, err := selectOrganization(ctx)
-	if err != nil {
-		return "", eris.Wrap(err, "Failed to select organization")
-	}
-	return org.ID, nil
-}
-
-// handleNoOrgs handles the case when there are no organizations.
-func handleNoOrgs(ctx context.Context) (string, error) {
-	for redo := true; redo; {
-		// Confirmation prompt
-		printer.NewLine(1)
-		confirmation := getInput("You don't have any organizations. Create a new one now? (Y/n)", "n")
-
-		switch confirmation {
-		case "Y":
-			redo = false
-		case "y":
-			printer.NewLine(1)
-			printer.Errorln("You need to enter Y (uppercase) to confirm creation")
-		case "n":
-			printer.NewLine(1)
-			printer.Errorln("Organization creation canceled")
-			return "", nil
-		default:
-			printer.NewLine(1)
-			printer.Errorln("Invalid input")
-		}
-	}
-
-	org, err := createOrganization(ctx)
-	if err != nil {
-		return "", eris.Wrap(err, "Failed to create organization")
-	}
-	return org.ID, nil
 }

--- a/cmd/world/forge/organization_flow.go
+++ b/cmd/world/forge/organization_flow.go
@@ -102,6 +102,13 @@ func (flow *initFlow) handleNeedExistingOrgData() error {
 
 	// If we have a selected org, use it
 	if selectedOrg.ID != "" {
+		// Show the org and project lists
+		if err := showOrganizationList(flow.context); err != nil {
+			// If we fail to show the org list, just use the selected org
+			printer.NewLine(1)
+			printer.Headerln("  Organization Information  ")
+			printer.Infof("  Organization: %s (%s)\n", selectedOrg.Name, selectedOrg.Slug)
+		}
 		flow.updateOrganization(&selectedOrg)
 		return nil
 	}
@@ -125,13 +132,17 @@ func (flow *initFlow) handleNeedExistingOrgData() error {
 func (flow *initFlow) handleNeedExistingOrganizationCaseNoOrgs() error {
 	printer.NewLine(1)
 	printer.Errorln("No organizations found.")
-	printer.Infoln("You must be a member of an organization to proceed.")
+	printer.NewLine(1)
+	printer.Headerln("   Options   ")
+	printer.Infoln("1. Use 'world forge organization create' to create an organization.")
+	printer.Infoln("2. Have a member send invite using 'world forge organization invite'.")
 	return ErrOrganizationSelectionCanceled
 }
 
 func (flow *initFlow) handleNeedExistingOrganizationCaseOneOrg(orgs []organization) error {
 	printer.NewLine(1)
-	printer.Infof("Organization: %s [%s]\n", orgs[0].Name, orgs[0].Slug)
+	printer.Headerln("  Organization Information  ")
+	printer.Infof("  %s (%s)\n", orgs[0].Name, orgs[0].Slug)
 	flow.updateOrganization(&orgs[0])
 	return nil
 }

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -87,14 +87,10 @@ func showProjectList(ctx context.Context) error {
 	printer.NewLine(1)
 	printer.Headerln("   Project Information   ")
 	if selectedProject.Name == "" {
-		printer.NewLine(1)
 		printer.Errorln("No project selected")
 		printer.NewLine(1)
 		printer.Infoln("Use 'world forge project switch' to choose a project")
 	} else {
-		printer.NewLine(1)
-		printer.Infoln("  Available Projects:")
-		printer.SectionDivider("-", 23)
 		for _, prj := range projects {
 			if prj.ID == selectedProject.ID {
 				printer.Infof("• %s (%s) [SELECTED]\n", prj.Name, prj.Slug)


### PR DESCRIPTION
# Refactor: Simplify login flow and improve organization/project display

Closes: PLAT-395

## Overview

This PR refactors the login flow to use the existing command state setup mechanism and improves the display of organization and project information. It removes redundant code by leveraging the existing flow infrastructure.

## Brief Changelog

- Replace `handlePostLoginConfig` with `SetupForgeCommandState` to reuse existing flow logic
- Improve organization and project display formatting for better readability
- Remove redundant organization and project selection logic
- Fix error messages when no organizations or projects exist
- Simplify display of selected organizations and projects
- Update function signature for `getToken` to use `any` instead of `interface{}`

## Testing and Verifying

This change is already covered by existing tests for the forge command state setup flow.

<!-- greptile_comment -->

## Greptile Summary

This PR refactors the login flow and improves organization/project display in the World CLI, focusing on code simplification and better user experience.

- Replaces custom post-login configuration with `SetupForgeCommandState` in `login.go` to reduce code duplication
- Improves organization and project display formatting in `organization.go` and `project.go` for better readability
- Removes redundant organization/project selection logic by leveraging existing flow infrastructure
- Updates `getToken` function signature to use `any` instead of `interface{}`
- Consolidates project and organization flow handling in respective `*_flow.go` files



<!-- /greptile_comment -->