### PR TITLE
refactor(command): Convert org to flow

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -261,9 +261,10 @@ func parseResponse[T any](body []byte) (*T, error) {
 func printNoOrganizations() {
 	printer.NewLine(1)
 	printer.Headerln("   No Organizations Found   ")
-	printer.Infoln("You don't have any organizations yet.")
 	printer.NewLine(1)
-	printer.Infoln("Use 'world forge organization create' to create one.")
+	printer.Headerln("   Options   ")
+	printer.Infoln("1. Use 'world forge organization create' to create an organization.")
+	printer.Infoln("2. Have a member send invite using 'world forge organization invite'.")
 }
 
 func printNoSelectedOrganization() {

--- a/cmd/world/forge/init_flow.go
+++ b/cmd/world/forge/init_flow.go
@@ -13,6 +13,10 @@ import (
 	"pkg.world.dev/world-cli/common/printer"
 )
 
+var (
+	ErrLogin = eris.New("not logged in")
+)
+
 // initFlow represents the initialization flow for the forge system.
 type initFlow struct {
 	context              context.Context
@@ -104,7 +108,8 @@ func SetupForgeCommandState( //nolint:gocognit,gocyclo,cyclop,funlen // logic si
 
 	// if we need to login and we are not logged in, return an error
 	if flow.requiredLogin == NeedLogin && !loggedIn {
-		return &flow.State, errors.New("not logged in")
+		printer.Errorln("Login required, please run `world login`")
+		return &flow.State, ErrLogin
 	}
 
 	// if we need the login step, always get the user info
@@ -259,4 +264,10 @@ func (flow *initFlow) AddKnownProject(proj *project) {
 		RepoPath:       proj.RepoPath,
 		ProjectName:    proj.Name,
 	})
+}
+
+// loginErrorCheck is used to check if the error is a login error.
+// Used to prevent reprinting the error which was already printed in a user friendly manner.
+func loginErrorCheck(err error) bool {
+	return eris.Is(err, ErrLogin)
 }

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -1,6 +1,8 @@
 package forge
 
 import (
+	"strings"
+
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/printer"
@@ -176,4 +178,11 @@ func (flow *initFlow) updateProject(project *project) {
 		logger.Error(eris.Wrap(err, "Project flow failed to save config"))
 		// continue on, this is not fatal
 	}
+}
+
+// isDefinedProjectError is used to prevent printed errors from reprinting
+// when being passed to the error handler.
+func isDefinedProjectError(err error) bool {
+	return strings.Contains(err.Error(), ErrProjectSelectionCanceled.Error()) ||
+		strings.Contains(err.Error(), ErrProjectCreationCanceled.Error())
 }

--- a/common/printer/printer.go
+++ b/common/printer/printer.go
@@ -28,8 +28,10 @@ func Successln(msg string) {
 }
 
 func Successf(format string, args ...any) {
-	msg := successStyle.Render(string(logsymbols.Success) + " " + fmt.Sprintf(format, args...))
+	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
+	msg := successStyle.Render(string(logsymbols.Success) + " " + fmt.Sprintf(newFormat, args...))
 	fmt.Print(msg)
+	NewLine(linesRemoved)
 }
 
 func Error(msg string) {
@@ -41,8 +43,10 @@ func Errorln(msg string) {
 }
 
 func Errorf(format string, args ...any) {
-	msg := errorStyle.Render(string(logsymbols.Error) + " " + fmt.Sprintf(format, args...))
+	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
+	msg := errorStyle.Render(string(logsymbols.Error) + " " + fmt.Sprintf(newFormat, args...))
 	fmt.Print(msg)
+	NewLine(linesRemoved)
 }
 
 func Info(msg string) {
@@ -67,8 +71,10 @@ func Headerln(msg string) {
 }
 
 func Headerf(format string, args ...any) {
-	msg := headerStyle.Render(fmt.Sprintf(format, args...))
+	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
+	msg := headerStyle.Render(fmt.Sprintf(newFormat, args...))
 	fmt.Print(msg)
+	NewLine(linesRemoved)
 }
 
 func Notification(msg string) {
@@ -76,8 +82,10 @@ func Notification(msg string) {
 }
 
 func Notificationf(format string, args ...any) {
-	msg := notificationStyle.Render(fmt.Sprintf(format, args...))
+	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
+	msg := notificationStyle.Render(fmt.Sprintf(newFormat, args...))
 	fmt.Print(msg)
+	NewLine(linesRemoved)
 }
 
 func Notificationln(msg string) {
@@ -86,7 +94,7 @@ func Notificationln(msg string) {
 
 func NewLine(numberOfLines int) {
 	if numberOfLines <= 0 {
-		numberOfLines = 1
+		return
 	}
 	fmt.Print(strings.Repeat("\n", numberOfLines))
 }
@@ -113,4 +121,20 @@ func SectionDivider(symbol string, length int) {
 		length = 1
 	}
 	fmt.Println(strings.Repeat(symbol, length))
+}
+
+// trimAndCountTrailingNewlines trims trailing newlines from a string and returns the count.
+// Used for sylized output to ensure the cursor is reset properly.
+func trimAndCountTrailingNewlines(s string) (string, int) {
+	if s == "" {
+		return "", 0
+	}
+
+	count := 0
+	i := len(s)
+	for i > 0 && s[i-1] == '\n' {
+		i--
+		count++
+	}
+	return s[:i], count
 }


### PR DESCRIPTION
# Improved Error Handling and User Experience in Forge Commands

Closes: PLAT-390

## Overview

This PR enhances the user experience in the World CLI forge commands by improving error handling, providing clearer guidance for users without organizations, and adding support for organization selection by slug.

## Brief Changelog

- Added proper error handling for login failures with user-friendly messages
- Improved organization selection flow with better error handling
- Added ability to select an organization by slug via `world forge organization switch --slug=<slug>`
- Enhanced "No Organizations" message to include invitation option
- Prevented duplicate error messages by adding error type checking
- Fixed formatting in printer functions to properly handle trailing newlines
- Refactored organization selection code for better maintainability

## Testing and Verifying

This change can be verified by:
- Running `world forge organization switch --slug=<slug>` with valid and invalid slugs
- Testing the login flow with and without organizations
- Verifying improved error messages when no organizations exist
- Checking that error messages are not duplicated in the output

<!-- greptile_comment -->

## Greptile Summary

This PR refactors the organization management code in the World CLI to improve error handling and user experience. The changes focus on organization selection flows and error message clarity.

- Added `selectOrganizationFromSlug` in `/cmd/world/forge/organization.go` for selecting organizations by slug
- Improved error handling in `/cmd/world/forge/init_flow.go` with dedicated `ErrLogin` type and duplicate message prevention
- Enhanced `/cmd/world/forge/organization_flow.go` with flow-based organization selection and config persistence
- Fixed newline handling in `/common/printer/printer.go` with `trimAndCountTrailingNewlines` helper
- Added clearer guidance in `printNoOrganizations()` with multiple options for users



<!-- /greptile_comment -->