### PR TITLE
refactor: project commands with flow

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -54,7 +54,7 @@ func deployment(ctx context.Context, cmdState *CommandState, deployType string) 
 
 		printer.Infof("Deploy requires a project created in World Forge: %s\n", org.Name)
 
-		pID, err := createProject(ctx)
+		pID, err := createProject(ctx, "", "", "")
 		if err != nil {
 			return eris.Wrap(err, "Failed on deployment to create project")
 		}

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -272,11 +272,22 @@ type CreateProjectCmd struct {
 }
 
 func (c *CreateProjectCmd) Run() error {
-	// TODO: pass in name, slug, and avatarURL if provided
-	project, err := createProject(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	if err != nil {
+		if loginErrorCheck(err) ||
+			isDefinedProjectError(err) ||
+			isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+
+	project, err := createProject(ctx, c.Name, c.Slug, c.AvatarURL)
 	if err != nil {
 		return eris.Wrap(err, "Failed to create project")
 	}
+	printer.NewLine(1)
 	printer.Successf("Created project: %s\n", project.Name)
 	return nil
 }
@@ -286,15 +297,31 @@ type SwitchProjectCmd struct {
 }
 
 func (c *SwitchProjectCmd) Run() error {
-	// TODO: pass in slug if provided
-	project, err := selectProject(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
 	if err != nil {
+		if loginErrorCheck(err) ||
+			isDefinedProjectError(err) ||
+			isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+
+	project, err := selectProject(ctx, c.Slug)
+	if err != nil {
+		if loginErrorCheck(err) ||
+			isDefinedProjectError(err) ||
+			isDefinedOrganizationError(err) {
+			return nil
+		}
 		return eris.Wrap(err, "Failed to select project")
 	}
 	if project == nil {
 		printer.Infoln("No project selected.")
 		return nil
 	}
+	printer.NewLine(1)
 	printer.Successf("Switched to project: %s\n", project.Name)
 	return nil
 }
@@ -306,15 +333,35 @@ type UpdateProjectCmd struct {
 }
 
 func (c *UpdateProjectCmd) Run() error {
-	// TODO: pass in name, slug, and avatarURL if provided
-	return updateProject(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
+	if err != nil {
+		if loginErrorCheck(err) ||
+			isDefinedProjectError(err) ||
+			isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+
+	return updateProject(ctx, c.Name, c.Slug, c.AvatarURL)
 }
 
 type DeleteProjectCmd struct {
 }
 
 func (c *DeleteProjectCmd) Run() error {
-	return deleteProject(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
+	if err != nil {
+		if loginErrorCheck(err) ||
+			isDefinedProjectError(err) ||
+			isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+	return deleteProject(ctx)
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -41,7 +41,7 @@ func (flow *initFlow) handleNeedProjectCaseNoProjects() error {
 
 		switch choice {
 		case "Y":
-			proj, err := createProject(flow.context)
+			proj, err := createProject(flow.context, "", "", "")
 			if err != nil {
 				return eris.Wrap(err, "Flow failed to create project in no-projects case")
 			}
@@ -70,7 +70,7 @@ func (flow *initFlow) handleNeedProjectCaseOneProject(projects []project) error 
 		case "n":
 			return ErrProjectSelectionCanceled
 		case "c":
-			proj, err := createProject(flow.context)
+			proj, err := createProject(flow.context, "", "", "")
 			if err != nil {
 				return eris.Wrap(err, "Flow failed to create project in one-project case")
 			}
@@ -84,7 +84,7 @@ func (flow *initFlow) handleNeedProjectCaseOneProject(projects []project) error 
 }
 
 func (flow *initFlow) handleNeedProjectCaseMultipleProjects() error {
-	proj, err := selectProject(flow.context)
+	proj, err := selectProject(flow.context, "")
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to select project in multiple-projects case")
 	}
@@ -147,7 +147,7 @@ func (flow *initFlow) handleNeedExistingProjectCaseOneProject(projects []project
 }
 
 func (flow *initFlow) handleNeedExistingProjectCaseMultipleProjects() error {
-	proj, err := selectProject(flow.context)
+	proj, err := selectProject(flow.context, "")
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to select project in existing multiple-projects case")
 	}


### PR DESCRIPTION
Closes: WORLD-XXX

feat: Implement CLI project management commands with parameter support

## Overview

This PR enhances the World Forge CLI project management commands by implementing proper parameter handling for project creation, switching, and updating. It allows users to specify project name, slug, and avatar URL directly as command-line arguments rather than only through interactive prompts.

## Brief Changelog

- Added parameter support for `CreateProjectCmd`, `SwitchProjectCmd`, and `UpdateProjectCmd`
- Implemented proper command setup with login and organization validation
- Enhanced project selection to support direct selection by slug
- Added comprehensive tests for the new command implementations
- Improved error handling and user feedback during project operations
- Fixed validation for project names, slugs, and avatar URLs

## Testing and Verifying

This change added tests and can be verified as follows:
- Added unit tests for all project management commands
- Added test cases for parameter handling in project creation and selection
- Added test cases for error conditions and edge cases
- Manually verified the commands work with both parameters and interactive input

<!-- greptile_comment -->

## Greptile Summary

This PR refactors project management commands in the World CLI to implement a flow-based approach with parameter support for project operations.

- Added parameter handling for project name, slug, and avatar URL in `cmd/world/forge/project.go`
- Enhanced project selection to support direct selection by slug and improved validation in `cmd/world/forge/project_flow.go`
- Implemented proper command setup with login and organization validation in `cmd/world/forge/forge.go`
- Added comprehensive test coverage for project management commands in `cmd/world/forge/forge_internal_test.go`
- Improved error handling and user feedback during project operations across all modified files



<!-- /greptile_comment -->