### PR TITLE
refactor: user cmds to flow

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -376,33 +376,57 @@ type UserCmd struct {
 }
 
 type InviteUserToOrganizationCmd struct {
-	Email string `flag:"" help:"The email of the user to invite"`
-	Role  string `flag:"" help:"The role of the user to invite"`
+	ID   string `flag:"" help:"The ID of the user to invite"`
+	Role string `flag:"" help:"The role of the user to invite"`
 }
 
 func (c *InviteUserToOrganizationCmd) Run() error {
-	// TODO: pass in email, role if provided
-	return inviteUserToOrganization(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	if err != nil {
+		if loginErrorCheck(err) || isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+
+	return inviteUserToOrganization(ctx, c.ID, c.Role)
 }
 
 type ChangeUserRoleInOrganizationCmd struct {
-	Email string `flag:"" help:"The email of the user to change the role of"`
-	Role  string `flag:"" help:"The new role of the user"`
+	ID   string `flag:"" help:"The ID of the user to change the role of"`
+	Role string `flag:"" help:"The new role of the user"`
 }
 
 func (c *ChangeUserRoleInOrganizationCmd) Run() error {
-	// TODO: pass in email, role if provided
-	return updateUserRoleInOrganization(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	if err != nil {
+		if loginErrorCheck(err) || isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+
+	return updateUserRoleInOrganization(ctx, c.ID, c.Role)
 }
 
 type UpdateUserCmd struct {
-	Email string `flag:"" help:"The email of the user to update"`
-	Role  string `flag:"" help:"The new role of the user"`
+	Email     string `flag:"" help:"The email of the user to update"`
+	Name      string `flag:"" help:"The new name of the user"`
+	AvatarURL string `flag:"" help:"The new avatar URL of the user"  type:"url"`
 }
 
 func (c *UpdateUserCmd) Run() error {
-	// TODO: pass in email, role if provided
-	return updateUser(context.Background())
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	if err != nil {
+		if loginErrorCheck(err) || isDefinedOrganizationError(err) {
+			return nil
+		}
+		return eris.Wrap(err, "forge command setup failed")
+	}
+	return updateUser(ctx, c.Email, c.Name, c.AvatarURL)
 }
 
 func InitForgeBase(env string) {

--- a/cmd/world/forge/user.go
+++ b/cmd/world/forge/user.go
@@ -33,38 +33,45 @@ func getUser(ctx context.Context) (User, error) {
 	return *user, nil
 }
 
-func updateUser(ctx context.Context) error {
+func updateUser(ctx context.Context, email, name, avatarURL string) error {
 	// get the current user
 	currentUser, err := getUser(ctx)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get current user")
 	}
 
-	payload := User{}
-
 	// prompt update name
-	name, err := inputUserName(ctx, currentUser.Name)
+	if name == "" {
+		name = currentUser.Name
+	}
+	name, err = inputUserName(ctx, name)
 	if err != nil {
 		return eris.Wrap(err, "Failed to input user name")
 	}
 
-	payload.Name = name
-
 	// prompt update email
-	email, err := inputUserEmail(ctx, currentUser.Email)
+	if email == "" {
+		email = currentUser.Email
+	}
+	email, err = inputUserEmail(ctx, email)
 	if err != nil {
 		return eris.Wrap(err, "Failed to input user email")
 	}
 
-	payload.Email = email
-
 	// prompt for avatar url
-	avatarURL, err := inputUserAvatarURL(ctx, currentUser.AvatarURL)
+	if avatarURL == "" {
+		avatarURL = currentUser.AvatarURL
+	}
+	avatarURL, err = inputUserAvatarURL(ctx, avatarURL)
 	if err != nil {
 		return eris.Wrap(err, "Failed to input user avatar URL")
 	}
 
-	payload.AvatarURL = avatarURL
+	payload := User{
+		Name:      name,
+		Email:     email,
+		AvatarURL: avatarURL,
+	}
 
 	_, err = sendRequest(ctx, http.MethodPut, userURL, payload)
 	if err != nil {


### PR DESCRIPTION
# Implement User Management Commands in Forge CLI

Closes: WORLD-XXX

## Overview

This PR implements the user management commands in the Forge CLI, allowing users to invite members to organizations, change user roles, and update user profiles through command-line flags rather than just interactive prompts.

## Brief Changelog

- Updated `InviteUserToOrganizationCmd` to accept user ID and role as flags
- Updated `ChangeUserRoleInOrganizationCmd` to accept user ID and role as flags
- Enhanced `UpdateUserCmd` to accept email, name, and avatar URL as flags
- Modified the underlying functions to accept parameters from command flags
- Added proper command setup with authentication and organization validation
- Added unit tests for the new command implementations

## Testing and Verifying

This change added tests and can be verified as follows:
- Added unit tests for `InviteUserToOrganizationCmd`, `ChangeUserRoleInOrganizationCmd`, and `UpdateUserCmd`
- Commands can be tested manually by running the CLI with the new flag options

<!-- greptile_comment -->

## Greptile Summary

This PR refactors user management commands in the World CLI to support both flag-based and interactive input modes, enhancing flexibility in user operations.

- Modified `inviteUserToOrganization()` and `updateUserRoleInOrganization()` in `/cmd/world/forge/organization.go` to accept ID and role parameters
- Updated user management commands in `/cmd/world/forge/forge.go` to support command-line flags while maintaining interactive fallback
- Enhanced `updateUser()` in `/cmd/world/forge/user.go` to accept email, name, and avatarURL parameters with validation
- Added comprehensive test coverage in `/cmd/world/forge/forge_internal_test.go` for both flag-based and interactive modes
- Implemented consistent error handling and organization validation across all user management operations



<!-- /greptile_comment -->