### PR TITLE
refactor: cleanup code

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -382,15 +382,17 @@ type InviteUserToOrganizationCmd struct {
 
 func (c *InviteUserToOrganizationCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
 	if err != nil {
 		if loginErrorCheck(err) || isDefinedOrganizationError(err) {
 			return nil
 		}
 		return eris.Wrap(err, "forge command setup failed")
 	}
-
-	return inviteUserToOrganization(ctx, c.ID, c.Role)
+	if cmdState.Organization.ID == "" {
+		return eris.New("Forge setup failed, no organization selected")
+	}
+	return cmdState.Organization.inviteUser(ctx, c.ID, c.Role)
 }
 
 type ChangeUserRoleInOrganizationCmd struct {
@@ -400,15 +402,17 @@ type ChangeUserRoleInOrganizationCmd struct {
 
 func (c *ChangeUserRoleInOrganizationCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
 	if err != nil {
 		if loginErrorCheck(err) || isDefinedOrganizationError(err) {
 			return nil
 		}
 		return eris.Wrap(err, "forge command setup failed")
 	}
-
-	return updateUserRoleInOrganization(ctx, c.ID, c.Role)
+	if cmdState.Organization.ID == "" {
+		return eris.New("Forge setup failed, no organization selected")
+	}
+	return cmdState.Organization.updateUserRole(ctx, c.ID, c.Role)
 }
 
 type UpdateUserCmd struct {

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -2683,12 +2683,13 @@ func (s *ForgeTestSuite) TestInviteUserToOrganization() {
 			}
 			defer func() { regionSelector = nil }()
 
+			org := organization{ID: tc.config.OrganizationID}
 			if tc.expectInputFail > 0 {
 				s.PanicsWithError(fmt.Sprintf("Input %d Failed", tc.expectInputFail), func() {
-					err = inviteUserToOrganization(s.ctx, "", "")
+					err = org.inviteUser(s.ctx, "", "")
 				})
 			} else {
-				err = inviteUserToOrganization(s.ctx, "", "")
+				err = org.inviteUser(s.ctx, "", "")
 				if tc.expectedError {
 					s.Error(err)
 				} else {
@@ -2834,12 +2835,13 @@ func (s *ForgeTestSuite) TestUpdateRoleInOrganization() {
 			}
 			defer func() { regionSelector = nil }()
 
+			org := organization{ID: tc.config.OrganizationID}
 			if tc.expectInputFail > 0 {
 				s.PanicsWithError(fmt.Sprintf("Input %d Failed", tc.expectInputFail), func() {
-					err = updateUserRoleInOrganization(s.ctx, "", "")
+					err = org.updateUserRole(s.ctx, "", "")
 				})
 			} else {
-				err = updateUserRoleInOrganization(s.ctx, "", "")
+				err = org.updateUserRole(s.ctx, "", "")
 				if tc.expectedError {
 					s.Error(err)
 				} else {

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -183,6 +183,9 @@ func (flow *initFlow) updateProject(project *project) {
 // isDefinedProjectError is used to prevent printed errors from reprinting
 // when being passed to the error handler.
 func isDefinedProjectError(err error) bool {
+	if err == nil {
+		return false
+	}
 	return strings.Contains(err.Error(), ErrProjectSelectionCanceled.Error()) ||
 		strings.Contains(err.Error(), ErrProjectCreationCanceled.Error())
 }


### PR DESCRIPTION
# Refactor: Organization Methods and Error Handling

Closes: WORLD-XXX

## Overview

This PR refactors organization-related functionality by converting standalone functions to methods on the `organization` struct, improving code organization and reducing redundant code.

## Brief Changelog

- Converted `inviteUserToOrganization` and `updateUserRoleInOrganization` to methods on the `organization` struct
- Refactored `saveOrganizationToConfig` into a method on the `organization` struct
- Updated command handlers to properly pass the organization context to these methods
- Fixed organization selection flow to properly display success messages
- Added nil check in `isDefinedProjectError` to prevent potential panic

## Testing and Verifying

This change is already covered by existing tests, which have been updated to use the new method-based approach.

<!-- greptile_comment -->

## Greptile Summary

Refactored organization-related functionality in World CLI by converting standalone functions to methods on the `organization` struct, improving code organization and maintainability.

- Converted `inviteUserToOrganization` and `updateUserRoleInOrganization` to methods (`inviteUser()`, `updateUserRole()`) on the `organization` struct
- Refactored `saveOrganizationToConfig` to `saveToConfig()` method for better encapsulation
- Added nil check in `isDefinedProjectError` to prevent potential panics
- Updated command handlers in `forge.go` to use new organization struct methods
- Modified test cases to reflect the new method-based approach while maintaining coverage



<!-- /greptile_comment -->