### PR TITLE
refactor: project cleanup

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -334,7 +334,7 @@ type UpdateProjectCmd struct {
 
 func (c *UpdateProjectCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
 	if err != nil {
 		if loginErrorCheck(err) ||
 			isDefinedProjectError(err) ||
@@ -343,8 +343,10 @@ func (c *UpdateProjectCmd) Run() error {
 		}
 		return eris.Wrap(err, "forge command setup failed")
 	}
-
-	return updateProject(ctx, c.Name, c.Slug, c.AvatarURL)
+	if cmdState.Project == nil {
+		return eris.New("Forge setup failed, no project selected")
+	}
+	return cmdState.Project.updateProject(ctx, c.Name, c.Slug, c.AvatarURL)
 }
 
 type DeleteProjectCmd struct {
@@ -352,7 +354,7 @@ type DeleteProjectCmd struct {
 
 func (c *DeleteProjectCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
 	if err != nil {
 		if loginErrorCheck(err) ||
 			isDefinedProjectError(err) ||
@@ -361,7 +363,10 @@ func (c *DeleteProjectCmd) Run() error {
 		}
 		return eris.Wrap(err, "forge command setup failed")
 	}
-	return deleteProject(ctx)
+	if cmdState.Project == nil {
+		return eris.New("Forge setup failed, no project selected")
+	}
+	return cmdState.Project.delete(ctx)
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# refactor: Improve project command structure in forge

Closes: WORLD-XXX

## Overview

This PR refactors the project-related commands in the forge package to use object methods instead of standalone functions, improving code organization and maintainability.

## Brief Changelog

- Converted standalone functions to methods on the `project` struct
- Renamed methods to be more consistent (`inputProjectName` → `inputName`, etc.)
- Added proper error handling when project is nil after command setup
- Updated command implementations to use the project methods directly
- Simplified region retrieval by using project data directly

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The functionality remains the same, but the code structure is improved.

<!-- greptile_comment -->

## Greptile Summary

Refactored project-related commands in the forge package to improve code organization and maintainability by converting standalone functions to methods on the project struct.

- Converted standalone functions to project struct methods in `cmd/world/forge/project.go` for better encapsulation
- Added nil checks for `cmdState.Project` in `cmd/world/forge/forge.go` to improve error handling
- Renamed methods for consistency (e.g., `inputProjectName` → `inputName`) 
- Simplified region retrieval by using project data directly instead of separate functions
- Consolidated notification configuration for Discord and Slack into shared helper methods



<!-- /greptile_comment -->