### PR TITLE
refactor: remove unused function

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -88,7 +88,7 @@ var getInput = func(prompt, defaultStr string) string {
 }
 
 // sendRequest sends an HTTP request with auth token and returns the response body.
-func sendRequest(ctx context.Context, method, url string, body interface{}) ([]byte, error) {
+func sendRequest(ctx context.Context, method, url string, body any) ([]byte, error) {
 	// Prepare request body and headers
 	req, err := prepareRequest(ctx, method, url, body)
 	if err != nil {
@@ -99,7 +99,7 @@ func sendRequest(ctx context.Context, method, url string, body interface{}) ([]b
 	return makeRequestWithRetries(ctx, req)
 }
 
-func prepareRequest(ctx context.Context, method, url string, body interface{}) (*http.Request, error) {
+func prepareRequest(ctx context.Context, method, url string, body any) (*http.Request, error) {
 	var bodyReader io.Reader
 
 	if body != nil {
@@ -289,15 +289,6 @@ func printNoProjectsInOrganization() {
 	printer.Infoln("You don't have any projects in this organization yet.")
 	printer.NewLine(1)
 	printer.Infoln("Use 'world forge project create' to create your first project!")
-}
-
-func isAlphanumeric(s string) bool {
-	for _, r := range s {
-		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
-			return false
-		}
-	}
-	return true
 }
 
 // slugToSaneCheck checks that slug is valid, and returns a sanitized version.

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -739,62 +739,6 @@ func (s *ForgeTestSuite) TestGetSelectedProject() {
 	}
 }
 
-func (s *ForgeTestSuite) TestIsAlphanumeric() {
-	testCases := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "Success - Lowercase alphanumeric",
-			input:    "abc123",
-			expected: true,
-		},
-		{
-			name:     "Success - Uppercase alphanumeric",
-			input:    "ABC123",
-			expected: true,
-		},
-		{
-			name:     "Success - Mixed case alphanumeric",
-			input:    "aBc123",
-			expected: true,
-		},
-		{
-			name:     "Error - Contains hyphen",
-			input:    "abc-123",
-			expected: false,
-		},
-		{
-			name:     "Error - Contains underscore",
-			input:    "abc_123",
-			expected: false,
-		},
-		{
-			name:     "Error - Contains space",
-			input:    "abc 123",
-			expected: false,
-		},
-		{
-			name:     "Error - Contains special character",
-			input:    "abc@123",
-			expected: false,
-		},
-		{
-			name:     "Error - Empty string",
-			input:    "",
-			expected: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			result := isAlphanumeric(tc.input)
-			s.Equal(tc.expected, result)
-		})
-	}
-}
-
 func (s *ForgeTestSuite) TestDeploy() {
 	testCases := []struct {
 		name                string


### PR DESCRIPTION
# refactor: Replace `interface{}` with `any` type alias

Closes: WORLD-XXX

## Overview

This PR replaces the use of `interface{}` with the more modern `any` type alias in the forge package. The `any` type was introduced in Go 1.18 as a more concise alias for `interface{}`.

## Brief Changelog

- Changed parameter types from `interface{}` to `any` in `sendRequest` and `prepareRequest` functions
- Removed unused `isAlphanumeric` function and its associated tests

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The functionality remains unchanged, as `any` is just a type alias for `interface{}`.

<!-- greptile_comment -->

## Greptile Summary

Modernizes Go code by replacing `interface{}` with `any` type alias and removes unused `isAlphanumeric` function in the forge package.

- Changed parameter type from `interface{}` to `any` in `cmd/world/forge/common.go` functions `sendRequest` and `prepareRequest`
- Removed unused `isAlphanumeric` function and its tests from `cmd/world/forge/forge_internal_test.go`
- Functionality remains unchanged as `any` is just a type alias for `interface{}`
- Changes are well-tested through existing HTTP request test coverage



<!-- /greptile_comment -->