### PR TITLE
feat: Edz/plat 250 deploy wait

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -151,8 +151,7 @@ func status(ctx context.Context, cmdState *CommandState) error {
 		return nil
 	}
 
-	printer.Infoln(" Deployment Status ")
-	printer.SectionDivider("-", 19)
+	printer.Headerln("   Deployment Status ")
 	printer.Infof("Project:      %s\n", cmdState.Project.Name)
 	printer.Infof("Project Slug: %s\n", cmdState.Project.Slug)
 	printer.Infof("Repository:   %s\n", cmdState.Project.RepoURL)

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -27,6 +27,9 @@ const (
 	DeployStatusFailed  DeployStatus = "failed"
 	DeployStatusPassed  DeployStatus = "passed"
 	DeployStatusRunning DeployStatus = "running"
+
+	DeployEnvPreview = "dev"
+	DeployEnvLive    = "prod"
 )
 
 type deploymentPreview struct {
@@ -126,9 +129,9 @@ func deployment(ctx context.Context, cmdState *CommandState, deployType string) 
 		return eris.Wrap(err, fmt.Sprintf("Failed to %s project", deployType))
 	}
 
-	env := "dev" //nolint:goconst // not used in other places
+	env := DeployEnvPreview
 	if deployType == "promote" {
-		env = "prod" //nolint:goconst // not used in other places
+		env = DeployEnvLive
 	}
 
 	err = waitUntilDeploymentIsComplete(ctx, cmdState.Project, env, deployType)

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -624,6 +624,7 @@ func waitUntilDeploymentIsComplete(ctx context.Context, project *project, env st
 			if deploy, exists := deploys[env]; exists {
 				printDeploymentStatus(deploy)
 				if shouldShowHealth(deploy) {
+					deployComplete = true // this changes the status message for the spinner
 					// just report health for the single environment
 					healthComplete, err := getAndPrintHealth(ctx, project, map[string]DeployInfo{
 						env: deploy,

--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -397,7 +397,7 @@ func status(ctx context.Context, cmdState *CommandState) error {
 				currRegion = region
 				printer.Infof("• %s\n", currRegion)
 			}
-			printer.Infof("  %d)", instanceNum)
+			printer.Infof("  %d) ", instanceNum)
 			switch {
 			case cardinalOK:
 				printer.Successf("Cardinal: %s - OK\n", cardinalHost)
@@ -408,6 +408,7 @@ func status(ctx context.Context, cmdState *CommandState) error {
 				printer.Errorf("Cardinal: %s - FAIL %d %s\n", cardinalHost, cardinalResultCode,
 					statusFailRegEx.ReplaceAllString(cardinalResultStr, ""))
 			}
+			printer.Info("     ")
 			switch {
 			case nakamaOK:
 				printer.Successf("Nakama:   %s - OK\n", nakamaHost)

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -99,7 +99,7 @@ func (c *DeployCmd) Run() error {
 		deployType = "forceDeploy"
 	}
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedIDOnly)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -111,7 +111,7 @@ type StatusCmd struct {
 
 func (c *StatusCmd) Run() error {
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedIDOnly)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -123,7 +123,7 @@ type PromoteCmd struct {
 
 func (c *PromoteCmd) Run() error {
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedIDOnly)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -135,7 +135,7 @@ type DestroyCmd struct {
 
 func (c *DestroyCmd) Run() error {
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedIDOnly)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -147,7 +147,7 @@ type ResetCmd struct {
 
 func (c *ResetCmd) Run() error {
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedIDOnly)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -161,7 +161,12 @@ type LogsCmd struct {
 }
 
 func (c *LogsCmd) Run() error {
-	return tailLogs(context.Background(), c.Region, c.Env)
+	ctx := context.Background()
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingIDOnly)
+	if err != nil {
+		return eris.Wrap(err, "forge command setup failed")
+	}
+	return tailLogs(ctx, c.Region, c.Env)
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -99,7 +99,7 @@ func (c *DeployCmd) Run() error {
 		deployType = "forceDeploy"
 	}
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedIDOnly, NeedData)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}

--- a/cmd/world/forge/log.go
+++ b/cmd/world/forge/log.go
@@ -95,8 +95,8 @@ func selectEnvironment(availableEnvs []string) (string, error) {
 	// If there are multiple environments, print them and let the user choose
 	printer.NewLine(1)
 	printer.Infoln("Available environments:")
-	printer.Infof("%d. %s\n", 1, "dev")
-	printer.Infof("%d. %s\n", 2, "prod")
+	printer.Infof("%d. %s\n", 1, "PREVIEW")
+	printer.Infof("%d. %s\n", 2, "LIVE")
 
 	inputStr := getInput("Choose an environment", "1")
 	inputInt, err := strconv.Atoi(inputStr)
@@ -108,9 +108,9 @@ func selectEnvironment(availableEnvs []string) (string, error) {
 	}
 
 	if inputInt == 2 {
-		return "prod", nil
+		return DeployEnvLive, nil
 	}
-	return "dev", nil
+	return DeployEnvPreview, nil
 }
 
 func getListOfEnvironments(ctx context.Context, project project) ([]string, error) {

--- a/common/printer/printer.go
+++ b/common/printer/printer.go
@@ -20,7 +20,7 @@ var (
 )
 
 func Success(msg string) {
-	fmt.Print(successStyle.Render(string(logsymbols.Success) + " " + msg))
+	printNewlineSafeStyledMessage(string(logsymbols.Success)+" "+msg, successStyle)
 }
 
 func Successln(msg string) {
@@ -28,14 +28,12 @@ func Successln(msg string) {
 }
 
 func Successf(format string, args ...any) {
-	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
-	msg := successStyle.Render(string(logsymbols.Success) + " " + fmt.Sprintf(newFormat, args...))
-	fmt.Print(msg)
-	NewLine(linesRemoved)
+	msg := fmt.Sprintf(format, args...)
+	printNewlineSafeStyledMessage(string(logsymbols.Success)+" "+msg, successStyle)
 }
 
 func Error(msg string) {
-	fmt.Print(errorStyle.Render(string(logsymbols.Error) + " " + msg))
+	printNewlineSafeStyledMessage(string(logsymbols.Error)+" "+msg, errorStyle)
 }
 
 func Errorln(msg string) {
@@ -43,10 +41,8 @@ func Errorln(msg string) {
 }
 
 func Errorf(format string, args ...any) {
-	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
-	msg := errorStyle.Render(string(logsymbols.Error) + " " + fmt.Sprintf(newFormat, args...))
-	fmt.Print(msg)
-	NewLine(linesRemoved)
+	msg := fmt.Sprintf(format, args...)
+	printNewlineSafeStyledMessage(string(logsymbols.Error)+" "+msg, errorStyle)
 }
 
 func Info(msg string) {
@@ -78,14 +74,12 @@ func Headerf(format string, args ...any) {
 }
 
 func Notification(msg string) {
-	fmt.Print(notificationStyle.Render(msg))
+	printNewlineSafeStyledMessage(msg, notificationStyle)
 }
 
 func Notificationf(format string, args ...any) {
-	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
-	msg := notificationStyle.Render(fmt.Sprintf(newFormat, args...))
-	fmt.Print(msg)
-	NewLine(linesRemoved)
+	msg := fmt.Sprintf(format, args...)
+	printNewlineSafeStyledMessage(msg, notificationStyle)
 }
 
 func Notificationln(msg string) {
@@ -123,18 +117,12 @@ func SectionDivider(symbol string, length int) {
 	fmt.Println(strings.Repeat(symbol, length))
 }
 
-// trimAndCountTrailingNewlines trims trailing newlines from a string and returns the count.
-// Used for sylized output to ensure the cursor is reset properly.
-func trimAndCountTrailingNewlines(s string) (string, int) {
-	if s == "" {
-		return "", 0
+func printNewlineSafeStyledMessage(msg string, style lipgloss.Style) {
+	if strings.HasSuffix(msg, "\n") {
+		msg = strings.TrimSuffix(msg, "\n")
+		styledMsg := style.Render(msg)
+		fmt.Println(styledMsg)
+	} else {
+		fmt.Print(style.Render(msg))
 	}
-
-	count := 0
-	i := len(s)
-	for i > 0 && s[i-1] == '\n' {
-		i--
-		count++
-	}
-	return s[:i], count
 }

--- a/common/printer/printer.go
+++ b/common/printer/printer.go
@@ -67,10 +67,8 @@ func Headerln(msg string) {
 }
 
 func Headerf(format string, args ...any) {
-	newFormat, linesRemoved := trimAndCountTrailingNewlines(format)
-	msg := headerStyle.Render(fmt.Sprintf(newFormat, args...))
-	fmt.Print(msg)
-	NewLine(linesRemoved)
+	msg := fmt.Sprintf(format, args...)
+	printNewlineSafeStyledMessage(msg, headerStyle)
 }
 
 func Notification(msg string) {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR enhances the World CLI's deployment process by adding real-time feedback and status monitoring capabilities. The changes introduce a spinner-based progress indicator and improve status reporting during deployments.

- Added new `waitUntilDeploymentIsComplete` function in `deployment.go` with spinner UI for real-time deployment feedback
- Implemented comprehensive health status tracking with `getAndPrintHealth` function to monitor deployment health across regions
- Introduced environment display name mapping (dev->PREVIEW, prod->LIVE) for clearer environment identification
- Improved printer package with `printNewlineSafeStyledMessage` for consistent styled output handling
- Added extensive test coverage in `forge_internal_test.go` for deployment status and health checks



<!-- /greptile_comment -->