### PR TITLE
refactor: DEVP-100 reorganize forge commands and validate world create name

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -58,20 +58,16 @@ var (
 
 //nolint:lll // needed to put all the help text in the same line
 var ForgeCmdPlugin struct {
-	Login   *LoginCmd   `cmd:"" group:"Getting Started:" help:"Login to World Forge, creating a new account if necessary"`
-	Deploy  *DeployCmd  `cmd:"" group:"Getting Started:" help:"Deploy your World Forge project to a TEST environment in the cloud"`
-	Status  *StatusCmd  `cmd:"" group:"Getting Started:" help:"Check the status of your deployed World Forge project"`
-	Promote *PromoteCmd `cmd:"" group:"Cloud Management Commands:" help:"Deploy your game project to a LIVE environment in the cloud"`
-	Destroy *DestroyCmd `cmd:"" group:"Cloud Management Commands:" help:"Remove your game project's deployed infrastructure from the cloud"`
-	Reset   *ResetCmd   `cmd:"" group:"Cloud Management Commands:" help:"Restart your game project with a clean state"`
-	Logs    *LogsCmd    `cmd:"" group:"Cloud Management Commands:" help:"Tail logs for your game project"`
-	Forge   *ForgeCmd   `cmd:""`
-	User    *UserCmd    `cmd:""`
-}
-
-type ForgeCmd struct { //nolint:revive // this is the "forge" command within the "world" command
+	Login        *LoginCmd        `cmd:"" group:"Getting Started:" help:"Login to World Forge, creating a new account if necessary"`
+	Deploy       *DeployCmd       `cmd:"" group:"Getting Started:" help:"Deploy your World Forge project to a TEST environment in the cloud"`
+	Status       *StatusCmd       `cmd:"" group:"Getting Started:" help:"Check the status of your deployed World Forge project"`
+	Promote      *PromoteCmd      `cmd:"" group:"Cloud Management Commands:" help:"Deploy your game project to a LIVE environment in the cloud"`
+	Destroy      *DestroyCmd      `cmd:"" group:"Cloud Management Commands:" help:"Remove your game project's deployed infrastructure from the cloud"`
+	Reset        *ResetCmd        `cmd:"" group:"Cloud Management Commands:" help:"Restart your game project with a clean state"`
+	Logs         *LogsCmd         `cmd:"" group:"Cloud Management Commands:" help:"Tail logs for your game project"`
 	Organization *OrganizationCmd `cmd:"" aliases:"org"  group:"Organization Commands:" help:"Manage your organizations"`
 	Project      *ProjectCmd      `cmd:"" aliases:"proj" group:"Project Commands:"      help:"Manage your projects"`
+	User         *UserCmd         `cmd:""`
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -84,7 +84,7 @@ func (m WorldCreateModel) Init() tea.Cmd {
 
 // Update handles incoming events and updates the model accordingly.
 //
-//nolint:funlen // Long function, but it's ok because it's structured
+//nolint:funlen,gocognit // Long function, but it's ok because it's structured
 func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case teacmd.CheckDependenciesMsg:
@@ -100,6 +100,11 @@ func (m WorldCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			if m.projectNameInput.Value() == "" {
 				m.projectNameInput.SetValue("starter-game")
+			}
+			// Validate project name doesn't contain spaces
+			if strings.Contains(m.projectNameInput.Value(), " ") {
+				m.logs = append(m.logs, style.CrossIcon.Render()+"Project name cannot contain spaces")
+				return m, tea.Quit
 			}
 			m.projectNameInput.Blur()
 			return m, m.steps.CompleteStepCmd(nil)


### PR DESCRIPTION
Closes: WORLD-XXX

feat: Reorganize World Forge CLI command structure

## Overview

This PR reorganizes the World Forge CLI command structure by removing the redundant `Forge` command and moving the Organization and Project commands to the top level of the command hierarchy.

## Brief Changelog

- Removed the `ForgeCmd` struct which was redundant
- Moved Organization and Project commands to the top level of the `ForgeCmdPlugin` struct
- Maintained all existing command groups and help text

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The functionality remains the same, only the command structure has been reorganized.

<!-- greptile_comment -->

## Greptile Summary

Reorganizes the World Forge CLI command structure by removing the redundant `ForgeCmd` struct and flattening the command hierarchy in `/cmd/world/forge/forge.go`.

- Removed redundant `ForgeCmd` struct nesting in `ForgeCmdPlugin`
- Moved Organization and Project commands to top-level fields in `ForgeCmdPlugin`
- Preserved all existing command groups, help text, and aliases
- Maintains backward compatibility with no functional changes
- Code changes are isolated to command structure organization only



<!-- /greptile_comment -->