### PR TITLE
refactor: DEVP-102 cardinal repo context

### DIFF
--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -493,7 +493,7 @@ func (p *project) inputRepoPath(ctx context.Context) {
 	// Get repository Path
 	var repoPath string
 	for {
-		repoPath = getInput("Enter Repository Cardinal Path", p.RepoPath)
+		repoPath = getInput("Enter path to Cardinal within Repo (Empty Valid)", p.RepoPath)
 
 		// strip off any leading slash
 		repoPath = strings.TrimPrefix(repoPath, "/")


### PR DESCRIPTION
Closes: WORLD-XXX

fix: Improve clarity of repository path prompt in forge project

## Overview

This PR updates the prompt text for entering the repository Cardinal path in the forge project command to make it clearer that an empty value is valid.

## Brief Changelog

- Changed the prompt text from "Enter Repository Cardinal Path" to "Enter location of Cardinal Dir within the repo (Empty Valid)"

## Testing and Verifying

This change is a trivial text update without any test coverage needed. The functionality remains the same, only the prompt text has been improved for clarity.

<!-- greptile_comment -->

## Greptile Summary

Updates the repository Cardinal path prompt text in the forge project command to improve clarity and user experience.

- Changed prompt text in `cmd/world/forge/project.go` from "Enter Repository Cardinal Path" to "Enter location of Cardinal Dir within the repo (Empty Valid)" to better communicate that empty values are acceptable
- Cosmetic change only - functionality for handling empty paths remains unchanged



<!-- /greptile_comment -->