### PR TITLE
fix: DEVP-103 build bug on world cardinal start

### DIFF
--- a/cmd/world/cardinal/start.go
+++ b/cmd/world/cardinal/start.go
@@ -37,7 +37,6 @@ var (
 //nolint:lll // needed to put all the help text in the same line
 type StartCmd struct {
 	Parent     *CardinalCmd `kong:"-"`
-	Build      bool         `         flag:"" help:"Rebuild Docker images before starting"`
 	Detach     bool         `         flag:"" help:"Run in detached mode"`
 	LogLevel   string       `         flag:"" help:"Set the log level for Cardinal"`
 	Debug      bool         `         flag:"" help:"Enable delve debugging"`
@@ -51,7 +50,7 @@ func (c *StartCmd) Run() error { //nolint:gocognit // this is a naturally comple
 	if err != nil {
 		return err
 	}
-	cfg.Build = c.Build
+	cfg.Build = true
 	cfg.Debug = c.Debug
 	cfg.Detach = c.Detach
 	cfg.Telemetry = c.Telemetry


### PR DESCRIPTION
# fix: Always build Docker images when starting Cardinal

Closes: WORLD-XXX

## Overview

This PR modifies the Cardinal start command to always build Docker images before starting, removing the optional `--build` flag.

## Brief Changelog

- Removed the `Build` boolean flag from the `StartCmd` struct
- Set `cfg.Build = true` to always build Docker images when starting Cardinal

## Testing and Verifying

This change is a trivial rework without any test coverage. The behavior can be verified by running the Cardinal start command and confirming that Docker images are always built.

<!-- greptile_comment -->

## Greptile Summary

Modified Cardinal start command to enforce Docker image building on every execution by removing the optional `--build` flag and setting `cfg.Build` to true.

- Removed `Build` boolean flag from `StartCmd` struct in `cmd/world/cardinal/start.go`
- Set `cfg.Build = true` to make Docker image building mandatory before starting Cardinal
- This change ensures fresh builds but may impact startup performance
- Removed user control over build behavior, making it a required step



<!-- /greptile_comment -->