### PR TITLE
refactor(management): DEVP-82 e2e fixes

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -90,9 +90,9 @@ type DeployCmd struct {
 }
 
 func (c *DeployCmd) Run() error {
-	deployType := "deploy"
+	deployType := DeploymentTypeDeploy
 	if c.Force {
-		deployType = "forceDeploy"
+		deployType = DeploymentTypeForceDeploy
 	}
 	ctx := context.Background()
 	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
@@ -107,7 +107,7 @@ type StatusCmd struct {
 
 func (c *StatusCmd) Run() error {
 	ctx := context.Background()
-	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingIDOnly, NeedExistingData)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -123,7 +123,7 @@ func (c *PromoteCmd) Run() error {
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
-	return deployment(ctx, cmdState, "promote")
+	return deployment(ctx, cmdState, DeploymentTypePromote)
 }
 
 type DestroyCmd struct {

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -921,6 +921,11 @@ func (s *ForgeTestSuite) TestStatus() {
 				Project: &project{
 					ID: "test-project-id",
 				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
+				},
 				User: &User{
 					ID: "test-user-id",
 				},
@@ -932,6 +937,11 @@ func (s *ForgeTestSuite) TestStatus() {
 			state: &CommandState{
 				Project: &project{
 					ID: "undeployed-project-id",
+				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
 				},
 				User: &User{
 					ID: "test-user-id",
@@ -945,6 +955,11 @@ func (s *ForgeTestSuite) TestStatus() {
 				Project: &project{
 					ID: "failedbuild-project-id",
 				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
+				},
 				User: &User{
 					ID: "test-user-id",
 				},
@@ -956,6 +971,11 @@ func (s *ForgeTestSuite) TestStatus() {
 			state: &CommandState{
 				Project: &project{
 					ID: "destroyed-project-id",
+				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
 				},
 				User: &User{
 					ID: "test-user-id",
@@ -969,6 +989,11 @@ func (s *ForgeTestSuite) TestStatus() {
 				Project: &project{
 					ID: "reset-project-id",
 				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
+				},
 				User: &User{
 					ID: "test-user-id",
 				},
@@ -980,6 +1005,11 @@ func (s *ForgeTestSuite) TestStatus() {
 			state: &CommandState{
 				Project: &project{
 					ID: "invalid-project-id",
+				},
+				Organization: &organization{
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
 				},
 				User: &User{
 					ID: "test-user-id",
@@ -1003,7 +1033,9 @@ func (s *ForgeTestSuite) TestStatus() {
 			name: "Error - No project selected",
 			state: &CommandState{
 				Organization: &organization{
-					ID: "test-org-id",
+					ID:   "test-org-id",
+					Name: "Test Org",
+					Slug: "test-org",
 				},
 				User: &User{
 					ID: "test-user-id",

--- a/cmd/world/forge/log.go
+++ b/cmd/world/forge/log.go
@@ -146,7 +146,7 @@ func confirmLogParams(params *logParams) error {
 	printer.NewLine(1)
 	printer.Infof("Showing logs for '%s-%s-cardinal' in '%s-%s'\n",
 		params.organization.Slug, params.project.Slug, params.env, params.region)
-	printer.Infoln("(Press Enter to continue | Ctrl+C to cancel/exit)")
+	printer.Info("(Press Enter to continue | Ctrl+C to cancel/exit)")
 	inputStr := getInput("", "")
 	if inputStr != "" {
 		return eris.New("Operation cancelled by user")


### PR DESCRIPTION
# Adds Force Deploy and Promote Deployment Types

Closes: DEVP-82

## Overview

This PR adds support for two new deployment types: Force Deploy and Promote. It also improves the deployment confirmation flow and enhances the status command output with additional organization information.

## Brief Changelog

- Added new deployment type constants: `DeploymentTypeForceDeploy` and `DeploymentTypePromote`
- Updated deployment confirmation prompt to be more concise
- Enhanced status command output to include organization name and slug
- Improved error handling for deployment cancellations
- Fixed the setup requirements for the status command
- Replaced generic "Project has not been deployed" message with a notification-styled message
- Simplified deployment preview output by removing unnecessary dividers

## Testing and Verifying

This change is already covered by existing tests, and the deployment flow can be manually verified by running the deploy, forceDeploy, and promote commands to confirm the updated UI and behavior.

<!-- greptile_comment -->

## Greptile Summary

This PR adds support for force deploy and promote deployment types in the World CLI, while improving deployment confirmation flow and status command output.

- Added `DeploymentTypeForceDeploy` and `DeploymentTypePromote` constants in `/cmd/world/forge/deployment.go` for new deployment types
- Enhanced status command output in `/cmd/world/forge/deployment.go` to include organization name and slug
- Modified deployment type validation in `/cmd/world/forge/deployment.go` to handle new types
- Updated deployment confirmation prompt in `/cmd/world/forge/deployment.go` to be more concise
- Simplified deployment preview UI by removing unnecessary dividers



<!-- /greptile_comment -->