### PR TITLE
feat: DEVP-105 add known repository detection and handling

### DIFF
--- a/cmd/world/forge/deployment.go
+++ b/cmd/world/forge/deployment.go
@@ -149,10 +149,8 @@ func deployment(ctx context.Context, cmdState *CommandState, deployType string) 
 
 func status(ctx context.Context, cmdState *CommandState) error {
 	if cmdState.Project == nil || cmdState.Project.ID == "" {
-		printNoSelectedProject()
 		return nil
 	} else if cmdState.Organization == nil || cmdState.Organization.ID == "" {
-		printNoSelectedOrganization()
 		return nil
 	}
 

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -46,7 +46,7 @@ func login(ctx context.Context) error {
 	}
 
 	// Handle post-login configuration
-	_, err = SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedExistingData)
+	cmdState, err := SetupForgeCommandState(ctx, NeedLogin, NeedData, NeedData)
 	if err != nil {
 		if !loginErrorCheck(err) {
 			// Even we have an error, if it's not a login error, we can display the login success message.
@@ -55,6 +55,16 @@ func login(ctx context.Context) error {
 		return eris.Wrap(err, "forge command setup failed")
 	}
 
+	if cmdState.CurrRepoKnown {
+		printer.NewLine(1)
+		printer.Headerln("   Known Project Details   ")
+		printer.Infof("Organization: %s\n", cmdState.Organization.Name)
+		printer.Infof("Org Slug:     %s\n", cmdState.Organization.Slug)
+		printer.Infof("Project:      %s\n", cmdState.Project.Name)
+		printer.Infof("Project Slug: %s\n", cmdState.Project.Slug)
+		printer.Infof("Repository:   %s\n", cmdState.Project.RepoURL)
+		printer.NewLine(1)
+	}
 	// Display login success message
 	displayLoginSuccess(config)
 

--- a/cmd/world/forge/organization_flow.go
+++ b/cmd/world/forge/organization_flow.go
@@ -117,9 +117,6 @@ func (flow *initFlow) handleNeedExistingOrganizationCaseNoOrgs() error {
 }
 
 func (flow *initFlow) handleNeedExistingOrganizationCaseOneOrg(orgs []organization) error {
-	printer.NewLine(1)
-	printer.Headerln("  Organization Information  ")
-	printer.Infof("  %s (%s)\n", orgs[0].Name, orgs[0].Slug)
 	flow.updateOrganization(&orgs[0])
 	return nil
 }
@@ -128,13 +125,6 @@ func (flow *initFlow) handleNeedExistingOrganizationCaseMultipleOrgs(orgs []orga
 	// First check if we already have a selected organization
 	selectedOrg, err := getSelectedOrganization(flow.context)
 	if err == nil && selectedOrg.ID != "" {
-		// Show the org and project lists
-		if err := showOrganizationList(flow.context); err != nil {
-			// If we fail to show the org list, just use the selected org
-			printer.NewLine(1)
-			printer.Headerln("  Organization Information  ")
-			printer.Infof("  Organization: %s (%s)\n", selectedOrg.Name, selectedOrg.Slug)
-		}
 		flow.updateOrganization(&selectedOrg)
 		return nil
 	}

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -575,7 +575,6 @@ func selectProject(ctx context.Context, flags *SwitchProjectCmd) (*project, erro
 		// Parse selection
 		num, err := strconv.Atoi(input)
 		if err != nil || num < 1 || num > len(projects) {
-			printer.NewLine(1)
 			printer.Errorf("Please enter a number between 1 and %d\n", len(projects))
 			continue
 		}
@@ -592,6 +591,24 @@ func selectProject(ctx context.Context, flags *SwitchProjectCmd) (*project, erro
 		printer.Successf("Switched to project: %s\n", selectedProject.Name)
 		return &selectedProject, nil
 	}
+}
+
+func getProjectDataByID(ctx context.Context, id string) (project, error) {
+	projects, err := getListOfProjects(ctx)
+	if err != nil {
+		return project{}, eris.Wrap(err, "Failed to get projects")
+	}
+
+	if len(projects) == 0 {
+		return project{}, eris.New("No projects found")
+	}
+
+	for _, project := range projects {
+		if project.ID == id {
+			return project, nil
+		}
+	}
+	return project{}, eris.New("Project not found with ID: " + id)
 }
 
 func (p *project) delete(ctx context.Context) error {

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -115,9 +115,6 @@ func (flow *initFlow) handleNeedExistingProjectData() error {
 }
 
 func (flow *initFlow) handleNeedExistingProjectCaseOneProject(projects []project) error {
-	printer.NewLine(1)
-	printer.Headerln("   Project Information   ")
-	printer.Infof("  Project: %s (%s)\n", projects[0].Name, projects[0].Slug)
 	flow.updateProject(&projects[0])
 	return nil
 }
@@ -126,15 +123,10 @@ func (flow *initFlow) handleNeedExistingProjectCaseMultipleProjects() error {
 	// First check if we already have a selected project
 	selectedProj, err := getSelectedProject(flow.context)
 	if err == nil && selectedProj.ID != "" {
-		if err := showProjectList(flow.context); err != nil {
-			// If we fail to show the project list, just use the selected project
-			printer.NewLine(1)
-			printer.Headerln("   Project Information   ")
-			printer.Infof("  Project: %s (%s)\n", selectedProj.Name, selectedProj.Slug)
-		}
 		flow.updateProject(&selectedProj)
 		return nil
 	}
+
 	proj, err := selectProject(flow.context, &SwitchProjectCmd{})
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to select project in existing multiple-projects case")
@@ -158,7 +150,6 @@ func (flow *initFlow) updateProject(project *project) {
 
 	flow.config.ProjectID = project.ID
 	flow.config.CurrProjectName = project.Name
-	flow.config.CurrRepoKnown = true
 
 	err := SaveForgeConfig(flow.config)
 	if err != nil {

--- a/cmd/world/forge/types.go
+++ b/cmd/world/forge/types.go
@@ -12,10 +12,11 @@ type Credential struct {
 }
 
 type CommandState struct {
-	LoggedIn     bool
-	User         *User
-	Organization *organization
-	Project      *project
+	LoggedIn      bool
+	CurrRepoKnown bool
+	User          *User
+	Organization  *organization
+	Project       *project
 }
 
 type KnownProject struct {


### PR DESCRIPTION
# Improved Repository Context Detection and Command State Handling

## Overview

This PR enhances the Forge CLI by improving how it detects and handles known repositories. It adds functionality to automatically identify project and organization context from the current working directory, reducing unnecessary prompts and providing better user feedback.

## Brief Changelog

- Added `inKnownRepo()` method to detect when a user is working in a known repository
- Added tests for the new repository detection functionality
- Enhanced login flow to display project details when in a known repository
- Prevented organization switching when in a known project repository
- Removed redundant information messages and improved user feedback
- Added helper functions to retrieve organization and project data by ID

## Testing and Verifying

This change is covered by the newly added unit test `TestInKnownRepo` which validates that the system correctly identifies known repositories and loads the appropriate organization and project context.

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the World CLI's repository context detection and command state handling, focusing on automatic identification of project/organization context from the working directory.

- Added `inKnownRepo()` in `/cmd/world/forge/init_flow.go` to detect when users are working in a known repository
- Modified login flow in `/cmd/world/forge/login.go` to display project details for known repositories and improve error handling
- Added `getOrganizationDataByID` and `getProjectDataByID` in `/cmd/world/forge/organization.go` and `/cmd/world/forge/project.go` for repository context lookup
- Prevented organization switching in `/cmd/world/forge/organization.go` when in a known project repository
- Added `CurrRepoKnown` field to `CommandState` struct in `/cmd/world/forge/types.go` for tracking repository context



<!-- /greptile_comment -->