### PR TITLE
refactor: DEVP-106 common pkg tests in parallel

### DIFF
--- a/cmd/world/root/root_internal_test.go
+++ b/cmd/world/root/root_internal_test.go
@@ -2,10 +2,13 @@ package root
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +16,20 @@ import (
 	"pkg.world.dev/world-cli/cmd/world/cardinal"
 	"pkg.world.dev/world-cli/cmd/world/evm"
 )
+
+var testCounter uint64
+
+func getUniquePort(t *testing.T, basePort int) string {
+	t.Helper()
+	port := basePort + int(atomic.AddUint64(&testCounter, 1))
+	return strconv.Itoa(port)
+}
+
+func getUniqueNamespace(t *testing.T) string {
+	t.Helper()
+	id := atomic.AddUint64(&testCounter, 1)
+	return fmt.Sprintf("test-%d", id)
+}
 
 // TestMain runs before all tests and handles setup/teardown.
 func TestMain(m *testing.M) {
@@ -86,6 +103,12 @@ func TestExecuteDoctorCommand(t *testing.T) {
 func TestCreateStartStopRestartPurge(t *testing.T) {
 	var err error
 
+	// Unique namespace and port
+	namespace := getUniqueNamespace(t)
+	port := getUniquePort(t, 4040)
+	t.Setenv("CARDINAL_NAMESPACE", namespace)
+	t.Setenv("CARDINAL_PORT", port)
+
 	// Create Cardinal
 	gameDir := t.TempDir()
 	t.Chdir(gameDir)
@@ -146,6 +169,12 @@ func TestCreateStartStopRestartPurge(t *testing.T) {
 }
 
 func TestDev(t *testing.T) {
+	// Unique namespace and port
+	namespace := getUniqueNamespace(t)
+	port := getUniquePort(t, 4040)
+	t.Setenv("CARDINAL_NAMESPACE", namespace)
+	t.Setenv("CARDINAL_PORT", port)
+
 	// Use t.TempDir(), which also auto-cleans the dir
 	gameDir := t.TempDir()
 
@@ -257,6 +286,12 @@ func ServiceIsDown(name, address string, t *testing.T) bool {
 }
 
 func TestEVMStart(t *testing.T) {
+	// Unique namespace and port
+	namespace := getUniqueNamespace(t)
+	port := getUniquePort(t, 9601)
+	t.Setenv("CARDINAL_NAMESPACE", namespace)
+	t.Setenv("EVM_PORT", port)
+
 	// Create temp working dir (auto-cleans up)
 	gameDir := t.TempDir()
 

--- a/common/docker/client_internal_test.go
+++ b/common/docker/client_internal_test.go
@@ -2,8 +2,12 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,17 +18,48 @@ import (
 	"pkg.world.dev/world-cli/common/teacmd"
 )
 
-const (
-	redisPort         = "56379"
-	redisPassword     = "password"
-	cardinalNamespace = "test"
+var (
+	// counter for generating unique test IDs.
+	testCounter uint64
 )
+
+// getUniquePort returns a unique port number for testing.
+func getUniquePort(t *testing.T) string {
+	t.Helper()
+	// Use atomic counter to generate unique port
+	basePort := 56379
+	maxAttempts := 1000 // Try up to 1000 different ports
+
+	for i := 0; i < maxAttempts; i++ {
+		port := basePort + int(atomic.AddUint64(&testCounter, 1))
+		portStr := strconv.Itoa(port)
+
+		// Check if port is available
+		addr := net.JoinHostPort("localhost", portStr)
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			ln.Close()
+			return portStr
+		}
+	}
+
+	t.Fatal("Failed to find an available port after", maxAttempts, "attempts")
+	return "" // This line will never be reached due to t.Fatal above
+}
+
+// getUniqueNamespace returns a unique namespace for testing.
+func getUniqueNamespace(t *testing.T) string {
+	t.Helper()
+	// Use atomic counter to generate unique namespace
+	id := atomic.AddUint64(&testCounter, 1)
+	return fmt.Sprintf("test-%d", id)
+}
 
 func TestMain(m *testing.M) {
 	// Purge any existing containers
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
+			"CARDINAL_NAMESPACE": "test-main", // Use a fixed namespace for TestMain
 		},
 	}
 
@@ -33,179 +68,185 @@ func TestMain(m *testing.M) {
 		logger.Errorf("Failed to create docker client: %v", err)
 		os.Exit(1)
 	}
-
 	err = dockerClient.Purge(context.Background(), service.Nakama,
 		service.Cardinal, service.Redis, service.NakamaDB, service.Jaeger, service.Prometheus)
 	if err != nil {
 		logger.Errorf("Failed to purge containers: %v", err)
 		os.Exit(1)
 	}
-
 	// Run the tests
 	code := m.Run()
-
 	err = dockerClient.Close()
 	if err != nil {
 		logger.Errorf("Failed to close docker client: %v", err)
 		os.Exit(1)
 	}
-
 	os.Exit(code)
 }
 
 func TestStart(t *testing.T) {
+	t.Parallel()
+
+	redisPort := getUniquePort(t)
+	namespace := getUniqueNamespace(t)
+
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
-			"REDIS_PASSWORD":     redisPassword,
+			"CARDINAL_NAMESPACE": namespace,
+			"REDIS_PASSWORD":     "password",
 			"REDIS_PORT":         redisPort,
 		},
 		Detach: true,
 	}
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	ctx := t.Context()
 	assert.NilError(t, dockerClient.Start(ctx, service.Redis), "failed to start container")
 	cleanUp(t, dockerClient)
 
 	// Test if the container is running
-	assert.Assert(t, redislIsUp(t))
+	assert.Assert(t, redisIsUp(t, redisPort))
 }
 
 func TestStop(t *testing.T) {
+	t.Parallel()
+
+	redisPort := getUniquePort(t)
+	namespace := getUniqueNamespace(t)
+
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
-			"REDIS_PASSWORD":     redisPassword,
+			"CARDINAL_NAMESPACE": namespace,
+			"REDIS_PASSWORD":     "password",
 			"REDIS_PORT":         redisPort,
 		},
 		Detach: true,
 	}
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	ctx := t.Context()
 	assert.NilError(t, dockerClient.Start(ctx, service.Redis), "failed to start container")
 	cleanUp(t, dockerClient)
-
 	assert.NilError(t, dockerClient.Stop(ctx, service.Redis), "failed to stop container")
 
 	// Test if the container is stopped
-	assert.Assert(t, redisIsDown(t))
+	assert.Assert(t, redisIsDown(t, redisPort))
 }
 
 func TestRestart(t *testing.T) {
+	t.Parallel()
+
+	redisPort := getUniquePort(t)
+	namespace := getUniqueNamespace(t)
+
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
-			"REDIS_PASSWORD":     redisPassword,
+			"CARDINAL_NAMESPACE": namespace,
+			"REDIS_PASSWORD":     "password",
 			"REDIS_PORT":         redisPort,
 		},
 		Detach: true,
 	}
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	ctx := t.Context()
 	assert.NilError(t, dockerClient.Start(ctx, service.Redis), "failed to start container")
 	cleanUp(t, dockerClient)
-
 	assert.NilError(t, dockerClient.Restart(ctx, service.Redis), "failed to restart container")
 
 	// Test if the container is running
-	assert.Assert(t, redislIsUp(t))
+	assert.Assert(t, redisIsUp(t, redisPort))
 }
 
 func TestPurge(t *testing.T) {
+	t.Parallel()
+
+	redisPort := getUniquePort(t)
+	namespace := getUniqueNamespace(t)
+
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
-			"REDIS_PASSWORD":     redisPassword,
+			"CARDINAL_NAMESPACE": namespace,
+			"REDIS_PASSWORD":     "password",
 			"REDIS_PORT":         redisPort,
 		},
 		Detach: true,
 	}
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	ctx := t.Context()
 	assert.NilError(t, dockerClient.Start(ctx, service.Redis), "failed to start container")
 	assert.NilError(t, dockerClient.Purge(ctx, service.Redis), "failed to purge container")
 
 	// Test if the container is stopped
-	assert.Assert(t, redisIsDown(t))
+	assert.Assert(t, redisIsDown(t, redisPort))
 }
 
 func TestStartUndetach(t *testing.T) {
+	t.Parallel()
+
+	redisPort := getUniquePort(t)
+	namespace := getUniqueNamespace(t)
+
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
-			"REDIS_PASSWORD":     redisPassword,
+			"CARDINAL_NAMESPACE": namespace,
+			"REDIS_PASSWORD":     "password",
 			"REDIS_PORT":         redisPort,
 		},
 	}
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		assert.NilError(t, dockerClient.Start(ctx, service.Redis), "failed to start container")
 		cleanUp(t, dockerClient)
 	}()
-	assert.Assert(t, redislIsUp(t))
+	assert.Assert(t, redisIsUp(t, redisPort))
 
 	cancel()
-	assert.Assert(t, redisIsDown(t))
+	assert.Assert(t, redisIsDown(t, redisPort))
 }
 
 func TestBuild(t *testing.T) {
+	t.Parallel()
+
+	namespace := getUniqueNamespace(t)
+
 	// Create a temporary directory
 	dir := t.TempDir()
-
-	// Change to the temporary directory
-	t.Chdir(dir)
-
-	sgtDir := dir + "/sgt"
+	sgtDir := filepath.Join(dir, "sgt")
 
 	// Pull the repository
 	templateGitURL := "https://github.com/Argus-Labs/starter-game-template.git"
 	err := teacmd.GitCloneCmd(templateGitURL, sgtDir, "Initial commit from World CLI")
 	assert.NilError(t, err)
-
 	// Preparation
 	cfg := &config.Config{
 		DockerEnv: map[string]string{
-			"CARDINAL_NAMESPACE": cardinalNamespace,
+			"CARDINAL_NAMESPACE": namespace,
 		},
 		RootDir: sgtDir,
 	}
 	cardinalService := service.Cardinal(cfg)
 	ctx := t.Context()
-
 	dockerClient, err := NewClient(cfg)
 	assert.NilError(t, err, "Failed to create docker client")
-
 	// Pull prerequisite images
 	assert.NilError(t, dockerClient.pullImages(ctx, cardinalService))
-
 	// Build the image
 	_, err = dockerClient.buildImage(ctx, cardinalService)
 	assert.NilError(t, err, "Failed to build Docker image")
 }
 
-func redislIsUp(t *testing.T) bool {
+func redisIsUp(t *testing.T, port string) bool {
+	t.Helper()
 	up := false
-	for range 60 {
-		conn, err := net.DialTimeout("tcp", "localhost:"+redisPort, time.Second)
+	for i := 0; i < 60; i++ {
+		conn, err := net.DialTimeout("tcp", "localhost:"+port, time.Second)
 		if err != nil {
 			time.Sleep(time.Second)
-			t.Logf("Failed to connect to Redis at localhost:%s, retrying...", redisPort)
+			t.Logf("Failed to connect to Redis at localhost:%s, retrying...", port)
 			continue
 		}
 		_ = conn.Close()
@@ -215,29 +256,28 @@ func redislIsUp(t *testing.T) bool {
 	return up
 }
 
-func redisIsDown(t *testing.T) bool {
+func redisIsDown(t *testing.T, port string) bool {
+	t.Helper()
 	down := false
-	for range 60 {
-		conn, err := net.DialTimeout("tcp", "localhost:"+redisPort, time.Second)
+	for i := 0; i < 60; i++ {
+		conn, err := net.DialTimeout("tcp", "localhost:"+port, time.Second)
 		if err != nil {
 			down = true
 			break
 		}
 		_ = conn.Close()
 		time.Sleep(time.Second)
-		t.Logf("Redis is still running at localhost:%s, retrying...", redisPort)
+		t.Logf("Redis is still running at localhost:%s, retrying...", port)
 		continue
 	}
 	return down
 }
-
 func cleanUp(t *testing.T, dockerClient *Client) {
 	t.Cleanup(func() {
 		//nolint:usetesting // don't use t.Context() here; it's canceled during cleanup
 		assert.NilError(t, dockerClient.Purge(context.Background(), service.Nakama,
 			service.Cardinal, service.Redis, service.NakamaDB, service.Jaeger, service.Prometheus),
 			"Failed to purge container during cleanup")
-
 		assert.NilError(t, dockerClient.Close())
 	})
 }

--- a/common/editor/editor_internal_test.go
+++ b/common/editor/editor_internal_test.go
@@ -12,61 +12,52 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-const (
-	testDir       = ".test-worldcli"
-	testTargetDir = ".test-worldcli/.editor"
-)
-
 func TestSetupCardinalEditor(t *testing.T) {
+	t.Parallel()
+
+	// Create test-specific directories
+	testDir := filepath.Join(t.TempDir(), "test-worldcli")
+	testTargetDir := filepath.Join(testDir, ".editor")
+
 	t.Run("setup cardinal editor", func(t *testing.T) {
+		t.Parallel()
 		assert.NilError(t, cleanUpDir(testDir))
 
 		latestVersion, err := getLatestReleaseVersion()
 		assert.NilError(t, err)
 		downloadURL := fmt.Sprintf(downloadURLPattern, latestVersion, latestVersion)
-
 		editorDir, err := downloadReleaseIfNotCached(latestVersion, downloadURL, testDir)
 		assert.NilError(t, err)
-
 		// check if editor directory exists
 		_, err = os.Stat(editorDir)
 		exists := os.IsNotExist(err)
 		assert.Equal(t, exists, false)
-
 		// check if it's not empty
 		dir, err := os.ReadDir(editorDir)
 		assert.NilError(t, err)
 		assert.Assert(t, len(dir) != 0)
-
 		// check if folder is renamed
 		err = copyDir(editorDir, testTargetDir)
 		assert.NilError(t, err)
-
 		_, err = os.Stat(testTargetDir)
 		exists = os.IsNotExist(err)
 		assert.Equal(t, exists, false)
-
 		// check if project id is replaced
 		projectID := "__THIS_IS_FOR_TESTING_ONLY__"
 		err = replaceProjectIDs(testTargetDir, projectID)
 		assert.NilError(t, err)
-
 		containsNewID, err := containsCardinalProjectIDPlaceholder(testTargetDir, projectID)
 		assert.NilError(t, err)
 		assert.Equal(t, containsNewID, true)
-
 		// TODO: check if cardinal editor works
-
 		assert.NilError(t, cleanUpDir(testDir))
 	})
 }
-
 func containsCardinalProjectIDPlaceholder(dir string, originalID string) (bool, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
-
 	for _, file := range files {
 		// recurse over child directories
 		if file.IsDir() {
@@ -76,15 +67,12 @@ func containsCardinalProjectIDPlaceholder(dir string, originalID string) (bool, 
 			}
 			continue
 		}
-
 		if strings.HasSuffix(file.Name(), ".js") {
 			filePath := filepath.Join(dir, file.Name())
-
 			content, err := os.ReadFile(filePath)
 			if err != nil {
 				return false, err
 			}
-
 			if strings.Contains(string(content), originalID) {
 				return true, nil
 			}
@@ -93,102 +81,130 @@ func containsCardinalProjectIDPlaceholder(dir string, originalID string) (bool, 
 
 	return false, nil
 }
+
 func TestCopyDir(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Test copy directory", func(t *testing.T) {
-		err := os.MkdirAll("tmp", 0755)
+		t.Parallel()
+		// Use test-specific directories
+		srcDir := filepath.Join(t.TempDir(), "tmp")
+		dstDir := filepath.Join(t.TempDir(), "tmp2")
+
+		err := os.MkdirAll(srcDir, 0755)
 		assert.NilError(t, err)
 
-		err = os.MkdirAll(filepath.Join("tmp", "subdir"), 0755)
+		err = os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755)
 		assert.NilError(t, err)
 
-		_, err = os.Create(filepath.Join("tmp", "file1"))
+		_, err = os.Create(filepath.Join(srcDir, "file1"))
 		assert.NilError(t, err)
 
-		_, err = os.Create(filepath.Join("tmp", "subdir", "file2"))
+		_, err = os.Create(filepath.Join(srcDir, "subdir", "file2"))
 		assert.NilError(t, err)
 
-		err = copyDir("tmp", "tmp2")
+		err = copyDir(srcDir, dstDir)
 		assert.NilError(t, err)
 
-		_, err = os.Stat("tmp")
+		_, err = os.Stat(srcDir)
 		assert.NilError(t, err)
 
-		_, err = os.Stat("tmp2")
+		_, err = os.Stat(dstDir)
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join("tmp2", "subdir"))
+		_, err = os.Stat(filepath.Join(dstDir, "subdir"))
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join("tmp2", "file1"))
+		_, err = os.Stat(filepath.Join(dstDir, "file1"))
 		assert.NilError(t, err)
 
-		_, err = os.Stat(filepath.Join("tmp2", "subdir", "file2"))
+		_, err = os.Stat(filepath.Join(dstDir, "subdir", "file2"))
 		assert.NilError(t, err)
 
-		assert.NilError(t, cleanUpDir("tmp"))
-		assert.NilError(t, cleanUpDir("tmp2"))
+		assert.NilError(t, cleanUpDir(srcDir))
+		assert.NilError(t, cleanUpDir(dstDir))
 	})
 }
 
 func TestStrippedGUID(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Test guid doesn't contain -", func(t *testing.T) {
+		t.Parallel()
 		s := strippedGUID()
 		assert.Check(t, !strings.Contains(s, "-"))
 	})
 }
 
 func TestAddFileVersion(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name       string
 		version    string
 		shouldFail bool
 	}{
-		{"v0.1.0", false},
-		{"/v1.0.1", true},
+		{
+			name:       "valid version",
+			version:    "v0.1.0",
+			shouldFail: false,
+		},
+		{
+			name:       "invalid version with leading slash",
+			version:    "/v1.0.1",
+			shouldFail: true,
+		},
 	}
 
 	for _, tc := range testCases {
-		err := addFileVersion(tc.version)
+		// capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		if tc.shouldFail && err == nil {
-			t.Errorf("Expected addFileVersion to fail for version '%s', but it didn't", tc.version)
-		} else if !tc.shouldFail {
-			if err != nil {
-				t.Errorf("addFileVersion failed for version '%s': %s", tc.version, err)
+			// For invalid paths, use the original path to test the error case
+			versionPath := tc.version
+			if !tc.shouldFail {
+				versionPath = filepath.Join(t.TempDir(), tc.version)
 			}
 
-			// Check if file exists
-			_, err = os.Stat(tc.version)
-			if os.IsNotExist(err) {
-				t.Errorf("file %s was not created", tc.version)
-			}
+			err := addFileVersion(versionPath)
 
-			// Cleanup
-			err = os.Remove(tc.version)
-			if err != nil {
-				t.Logf("Failed to delete test file '%s': %s", tc.version, err)
+			if tc.shouldFail {
+				if err == nil {
+					t.Errorf("Expected addFileVersion to fail for version '%s', but it didn't", tc.version)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("addFileVersion failed for version '%s': %s", tc.version, err)
+				}
+
+				// Check if file exists
+				_, err = os.Stat(versionPath)
+				if os.IsNotExist(err) {
+					t.Errorf("file %s was not created", versionPath)
+				}
 			}
-		}
+		})
 	}
 }
 
 func TestGetModuleVersion(t *testing.T) {
+	t.Parallel()
+
 	// Setup temporary go.mod file for testing
 	gomodContent := `
 module example.com/mymodule
-
 go 1.21.1
-
 require (
 	pkg.world.dev/world-engine/cardinal v1.2.3-beta
 	github.com/moduleexample/v3 v3.2.1
 )
 `
-	gomodPath := "./test-go.mod"
+	gomodPath := filepath.Join(t.TempDir(), "test-go.mod")
 	err := os.WriteFile(gomodPath, []byte(gomodContent), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(gomodPath) // clean up
 
 	tests := []struct {
 		name        string
@@ -213,7 +229,7 @@ require (
 		},
 		{
 			name:        "go.mod file does not exist",
-			gomodPath:   "./nonexistent-go.mod",
+			gomodPath:   filepath.Join(t.TempDir(), "nonexistent-go.mod"),
 			modulePath:  "github.com/moduleexample",
 			wantVersion: "",
 			expectError: true,
@@ -221,7 +237,10 @@ require (
 	}
 
 	for _, tt := range tests {
+		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			version, err := getModuleVersion(tt.gomodPath, tt.modulePath)
 			if (err != nil) != tt.expectError {
 				t.Errorf("getModuleVersion() error = %v, expectError %v", err, tt.expectError)
@@ -235,37 +254,41 @@ require (
 }
 
 func TestFileExists(t *testing.T) {
-	// Create a temporary file and defer its removal
-	tempFile, err := os.CreateTemp(t.TempDir(), "example")
-	if err != nil {
-		t.Fatalf("Unable to create temporary file: %s", err)
-	}
-	defer os.Remove(tempFile.Name())
+	t.Parallel()
 
-	// Test case where the file does exist
-	if exists := fileExists(tempFile.Name()); !exists {
-		t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, true)
-	}
+	t.Run("Test file exists", func(t *testing.T) {
+		t.Parallel()
+		// Create a temporary file
+		tempFile, err := os.CreateTemp(t.TempDir(), "example")
+		if err != nil {
+			t.Fatalf("Unable to create temporary file: %s", err)
+		}
+		defer os.Remove(tempFile.Name())
 
-	// Remove the file to simulate it not existing
-	tempFile.Close()
-	os.Remove(tempFile.Name())
+		// Test case where the file does exist
+		if exists := fileExists(tempFile.Name()); !exists {
+			t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, true)
+		}
 
-	// Test case where the file does not exist
-	if exists := fileExists(tempFile.Name()); exists {
-		t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, false)
-	}
+		// Remove the file to simulate it not existing
+		tempFile.Close()
+		os.Remove(tempFile.Name())
 
-	// Create a temporary directory and defer its removal
-	tempDir := t.TempDir()
+		// Test case where the file does not exist
+		if exists := fileExists(tempFile.Name()); exists {
+			t.Errorf("fileExists(%s) = %v, want %v", tempFile.Name(), exists, false)
+		}
 
-	// Test case where the path is a directory
-	if exists := fileExists(tempDir); exists {
-		t.Errorf("fileExists(%s) = %v, want %v", tempDir, exists, false)
-	}
+		// Test case where the path is a directory
+		if exists := fileExists(t.TempDir()); exists {
+			t.Errorf("fileExists(%s) = %v, want %v", t.TempDir(), exists, false)
+		}
+	})
 }
 
 func TestGetVersionMap(t *testing.T) {
+	t.Parallel()
+
 	// Define test cases
 	tests := []struct {
 		name           string
@@ -306,14 +329,16 @@ func TestGetVersionMap(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		// capture range variable
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Setup a test server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tc.serverStatus)
 				fmt.Fprintln(w, tc.serverResponse)
 			}))
 			defer server.Close()
-
 			// Call the function with the test server URL
 			got, err := getVersionMap(server.URL)
 			if (err != nil) != tc.wantErr {
@@ -339,7 +364,6 @@ func compareMaps(a, b map[string]string) bool {
 	}
 	return true
 }
-
 func cleanUpDir(targetDir string) error {
 	return os.RemoveAll(targetDir)
 }

--- a/common/login/login_internal_test.go
+++ b/common/login/login_internal_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDecryptAccessToken(t *testing.T) {
+	t.Parallel()
 	// Initialize encryption
 	enc, err := NewEncryption()
 	require.NoError(t, err)

--- a/common/teacmd/git_internal_test.go
+++ b/common/teacmd/git_internal_test.go
@@ -14,12 +14,12 @@ import (
 const templateURLTest = "https://github.com/Argus-Labs/starter-game-template.git"
 
 func TestGitCloneCmd(t *testing.T) {
+	t.Parallel()
 	type param struct {
 		url       string
 		targetDir string
 		initMsg   string
 	}
-
 	test := []struct {
 		name     string
 		wantErr  bool
@@ -49,6 +49,7 @@ func TestGitCloneCmd(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// clean up before test
 			cleanUpDir(tt.param.targetDir)
 
@@ -58,13 +59,11 @@ func TestGitCloneCmd(t *testing.T) {
 			} else {
 				assert.NilError(t, err)
 			}
-
 			// clean up after test
 			cleanUpDir(tt.param.targetDir)
 		})
 	}
 }
-
 func cleanUpDir(targetDir string) {
 	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
 		err := os.RemoveAll(targetDir)
@@ -75,27 +74,17 @@ func cleanUpDir(targetDir string) {
 }
 
 func TestAppendToToml(t *testing.T) {
-	// Create a temporary TOML file for testing
-	tempFile, err := os.CreateTemp(t.TempDir(), "test.toml")
-	if err != nil {
-		t.Fatalf("failed to create temporary file: %v", err)
-	}
-	t.Cleanup(func() {
-		os.Remove(tempFile.Name())
-	})
-
+	t.Parallel()
 	// Define test cases
 	tests := []struct {
 		name          string
-		filePath      string
 		section       string
 		fields        map[string]any
 		expectedError error
 	}{
 		{
-			name:     "append first section and fields",
-			filePath: tempFile.Name(),
-			section:  "example_section",
+			name:    "append first section and fields",
+			section: "example_section",
 			fields: map[string]any{
 				"field1": "example_value",
 				"field2": 123,
@@ -103,9 +92,8 @@ func TestAppendToToml(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:     "append fields to existing section",
-			filePath: tempFile.Name(),
-			section:  "example_section",
+			name:    "append fields to existing section",
+			section: "example_section",
 			fields: map[string]any{
 				"field1": "replaced_value",
 				"field2": 321,
@@ -113,9 +101,8 @@ func TestAppendToToml(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:     "create new section and append fields",
-			filePath: tempFile.Name(),
-			section:  "new_section",
+			name:    "create new section and append fields",
+			section: "new_section",
 			fields: map[string]any{
 				"field3": true,
 				"field4": 3.14,
@@ -127,8 +114,30 @@ func TestAppendToToml(t *testing.T) {
 
 	// Run test cases
 	for _, tt := range tests {
+		// capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			err := appendToToml(tt.filePath, tt.section, tt.fields)
+			t.Parallel()
+			// Create a temporary file for this subtest
+			tempFile, err := os.CreateTemp(t.TempDir(), "test.toml")
+			if err != nil {
+				t.Fatalf("failed to create temporary file: %v", err)
+			}
+			t.Cleanup(func() {
+				os.Remove(tempFile.Name())
+			})
+
+			// For tests that need to append to existing content, create the initial content
+			if tt.name == "append fields to existing section" {
+				initialContent := `[example_section]
+field1 = "old_value"
+field2 = 0
+`
+				if err := os.WriteFile(tempFile.Name(), []byte(initialContent), 0644); err != nil {
+					t.Fatalf("failed to write initial content: %v", err)
+				}
+			}
+
+			err = appendToToml(tempFile.Name(), tt.section, tt.fields)
 			if !errors.Is(err, tt.expectedError) {
 				t.Errorf("unexpected error: got %v, want %v", err, tt.expectedError)
 			}
@@ -137,6 +146,7 @@ func TestAppendToToml(t *testing.T) {
 }
 
 func TestGenerateRandomHexString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		length int
@@ -157,11 +167,11 @@ func TestGenerateRandomHexString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := generateRandomHexString(tt.length)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-
 			if len(got) != tt.length*2 {
 				t.Errorf("unexpected length of generated hex string: got %d, want %d", len(got), tt.length*2)
 			}


### PR DESCRIPTION


feat: Improve test parallelization and isolation

## Overview

This PR improves test reliability by making tests run in parallel and ensuring proper test isolation. It introduces dynamic port allocation and unique namespaces for Docker tests to prevent conflicts when tests run concurrently.

## Brief Changelog

- Added `t.Parallel()` to test functions to enable concurrent test execution
- Implemented `getUniquePort()` and `getUniqueNamespace()` functions to generate unique test resources
- Replaced hardcoded test directories with `t.TempDir()` for proper test isolation
- Added atomic counter to ensure unique resource allocation across parallel tests
- Modified test cleanup to properly handle resources in concurrent environments
- Improved test structure to avoid shared state between subtests

## Testing and Verifying

This change is already covered by existing tests. The modifications ensure that tests can run in parallel without interfering with each other, which improves test reliability and reduces test execution time.

<!-- greptile_comment -->

## Greptile Summary

This PR improves test parallelization and isolation across multiple test files in the world-cli repository by:

- Added `t.Parallel()` to enable concurrent test execution across all test files
- Implemented dynamic resource allocation with `getUniquePort()` and `getUniqueNamespace()` using atomic counters
- Replaced static test directories with `t.TempDir()` for proper isolation
- Improved cleanup handling for concurrent test environments
- Fixed potential race conditions by properly capturing range variables in subtests



<!-- /greptile_comment -->