### PR TITLE
fix: URL validation dns lookup to see if valid URL

### DIFF
--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -2046,7 +2046,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 		setupWorldToml      bool // New field to indicate if we should create world.toml
 	}{
 		{
-			name: "Success - Public repo default slug",
+			name: "Success - Public repo default slug + avatar URL validation",
 			config: Config{
 				OrganizationID: "test-org-id",
 				Credential: Credential{
@@ -2058,16 +2058,20 @@ func (s *ForgeTestSuite) TestCreateProject() {
 				"Test Project", // name
 				"",             // take default
 				"https://github.com/argus-labs/starter-game-template", // Repository URL
-				"",                // repoToken (empty for public repo)
-				"",                // repoPath (empty for default root path of repo)
-				"10",              // tick rate
-				"Y",               // enable discord notifications  NOTE: these won't show up in the console
-				"test-token",      // discord token                       because results are mocked
-				"1234567890",      // discord channel ID
-				"Y",               // enable slack notifications
-				"test-token",      // slack token
-				"1234567890",      // slack channel ID
-				"http://test.com", // avatar URL
+				"",                 // repoToken (empty for public repo)
+				"",                 // repoPath (empty for default root path of repo)
+				"10",               // tick rate
+				"Y",                // enable discord notifications  NOTE: these won't show up in the console
+				"test-token",       // discord token                       because results are mocked
+				"1234567890",       // discord channel ID
+				"Y",                // enable slack notifications
+				"test-token",       // slack token
+				"1234567890",       // slack channel ID
+				"test.com",         // no http
+				"http://test",      // no tld
+				"http://.co.uk",    // invalid domain
+				"http://localhost", // localhost invalid
+				"http://test.com",  // avatar URL
 			},
 			regionSelectActions: []tea.KeyMsg{
 				{Type: tea.KeySpace}, // select region

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -311,8 +311,8 @@ func createOrganization(ctx context.Context, flags *CreateOrganizationCmd) (*org
 				break
 			}
 
-			if !isValidURL(orgAvatarURL) {
-				printer.Errorln("Invalid URL, leave empty to skip")
+			if err := isValidURL(orgAvatarURL); err != nil {
+				printer.Errorln(err.Error())
 				printer.NewLine(1)
 				continue
 			}

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -674,8 +674,7 @@ func (p *project) updateProject(ctx context.Context, flags *UpdateProjectCmd) er
 	p.AvatarURL = flags.AvatarURL
 
 	printer.NewLine(1)
-	printer.Infoln("  Project Update  ")
-	printer.SectionDivider("-", 18)
+	printer.Headerln("  Project Update  ")
 
 	// get project input
 	err = p.getSetupInput(ctx, regions)
@@ -1073,8 +1072,8 @@ func (p *project) inputAvatarURL(ctx context.Context) error {
 				return nil
 			}
 
-			if !isValidURL(avatarURL) {
-				printer.Errorln("Invalid URL")
+			if err := isValidURL(avatarURL); err != nil {
+				printer.Errorln(err.Error())
 				printer.NewLine(1)
 				p.AvatarURL = ""
 				continue

--- a/cmd/world/forge/user.go
+++ b/cmd/world/forge/user.go
@@ -133,8 +133,8 @@ func inputUserAvatarURL(ctx context.Context, // TODO: refactor
 			if avatarURL == "" {
 				return avatarURL, nil
 			}
-			if !isValidURL(avatarURL) {
-				printer.Errorln("Invalid URL format")
+			if err := isValidURL(avatarURL); err != nil {
+				printer.Errorln(err.Error())
 				printer.NewLine(1)
 				continue
 			}


### PR DESCRIPTION
# feat: Enhance URL validation with DNS lookup and improved error messages

Closes: WORLD-XXX

## Overview

This PR enhances URL validation by adding DNS lookup verification and providing more specific error messages when invalid URLs are entered. The validation now checks that URLs have proper formatting, include a valid TLD, are not using localhost, and that the domain actually exists.

## Brief Changelog

- Changed `isValidURL` to return an error with specific validation failure reason instead of a boolean
- Added validation for proper URL format (must start with http:// or https://)
- Added validation for TLD presence in the hostname
- Added explicit rejection of localhost URLs
- Implemented DNS lookup to verify domain existence
- Updated all callers to handle the new error-based validation approach
- Improved error messaging to users when URL validation fails

## Testing and Verifying

This change can be verified by attempting to enter various invalid URLs during organization creation, project updates, or user avatar URL settings:
- URLs without http/https prefix
- URLs without a valid TLD
- localhost URLs
- URLs with non-existent domains

Each should now display a specific error message explaining why the URL is invalid.

<!-- greptile_comment -->

## Greptile Summary

Enhanced URL validation in the World CLI by implementing DNS lookup verification and detailed error messaging for invalid URLs across organization, project, and user management features.

- Modified `isValidURL` in `cmd/world/forge/common.go` to return specific error messages instead of boolean, adding DNS lookup and TLD validation
- Updated avatar URL validation in `cmd/world/forge/organization.go` with improved error handling and user feedback
- Enhanced URL validation in `cmd/world/forge/project.go` with specific failure messages and better UI formatting
- Implemented proper error handling for optional avatar URLs in `cmd/world/forge/user.go`



<!-- /greptile_comment -->