### PR TITLE
chore: update gitignore DEVP-33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,75 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
+# =======================
+# General Go .gitignore
+# =======================
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
+*.a
+*.o
+*.obj
 
-# Test binary, built with `go test -c`
+# Go test binaries and debug
 *.test
+debug
+debug.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Coverage and profiling outputs
 *.out
+*.prof
+*.trace
+coverage.*
 
-# Dependency directories (remove the comment below to include it)
+# Dependency directories
 vendor/
+node_modules/
 
-# Go workspace file
+# Go workspace
 go.work
+go.work.sum
 
-# Build
-world-cli
-dist/
+# Build artifacts
+/world-cli
+/world
+/dist/
+/bin/
+/build/
 
-# Mac
+# IDEs and Editors
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+*.sublime-project
+*.sublime-workspace
+
+# OS-generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
 
-# Jetbrains
-.idea
+# Env files
+.env
+.env.local
+.env.*.local
 
-# Test
+# Test and temporary directories
 /starter-game
+/tmp/
+/temp/
 
-# Built binary
-./world
+# Logs
+*.log
+
+# Generated Go files (protobuf, codegen)
+*.pb.go
+*.pb.gw.go
+*.gen.go


### PR DESCRIPTION
# Chore: Enhance .gitignore with comprehensive patterns

DEVP-33

## Overview

This PR enhances our .gitignore file with more comprehensive patterns to better exclude unwanted files from version control. It adds more specific patterns for Go development, IDE configurations, OS-generated files, and various build artifacts.

## Brief Changelog

- Organized .gitignore into logical sections with clear headers
- Added patterns for additional Go-related files (*.a, *.o, *.obj)
- Included more debug and test output patterns
- Added IDE/editor specific patterns (.vscode/, *.swp, etc.)
- Expanded OS-generated file patterns beyond just .DS_Store
- Added patterns for environment files (.env*)
- Included patterns for logs and generated Go files
- Added temporary directories and additional build output locations

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The updated patterns follow standard Git ignore conventions and have been verified to properly exclude the specified file types.

<!-- greptile_comment -->

## Greptile Summary

Updates the `.gitignore` file with comprehensive patterns for better version control management in the World CLI project.

- Added organized sections with clear headers for different file types
- Expanded Go-specific patterns to include `*.a`, `*.o`, `*.obj`, and additional debug/test outputs
- Added IDE/editor patterns for `.vscode/`, `.idea/`, and swap files
- Included environment file patterns (`.env*`) and temporary directories
- Added patterns for generated Go files (`*.pb.go`, `*.gen.go`) and build artifacts



<!-- /greptile_comment -->