### PR TITLE
fix: DEVP-129 repo lookup

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -182,7 +182,7 @@ type CreateOrganizationCmd struct {
 
 func (c *CreateOrganizationCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, Ignore, Ignore)
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedRepoLookup, NeedRepoLookup)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -197,7 +197,7 @@ type SwitchOrganizationCmd struct {
 
 func (c *SwitchOrganizationCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, Ignore, Ignore)
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedRepoLookup, NeedRepoLookup)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -225,7 +225,7 @@ type CreateProjectCmd struct {
 
 func (c *CreateProjectCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedRepoLookup)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}
@@ -240,7 +240,7 @@ type SwitchProjectCmd struct {
 
 func (c *SwitchProjectCmd) Run() error {
 	ctx := context.Background()
-	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, Ignore)
+	_, err := SetupForgeCommandState(ctx, NeedLogin, NeedExistingData, NeedRepoLookup)
 	if err != nil {
 		return eris.Wrap(err, "forge command setup failed")
 	}

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -107,7 +107,7 @@ func selectOrganization(ctx context.Context, flags *SwitchOrganizationCmd) (orga
 		return organization{}, eris.Wrap(err, "Could not get config")
 	}
 	if config.CurrRepoKnown {
-		printer.Errorf("Current git working directory belongs to project %s. Cannot switch.\n",
+		printer.Errorf("Current git working directory belongs to project %s.\n  Cannot switch Organization.\n",
 			config.CurrProjectName)
 		return organization{}, nil
 	}

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -536,7 +536,7 @@ func selectProject(ctx context.Context, flags *SwitchProjectCmd) (*project, erro
 		return nil, eris.Wrap(err, "Could not get config")
 	}
 	if config.CurrRepoKnown {
-		printer.Errorf("Current git working directory belongs to project %s. Cannot switch.\n",
+		printer.Errorf("Current git working directory belongs to project %s.\n  Cannot switch Project.\n",
 			config.CurrProjectName)
 		return nil, nil //nolint: nilnil // See: https://www.dolthub.com/blog/2024-05-31-benchmarking-go-error-handling/
 	}

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -146,7 +146,6 @@ func (flow *initFlow) handleNeedExistingProjectCaseMultipleProjects() error {
 func (flow *initFlow) updateProject(project *project) {
 	flow.State.Project = project
 	flow.projectStepDone = true
-	flow.AddKnownProject(project)
 
 	flow.config.ProjectID = project.ID
 	flow.config.CurrProjectName = project.Name


### PR DESCRIPTION
# Improve Git Repository Lookup and Command Requirements

## Overview

This PR enhances the git repository lookup functionality to handle cases where the 'origin' remote is missing, and improves the command requirements for organization and project operations. It adds fallback mechanisms for git remote detection and clarifies error messages when attempting to switch projects or organizations.

## Brief Changelog

- Added fallback mechanism to use the first available remote URL if 'origin' is not configured
- Updated command requirements to use `NeedRepoLookup` where appropriate
- Improved error messages when attempting to switch projects or organizations
- Enhanced logic for determining when repository lookup is needed
- Added comprehensive tests for different git remote scenarios

## Testing and Verifying

This change added tests and can be verified as follows:
- Added unit tests that validate git repository lookup with different remote configurations
- Tests cover scenarios with origin remote, non-origin remote, and no git repository

<!-- greptile_comment -->

## Greptile Summary

This PR enhances git repository lookup functionality and improves command requirements handling in the World CLI. The changes focus on better repository detection and validation for organization/project operations.

- Added fallback mechanism in `FindGitPathAndURL()` to use first available remote URL if 'origin' is missing
- Updated `SetupForgeCommandState` to use `NeedRepoLookup` for proper repository validation before command execution
- Added validation for repository paths and improved error messages for project/organization switching
- Enhanced project configuration handling from `world.toml` and improved config management
- Removed `AddKnownProject` from `updateProject` method as part of repository detection refactoring



<!-- /greptile_comment -->