### PR TITLE
refactor(project): Help creation logic with repo and toml

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -262,10 +263,10 @@ func printNoOrganizations() {
 	printer.NewLine(1)
 	printer.Headerln("   No Organizations Found   ")
 	printer.Info("1. Use ")
-	printer.Notification("'world forge organization create'")
+	printer.Notification("'world organization create'")
 	printer.Infoln(" to create an organization.")
 	printer.Info("2. Have a member send invite using ")
-	printer.Notification("'world forge organization invite'")
+	printer.Notification("'world organization invite'")
 	printer.Infoln(".")
 }
 
@@ -274,7 +275,7 @@ func printNoSelectedOrganization() {
 	printer.Headerln("   No Organization Selected   ")
 	printer.Infoln("You don't have any organization selected.")
 	printer.Info("Use ")
-	printer.Notification("'world forge organization switch'")
+	printer.Notification("'world organization switch'")
 	printer.Infoln(" to select one!")
 }
 
@@ -283,7 +284,7 @@ func printNoSelectedProject() {
 	printer.Headerln("   No Project Selected   ")
 	printer.Infoln("You don't have any project selected.")
 	printer.Info("Use ")
-	printer.Notification("'world forge project switch'")
+	printer.Notification("'world project switch'")
 	printer.Infoln(" to select one!")
 }
 
@@ -291,9 +292,17 @@ func printNoProjectsInOrganization() {
 	printer.NewLine(1)
 	printer.Headerln("   No Projects Found   ")
 	printer.Infoln("You don't have any projects in this organization yet.")
-	printer.Info("Use ")
-	printer.Notification("'world forge project create'")
-	printer.Infoln(" to start your first project!")
+	printRequiredStepsToCreateProject()
+}
+
+func printRequiredStepsToCreateProject() {
+	printer.NewLine(1)
+	printer.Headerln(" To create a new project follow these steps ")
+	printer.Infoln("1. Move to the root of your World project.")
+	printer.Infoln("   This is the directory that contains world.toml and the cardinal directory")
+	printer.Infoln("2. Must be within a git repository")
+	printer.Info("3. Use command ")
+	printer.Notificationln("'world project create'")
 }
 
 // slugToSaneCheck checks that slug is valid, and returns a sanitized version.
@@ -409,4 +418,27 @@ func replaceLast(x, y, z string) string {
 		return x
 	}
 	return x[:i] + z + x[i+len(y):]
+}
+
+// isInWorldCadinalRoot checks if the current working directory is a World project.
+// It checks for the presence of world.toml and cardinal directory.
+func isInWorldCadinalRoot() (bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, eris.Wrap(err, "failed to get working directory")
+	}
+
+	worldTomlPath := filepath.Join(cwd, "world.toml")
+	cardinalDirPath := filepath.Join(cwd, "cardinal")
+
+	tomlInfo, err := os.Stat(worldTomlPath)
+	if err != nil || tomlInfo.IsDir() {
+		return false, nil //nolint:nilerr // false return gives all the information we need
+	}
+
+	cardinalInfo, err := os.Stat(cardinalDirPath)
+	if err != nil || !cardinalInfo.IsDir() {
+		return false, nil //nolint:nilerr // false return gives all the information we need
+	}
+	return true, nil
 }

--- a/cmd/world/forge/config.go
+++ b/cmd/world/forge/config.go
@@ -3,7 +3,6 @@ package forge
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -95,46 +94,6 @@ func GetCurrentForgeConfig() (Config, error) {
 		}
 	}
 	return currConfig, err
-}
-
-func FindGitPathAndURL() (string, string, error) {
-	// Try to get the 'origin' remote URL first
-	urlData, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
-	if err != nil || strings.TrimSpace(string(urlData)) == "" {
-		// Fallback: get the first available remote URL
-		remoteList, fallbackErr := exec.Command("git", "remote", "-v").Output()
-		if fallbackErr != nil {
-			return "", "", eris.Wrap(fallbackErr, "failed to get remote list")
-		}
-		lines := strings.Split(string(remoteList), "\n")
-		for _, line := range lines {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				urlData = []byte(parts[1])
-				break
-			}
-		}
-	}
-
-	url := strings.TrimSpace(string(urlData))
-	if url == "" {
-		return "", "", eris.New("no git remote URL found")
-	}
-	url = replaceLast(url, ".git", "")
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return "", url, err
-	}
-	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return "", url, err
-	}
-	rootPath := strings.TrimSpace(string(root))
-	path := strings.Replace(workingDir, rootPath, "", 1)
-	if len(path) > 0 && path[0] == '/' {
-		path = path[1:]
-	}
-	return path, url, nil
 }
 
 func SaveForgeConfig(globalConfig Config) error {

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -264,7 +264,7 @@ func (c *UpdateProjectCmd) Run() error {
 	if cmdState.Project == nil {
 		return eris.New("Forge setup failed, no project selected")
 	}
-	return cmdState.Project.updateProject(ctx, c)
+	return cmdState.Project.updateProject(ctx, c, cmdState)
 }
 
 type DeleteProjectCmd struct {

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -102,14 +102,13 @@ func getListOfOrganizations(ctx context.Context) ([]organization, error) {
 }
 
 func selectOrganization(ctx context.Context, flags *SwitchOrganizationCmd) (organization, error) {
-	config, err := GetCurrentForgeConfig()
+	isKnown, err := isKnownRepo()
 	if err != nil {
-		return organization{}, eris.Wrap(err, "Could not get config")
+		return organization{}, eris.Wrap(err, "selectOrganization")
 	}
-	if config.CurrRepoKnown {
-		printer.Errorf("Current git working directory belongs to project %s.\n  Cannot switch Organization.\n",
-			config.CurrProjectName)
-		return organization{}, nil
+	if isKnown {
+		printer.Infoln(": Cannot switch Organization.")
+		return organization{}, eris.New("Cannot switch Organization, directory belongs to another project.")
 	}
 
 	// If slug is provided, select organization from slug

--- a/cmd/world/forge/project_flow.go
+++ b/cmd/world/forge/project_flow.go
@@ -33,9 +33,9 @@ func (flow *initFlow) handleNeedProjectData() error {
 
 func (flow *initFlow) handleNeedProjectCaseNoProjects() error {
 	for {
+		printNoProjectsInOrganization()
 		printer.NewLine(1)
-		printer.Infoln("No projects found.")
-		choice := getInput("Would you like to create one? (Y/n)", "Y")
+		choice := getInput("If conditions are met, would you like to create a new project? (Y/n)", "Y")
 
 		switch choice {
 		case "Y":
@@ -105,13 +105,17 @@ func (flow *initFlow) handleNeedExistingProjectData() error {
 
 	switch len(projects) {
 	case 0: // No projects found
-		printNoProjectsInOrganization()
-		return ErrProjectSelectionCanceled
+		return flow.handleNeedExistingProjectCaseNoProjects()
 	case 1: // One project found
 		return flow.handleNeedExistingProjectCaseOneProject(projects)
 	default: // Multiple projects found
 		return flow.handleNeedExistingProjectCaseMultipleProjects()
 	}
+}
+
+func (flow *initFlow) handleNeedExistingProjectCaseNoProjects() error {
+	printNoProjectsInOrganization()
+	return ErrProjectSelectionCanceled
 }
 
 func (flow *initFlow) handleNeedExistingProjectCaseOneProject(projects []project) error {

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -60,7 +60,9 @@ func NewWorldCreateModel(directory string) WorldCreateModel {
 	}
 
 	if directory != "" {
-		pnInput.SetValue(directory)
+		// Extract just the directory name from the path
+		dirName := filepath.Base(directory)
+		pnInput.SetValue(dirName)
 	}
 
 	return WorldCreateModel{


### PR DESCRIPTION
## Overview

This PR improves the project creation and management workflow by ensuring that World CLI commands are executed in the correct context. It adds validation to check if the current directory is a valid World project root (containing world.toml and cardinal/ directory) and if it's within a git repository before allowing project creation or updates.

## Brief Changelog

- Added validation to ensure project commands are executed in a World project root directory
- Added `isInWorldCadinalRoot()` function to check for world.toml and cardinal/ directory
- Updated command references in help messages to use the new command structure (removed 'forge' from command paths)
- Enhanced error messages with clearer instructions when project creation requirements aren't met
- Added `printRequiredStepsToCreateProject()` function to provide consistent guidance
- Fixed project switching and organization switching to properly check if the current directory belongs to another project
- Moved git repository validation logic to a separate file for better organization
- Updated tests to properly set up the required directory structure for project commands

## Testing and Verifying

This change is covered by existing tests, which have been updated to properly set up the required directory structure for project commands. The tests now create temporary directories with the necessary World project structure (world.toml and cardinal/ directory) and initialize git repositories to simulate the real-world environment.