### PR TITLE
feat: DEVP-130 remove known projects

### DIFF
--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -3510,7 +3510,7 @@ func (s *ForgeTestSuite) TestAddKnownProject() {
 	}
 
 	flowObject := &initFlow{config: *config}
-	flowObject.AddKnownProject(proj)
+	proj.AddKnownProject(&flowObject.config)
 	config = &flowObject.config
 
 	s.Len(config.KnownProjects, 1)
@@ -3521,6 +3521,110 @@ func (s *ForgeTestSuite) TestAddKnownProject() {
 		RepoPath:       "cmd/world/forge",
 		ProjectName:    "Test Project",
 	}, config.KnownProjects[0])
+}
+
+func (s *ForgeTestSuite) TestRemoveKnownProject() {
+	testCases := []struct {
+		name             string
+		initialConfig    *Config
+		projectToRemove  *project
+		expectedProjects []KnownProject
+	}{
+		{
+			name: "successfully remove project",
+			initialConfig: &Config{
+				KnownProjects: []KnownProject{
+					{
+						ProjectID:      "test-project-id",
+						OrganizationID: "test-org-id",
+						RepoURL:        "https://github.com/test/repo",
+						RepoPath:       "cmd/world/forge",
+						ProjectName:    "Test Project",
+					},
+					{
+						ProjectID:      "other-project-id",
+						OrganizationID: "other-org-id",
+						RepoURL:        "https://github.com/other/repo",
+						RepoPath:       "other/path",
+						ProjectName:    "Other Project",
+					},
+				},
+			},
+			projectToRemove: &project{
+				ID:       "test-project-id",
+				OrgID:    "test-org-id",
+				RepoURL:  "https://github.com/test/repo",
+				RepoPath: "cmd/world/forge",
+				Name:     "Test Project",
+			},
+			expectedProjects: []KnownProject{
+				{
+					ProjectID:      "other-project-id",
+					OrganizationID: "other-org-id",
+					RepoURL:        "https://github.com/other/repo",
+					RepoPath:       "other/path",
+					ProjectName:    "Other Project",
+				},
+			},
+		},
+		{
+			name: "remove project with empty config",
+			initialConfig: &Config{
+				KnownProjects: make([]KnownProject, 0),
+			},
+			projectToRemove: &project{
+				ID:       "test-project-id",
+				OrgID:    "test-org-id",
+				RepoURL:  "https://github.com/test/repo",
+				RepoPath: "cmd/world/forge",
+				Name:     "Test Project",
+			},
+			expectedProjects: make([]KnownProject, 0),
+		},
+		{
+			name: "remove non-existent project",
+			initialConfig: &Config{
+				KnownProjects: []KnownProject{
+					{
+						ProjectID:      "other-project-id",
+						OrganizationID: "other-org-id",
+						RepoURL:        "https://github.com/other/repo",
+						RepoPath:       "other/path",
+						ProjectName:    "Other Project",
+					},
+				},
+			},
+			projectToRemove: &project{
+				ID:       "test-project-id",
+				OrgID:    "test-org-id",
+				RepoURL:  "https://github.com/test/repo",
+				RepoPath: "cmd/world/forge",
+				Name:     "Test Project",
+			},
+			expectedProjects: []KnownProject{
+				{
+					ProjectID:      "other-project-id",
+					OrganizationID: "other-org-id",
+					RepoURL:        "https://github.com/other/repo",
+					RepoPath:       "other/path",
+					ProjectName:    "Other Project",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Setup
+			flowObject := &initFlow{config: *tc.initialConfig}
+
+			// Execute
+			tc.projectToRemove.RemoveKnownProject(&flowObject.config)
+
+			// Verify
+			s.Equal(tc.expectedProjects, flowObject.config.KnownProjects)
+		})
+	}
 }
 
 func (s *ForgeTestSuite) TestHandleNeedOrgData() {

--- a/cmd/world/forge/init_flow.go
+++ b/cmd/world/forge/init_flow.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/printer"
 )
 
@@ -252,14 +251,7 @@ func (flow *initFlow) doRepoLookup(ctx context.Context) error {
 	}
 	if proj != nil {
 		// add to list of known projects
-		flow.AddKnownProject(proj)
-		// save the config, but don't change the default ProjectID & OrgID
-		err := SaveForgeConfig(flow.config)
-		if err != nil {
-			printer.Notificationf("Warning: Failed to save config: %s", err)
-			logger.Error(eris.Wrap(err, "Init flow failed to save config"))
-			// continue on, this is not fatal
-		}
+		proj.AddKnownProject(&flow.config)
 		// now return a copy of it with the looked up ProjectID and OrganizationID set
 		flow.config.ProjectID = proj.ID
 		flow.config.OrganizationID = proj.OrgID
@@ -267,16 +259,6 @@ func (flow *initFlow) doRepoLookup(ctx context.Context) error {
 		flow.config.CurrRepoKnown = true
 	}
 	return nil
-}
-
-func (flow *initFlow) AddKnownProject(proj *project) {
-	flow.config.KnownProjects = append(flow.config.KnownProjects, KnownProject{
-		ProjectID:      proj.ID,
-		OrganizationID: proj.OrgID,
-		RepoURL:        proj.RepoURL,
-		RepoPath:       proj.RepoPath,
-		ProjectName:    proj.Name,
-	})
 }
 
 func (flow *initFlow) inKnownRepo() bool {


### PR DESCRIPTION


feat: Refactor project management in forge config

## Overview

This PR refactors how projects are managed in the forge configuration by moving the project management methods from the `initFlow` struct to the `project` struct. It also adds functionality to remove projects from the known projects list when they are deleted or updated.

## Brief Changelog

- Moved `AddKnownProject` method from `initFlow` to `project` struct
- Added `RemoveKnownProject` method to `project` struct
- Updated project deletion and update methods to remove the project from known projects
- Added comprehensive test cases for `RemoveKnownProject` functionality
- Improved error handling for config updates

## Testing and Verifying

This change added tests and can be verified as follows:
- Added unit tests that validate the `RemoveKnownProject` functionality with various scenarios including:
  - Successfully removing a project
  - Handling empty configurations
  - Handling non-existent projects

<!-- greptile_comment -->

## Greptile Summary

Refactors project management in the forge configuration by moving project-related methods from `initFlow` to the `project` struct and adding functionality to remove projects from known projects list.

- Added `RemoveKnownProject` method to `project` struct to handle project removal from known projects list
- Moved `AddKnownProject` method from `initFlow` to `project` struct for better organization
- Updated project deletion and update workflows to properly remove projects from known projects list
- Added error handling for config updates with retry mechanism
- Added notification messages for project removal/addition operations



<!-- /greptile_comment -->