### PR TITLE
refactor: unique org/proj slug

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -33,6 +33,8 @@ const (
 	jitterDivisor  time.Duration = 2 // Divisor used to calculate maximum jitter range
 	RetryBaseDelay time.Duration = 100 * time.Millisecond
 	requestTimeout time.Duration = 5 * time.Second
+
+	nilUUID = "00000000-0000-0000-0000-000000000000"
 )
 
 var (

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -124,6 +124,10 @@ func (s *ForgeTestSuite) SetupTest() { //nolint: cyclop, gocyclo // test, don't 
 					s.handleProjectLookup(w, r)
 				case "/api/auth/service-auth-session":
 					s.handleArgusIDAuthSession(w, r)
+				case "/api/organization/test-org-id/project/test-project-id/testp/check_slug":
+					s.handleProjectSlugCheck(w, r)
+				case "/api/organization/test-org-id/project/00000000-0000-0000-0000-000000000000/testp/check_slug":
+					s.handleProjectSlugCheck(w, r)
 				default:
 					http.Error(w, "Not found", http.StatusNotFound)
 				}
@@ -614,6 +618,24 @@ func (s *ForgeTestSuite) writeJSONString(w http.ResponseWriter, data string) {
 	s.Require().NoError(err)
 }
 
+func (s *ForgeTestSuite) handleProjectSlugCheck(w http.ResponseWriter, r *http.Request) {
+	// Extract org ID and project ID from URL
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 6 {
+		http.Error(w, "Invalid URL", http.StatusBadRequest)
+		return
+	}
+
+	slug := parts[len(parts)-2]
+	if slug != "testp" {
+		http.Error(w, "Project slug already exists", http.StatusConflict)
+		return
+	}
+
+	// Return success for any other slug
+	s.writeJSON(w, map[string]string{"status": "available"})
+}
+
 func (s *ForgeTestSuite) TestGetSelectedOrganization() {
 	testCases := []struct {
 		name          string
@@ -865,7 +887,7 @@ func (s *ForgeTestSuite) TestDeploy() {
 			},
 			inputs: []string{
 				"Test Project", // Project name
-				"test_project", // Project slug
+				"testp",        // Project slug
 				"https://github.com/argus-labs/starter-game-template", // Repository URL
 				"",   // No token needed for public repo
 				"",   // Default repo path
@@ -2220,7 +2242,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 			},
 			inputs: []string{
 				"Test Project", // name
-				"",             // take default
+				"testp",        // take default
 				"https://github.com/argus-labs/starter-game-template", // Repository URL
 				"",                 // repoToken (empty for public repo)
 				"",                 // repoPath (empty for default root path of repo)
@@ -2245,7 +2267,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 			expectedError:   false,
 			expectedProject: &project{
 				Name: "Test Project",
-				Slug: "test_project",
+				Slug: "testp",
 			},
 		},
 		{
@@ -2298,7 +2320,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 			},
 			inputs: []string{
 				"Test Project", // name
-				"",             // take default slug
+				"testp",        // take default slug
 				"https://github.com/argus-labs/starter-game-template", // repoURL
 				"",   // repoToken (empty for public repo)
 				"",   // repoPath
@@ -2322,7 +2344,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 			},
 			inputs: []string{
 				"Test Private",
-				"",
+				"testp",
 				"https://github.com/test/private-repo",
 				"bad-secret-token",
 			},
@@ -2411,8 +2433,8 @@ func (s *ForgeTestSuite) TestCreateProject() {
 				},
 			},
 			inputs: []string{
-				"", // name (should be taken from world.toml)
-				"", // take default slug
+				"",      // name (should be taken from world.toml)
+				"testp", // take default slug
 				"https://github.com/argus-labs/starter-game-template", // repoURL
 				"",                // repoToken (empty for public repo)
 				"",                // repoPath (empty for default root path of repo)
@@ -2433,7 +2455,7 @@ func (s *ForgeTestSuite) TestCreateProject() {
 			expectedError:   false,
 			expectedProject: &project{
 				Name: "test-project-from-toml",
-				Slug: "test_project_from_toml",
+				Slug: "testp",
 			},
 			setupWorldToml: true,
 		},
@@ -4190,7 +4212,7 @@ func (s *ForgeTestSuite) TestHandleNeedProjectData() {
 			inputs: []string{
 				"c",           // Choose to create new project
 				"New Project", // Project name
-				"newp",        // Project slug
+				"testp",       // Project slug
 				"https://github.com/argus-labs/starter-game-template", // Repo URL
 				"",   // No token needed for public repo
 				"",   // Default repo path
@@ -4741,8 +4763,8 @@ func (s *ForgeTestSuite) TestCreateProjectCmd() {
 				AvatarURL: "http://test.com",
 			},
 			inputs: []string{
-				"", // name
-				"", // take default
+				"",      // name
+				"testp", // take default
 				"https://github.com/argus-labs/starter-game-template", // Repository URL
 				"",           // repoToken (empty for public repo)
 				"",           // repoPath (empty for default root path of repo)
@@ -4763,7 +4785,7 @@ func (s *ForgeTestSuite) TestCreateProjectCmd() {
 			expectedProj: &project{
 				ID:   "test-project-id",
 				Name: "Test Project",
-				Slug: "test-project",
+				Slug: "testp",
 			},
 		},
 		{
@@ -4781,8 +4803,8 @@ func (s *ForgeTestSuite) TestCreateProjectCmd() {
 				AvatarURL: "http://test.com",
 			},
 			inputs: []string{
-				"", // name
-				"", // take default
+				"",      // name
+				"testp", // take default
 				"https://github.com/argus-labs/starter-game-template", // Repository URL
 				"",           // repoToken (empty for public repo)
 				"",           // repoPath (empty for default root path of repo)
@@ -4811,7 +4833,7 @@ func (s *ForgeTestSuite) TestCreateProjectCmd() {
 			},
 			cmd: &CreateProjectCmd{
 				Name:      "Test Project",
-				Slug:      "Test",
+				Slug:      "testp",
 				AvatarURL: "http://test.com",
 			},
 			expectedError: true,

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -9,6 +9,9 @@ import (
 	"pkg.world.dev/world-cli/common/printer"
 )
 
+// ErrOrganizationSlugAlreadyExists is passed from forge to world-cli, Must always match.
+var ErrOrganizationSlugAlreadyExists = eris.New("organization slug already exists")
+
 type organization struct {
 	ID               string `json:"id"`
 	Name             string `json:"name"`
@@ -345,6 +348,10 @@ func createOrgRequestAndSave(fCtx ForgeContext, name, slug, avatarURL string) (*
 		AvatarURL: avatarURL,
 	})
 	if err != nil {
+		if eris.Is(err, ErrOrganizationSlugAlreadyExists) {
+			printer.Errorf("An Organization already exists with slug: %s, please choose a different slug.\n", slug)
+			printer.NewLine(1)
+		}
 		return nil, eris.Wrap(err, "Failed to create organization")
 	}
 


### PR DESCRIPTION
# Add Project Slug Validation

## Overview

This PR adds validation for project slugs to prevent conflicts when creating or updating projects. It checks if a slug is already in use before allowing it to be set, providing better user feedback and preventing errors during project creation.

## Brief Changelog

- Added a new `nilUUID` constant for use in API requests
- Implemented project slug validation via a new API endpoint `/check_slug`
- Added error handling for slug conflicts with appropriate user feedback
- Created test handlers for slug validation in test suite
- Updated tests to use valid slugs that pass validation

## Testing and Verifying

This change is covered by existing tests that have been updated to use valid slugs. The test suite now includes handlers for the new slug validation endpoint to simulate both successful and failed validation scenarios.

<!-- greptile_comment -->

## Greptile Summary

Added validation for organization and project slugs to prevent conflicts during creation and updates. The changes implement API-based validation and improved error handling.

- Added `ErrOrganizationSlugAlreadyExists` and `ErrProjectSlugAlreadyExists` error types for handling slug conflicts
- Implemented `/check_slug` API endpoint validation in `checkIfProjectSlugIsTaken` function
- Added comprehensive error handling and user feedback for slug conflicts
- Updated test suite with new handlers and test cases for slug validation
- Added `nilUUID` constant for use in API requests when validating new slugs



<!-- /greptile_comment -->