### PR TITLE
feat: [DEVP-135] new deployment process

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -21,18 +21,16 @@ import (
 	"time"
 	"unicode"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 	"github.com/rotisserie/eris"
 	"github.com/tidwall/gjson"
-	"golang.org/x/term"
 	"pkg.world.dev/world-cli/common/printer"
 )
 
 const (
 	jitterDivisor  time.Duration = 2 // Divisor used to calculate maximum jitter range
 	RetryBaseDelay time.Duration = 100 * time.Millisecond
-	requestTimeout time.Duration = 5 * time.Second
+	requestTimeout time.Duration = 30 * time.Second // Increased timeout for large file uploads
 
 	nilUUID = "00000000-0000-0000-0000-000000000000"
 )
@@ -372,16 +370,6 @@ func CreateSlugFromName(name string, minLength int, maxLength int) string {
 		slug = strings.TrimRight(slug, "_")
 	}
 	return slug
-}
-
-// NewTeaProgram will create a BubbleTea program that automatically sets the no input option
-// if you are not on a TTY, so you can run the debugger. Call it just as you would call tea.NewProgram().
-func NewTeaProgram(model tea.Model, opts ...tea.ProgramOption) *tea.Program {
-	if !term.IsTerminal(int(os.Stderr.Fd())) {
-		opts = append(opts, tea.WithInput(nil))
-		// opts = append(opts, tea.WithoutRenderer())
-	}
-	return tea.NewProgram(model, opts...)
 }
 
 func isValidEmail(email string) bool {

--- a/cmd/world/forge/deployment_build.go
+++ b/cmd/world/forge/deployment_build.go
@@ -1,0 +1,101 @@
+package forge
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/magefile/mage/sh"
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/common/config"
+	"pkg.world.dev/world-cli/common/docker"
+	"pkg.world.dev/world-cli/common/docker/service"
+)
+
+// deploymentBuild builds the image and returns the commit hash and the image reader.
+func deploymentBuild(ctx context.Context, project *project) (string, io.ReadCloser, error) {
+	tempDir, err := os.MkdirTemp("", "wfbuild")
+	if err != nil {
+		return "", nil, eris.Wrapf(err, "Failed to create temp dir")
+	}
+
+	commitHash, err := cloneRepo(project.RepoURL, project.RepoToken, tempDir)
+	if err != nil {
+		return "", nil, eris.Wrapf(err, "Failed to clone repo")
+	}
+
+	// build the image
+	reader, err := buildImage(ctx, project.RepoPath, tempDir)
+	if err != nil {
+		return "", nil, eris.Wrapf(err, "Failed to build image")
+	}
+
+	return commitHash, reader, nil
+}
+
+func cloneRepo(repoURL, token string, tempDir string) (string, error) {
+	env := map[string]string{
+		"GIT_COMMITTER_NAME":  "World CLI",
+		"GIT_COMMITTER_EMAIL": "no-reply@world.dev",
+	}
+
+	outBuff := bytes.Buffer{}
+	errBuff := bytes.Buffer{}
+
+	// shallow clone the repo
+	if token != "" {
+		// Add token to the URL for authentication
+		repoURLWithToken := strings.Replace(repoURL, "https://", "https://"+token+"@", 1)
+		repoURL = repoURLWithToken
+	}
+	_, err := sh.Exec(env, &outBuff, &errBuff, "git", "clone", "--depth", "1", repoURL, tempDir)
+	if err != nil {
+		return "", eris.Wrapf(err, "failed to clone repo: %s", errBuff.String())
+	}
+
+	// get the commit hash
+	_, err = sh.Exec(env, &outBuff, &errBuff, "git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", eris.Wrapf(err, "failed to get commit hash: %s", errBuff.String())
+	}
+
+	commitHash := outBuff.String()
+
+	return commitHash, nil
+}
+
+func buildImage(ctx context.Context, repoPath, tempDir string) (io.ReadCloser, error) {
+	// get config from world.toml
+	worldTomlPath := path.Join(tempDir, repoPath, "world.toml")
+	cfg, err := config.GetConfig(&worldTomlPath)
+	if err != nil {
+		return nil, eris.Wrapf(err, "Failed to get config")
+	}
+
+	// create docker client
+	dockerClient, err := docker.NewClient(cfg)
+	if err != nil {
+		return nil, eris.Wrapf(err, "Failed to create docker client")
+	}
+
+	// build the image
+	err = dockerClient.Build(ctx, "", "", service.Cardinal)
+	if err != nil {
+		return nil, eris.Wrapf(err, "Failed to build image")
+	}
+
+	// get the image name
+	cardinalService := service.Cardinal(cfg)
+	imageName := cardinalService.Image
+
+	// save the image
+	reader, err := dockerClient.Save(ctx, imageName)
+	if err != nil {
+		return nil, eris.Wrapf(err, "Failed to save image")
+	}
+
+	return reader, nil
+}

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -336,12 +336,13 @@ func (s *ForgeTestSuite) handleProjectGet(w http.ResponseWriter, _ *http.Request
 }
 
 func (s *ForgeTestSuite) handleGetRegions(w http.ResponseWriter, _ *http.Request) {
-	result := map[string]string{
-		"38f46cb3-63a3-4955-ae5f-6c31595fd970": "ap-southeast-1",
-		"4ee8a580-879f-47c8-a183-de6d50329dc1": "us-east-1",
-		"71d61857-f803-4135-80a7-68b3e6f55443": "eu-central-1",
-		"f80a422c-eb8d-4d6d-8244-0f065773cb20": "us-west-2",
+	result := map[string]struct{}{
+		"ap-southeast-1": {},
+		"us-east-1":      {},
+		"eu-central-1":   {},
+		"us-west-2":      {},
 	}
+
 	s.writeJSON(w, map[string]interface{}{"data": result})
 }
 
@@ -828,7 +829,8 @@ func (s *ForgeTestSuite) TestDeploy() {
 						ID: "test-org-id",
 					},
 					Project: &project{
-						ID: "test-project-id",
+						ID:      "test-project-id",
+						RepoURL: "https://github.com/argus-labs/starter-game-template",
 					},
 					User: &User{
 						ID: "test-user-id",
@@ -1216,7 +1218,8 @@ func (s *ForgeTestSuite) TestDestroy() {
 						ID: "test-org-id",
 					},
 					Project: &project{
-						ID: "test-project-id",
+						ID:      "test-project-id",
+						RepoURL: "https://github.com/argus-labs/starter-game-template",
 					},
 					User: &User{
 						ID: "test-user-id",
@@ -1330,7 +1333,8 @@ func (s *ForgeTestSuite) TestReset() {
 						ID: "test-org-id",
 					},
 					Project: &project{
-						ID: "test-project-id",
+						ID:      "test-project-id",
+						RepoURL: "https://github.com/argus-labs/starter-game-template",
 					},
 					User: &User{
 						ID: "test-user-id",

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -16,6 +16,7 @@ import (
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/printer"
 	"pkg.world.dev/world-cli/common/tomlutil"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/multiselect"
 )
 
@@ -178,13 +179,13 @@ func getListRegions(fCtx ForgeContext, orgID, projID string) ([]string, error) {
 		return nil, eris.Wrap(err, "Failed to get regions")
 	}
 
-	regionMap, err := parseResponse[map[string]string](body)
+	regionMap, err := parseResponse[map[string]struct{}](body)
 	if err != nil {
 		return nil, eris.Wrap(err, "Failed to parse regions")
 	}
 
 	regions := make([]string, 0, len(*regionMap))
-	for _, region := range *regionMap {
+	for region := range *regionMap {
 		regions = append(regions, region)
 	}
 
@@ -982,9 +983,9 @@ func (p *project) runRegionSelector(ctx context.Context, regions []string) (bool
 					selectedRegions[i] = true
 				}
 			}
-			regionSelector = NewTeaProgram(multiselect.UpdateMultiselectModel(ctx, regions, selectedRegions))
+			regionSelector = util.NewTeaProgram(multiselect.UpdateMultiselectModel(ctx, regions, selectedRegions))
 		} else {
-			regionSelector = NewTeaProgram(multiselect.InitialMultiselectModel(ctx, regions))
+			regionSelector = util.NewTeaProgram(multiselect.InitialMultiselectModel(ctx, regions))
 		}
 	}
 	m, err := regionSelector.Run()

--- a/cmd/world/root/create.go
+++ b/cmd/world/root/create.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"pkg.world.dev/world-cli/cmd/world/forge"
 	"pkg.world.dev/world-cli/common/editor"
 	"pkg.world.dev/world-cli/common/teacmd"
 	"pkg.world.dev/world-cli/common/tomlutil"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/steps"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -233,7 +233,7 @@ type CreateCmd struct {
 }
 
 func (c *CreateCmd) Run() error {
-	p := forge.NewTeaProgram(NewWorldCreateModel(c.Directory))
+	p := util.NewTeaProgram(NewWorldCreateModel(c.Directory))
 	if _, err := p.Run(); err != nil {
 		return err
 	}

--- a/cmd/world/root/doctor.go
+++ b/cmd/world/root/doctor.go
@@ -2,9 +2,9 @@ package root
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"pkg.world.dev/world-cli/cmd/world/forge"
 	"pkg.world.dev/world-cli/common/dependency"
 	"pkg.world.dev/world-cli/common/teacmd"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/style"
 )
 
@@ -67,7 +67,7 @@ type DoctorCmd struct {
 }
 
 func (c *DoctorCmd) Run() error {
-	p := forge.NewTeaProgram(NewWorldDoctorModel())
+	p := util.NewTeaProgram(NewWorldDoctorModel())
 	_, err := p.Run()
 	if err != nil {
 		return err

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -265,3 +265,12 @@ func (c *Client) Exec(ctx context.Context, containerID string, cmd []string) (st
 	// Return the output as a string
 	return outputBuf.String(), nil
 }
+
+func (c *Client) Save(ctx context.Context, imageName string) (io.ReadCloser, error) {
+	reader, err := c.client.ImageSave(ctx, []string{imageName})
+	if err != nil {
+		return nil, eris.Wrapf(err, "Failed to save image")
+	}
+
+	return reader, nil
+}

--- a/common/docker/client_container.go
+++ b/common/docker/client_container.go
@@ -14,9 +14,9 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-cli/cmd/world/forge"
 	"pkg.world.dev/world-cli/common/docker/service"
 	"pkg.world.dev/world-cli/common/printer"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/multispinner"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -38,7 +38,7 @@ func (c *Client) processMultipleContainers(ctx context.Context, processType proc
 	errChan := make(chan error, len(dockerServicesNames))
 
 	// Create tea program for multispinner
-	p := forge.NewTeaProgram(multispinner.CreateSpinner(dockerServicesNames, cancel))
+	p := util.NewTeaProgram(multispinner.CreateSpinner(dockerServicesNames, cancel))
 
 	// Process all containers
 	for _, ds := range services {

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -21,9 +21,9 @@ import (
 	"github.com/rotisserie/eris"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
-	"pkg.world.dev/world-cli/cmd/world/forge"
 	"pkg.world.dev/world-cli/common/docker/service"
 	"pkg.world.dev/world-cli/common/printer"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/multispinner"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -50,7 +50,7 @@ func (c *Client) buildImages(ctx context.Context, dockerServices ...service.Serv
 	// Channel to collect errors from the goroutines
 	errChan := make(chan error, len(imagesName))
 
-	p := forge.NewTeaProgram(multispinner.CreateSpinner(imagesName, cancel))
+	p := util.NewTeaProgram(multispinner.CreateSpinner(imagesName, cancel))
 
 	for _, ds := range serviceToBuild {
 		// Capture dockerService in the loop

--- a/common/docker/client_network.go
+++ b/common/docker/client_network.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types/network"
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-cli/cmd/world/forge"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/multispinner"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -13,7 +13,7 @@ import (
 func (c *Client) createNetworkIfNotExists(ctx context.Context, networkName string) error {
 	// Create context with cancel
 	ctx, cancel := context.WithCancel(ctx)
-	p := forge.NewTeaProgram(multispinner.CreateSpinner([]string{networkName}, cancel))
+	p := util.NewTeaProgram(multispinner.CreateSpinner([]string{networkName}, cancel))
 
 	errChan := make(chan error, 1)
 

--- a/common/docker/client_volume.go
+++ b/common/docker/client_volume.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types/volume"
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-cli/cmd/world/forge"
+	"pkg.world.dev/world-cli/common/util"
 	"pkg.world.dev/world-cli/tea/component/multispinner"
 	"pkg.world.dev/world-cli/tea/style"
 )
@@ -14,7 +14,7 @@ import (
 func (c *Client) processVolume(ctx context.Context, processType processType, volumeName string) error {
 	// Create context with cancel
 	ctx, cancel := context.WithCancel(ctx)
-	p := forge.NewTeaProgram(multispinner.CreateSpinner([]string{volumeName}, cancel))
+	p := util.NewTeaProgram(multispinner.CreateSpinner([]string{volumeName}, cancel))
 
 	errChan := make(chan error, 1)
 

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+)
+
+// NewTeaProgram will create a BubbleTea program that automatically sets the no input option
+// if you are not on a TTY, so you can run the debugger. Call it just as you would call tea.NewProgram().
+func NewTeaProgram(model tea.Model, opts ...tea.ProgramOption) *tea.Program {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		opts = append(opts, tea.WithInput(nil))
+		// opts = append(opts, tea.WithoutRenderer())
+	}
+	return tea.NewProgram(model, opts...)
+}


### PR DESCRIPTION
## Overview

- Add step to clone, and build docker image on local machine
- Put the docker image into deploy request using multipart form

<!-- greptile_comment -->

## Greptile Summary

Implements new deployment process by introducing local Docker image building and multipart form uploads, shifting from remote pull model to local build and upload approach.

- Added `deployment_build.go` implementing local Docker image building with Git repo cloning and authentication support
- Modified `client.go` to add Docker image export functionality via `Save` method for multipart form uploads
- Increased request timeout from 5s to 30s in `common.go` to accommodate large file uploads
- Refactored `NewTeaProgram` functionality from forge package to `common/util/util.go` for better code organization
- Enhanced `deployment.go` with local build integration and multipart form handling for Docker image uploads



<!-- /greptile_comment -->