### PR TITLE
feat: add organization invitation handling during init flow

### DIFF
--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -81,6 +81,28 @@ func getSelectedOrganization(fCtx ForgeContext) (organization, error) {
 	return *org, nil
 }
 
+func getOrganizationsInvitedTo(fCtx ForgeContext) ([]organization, error) {
+	body, err := sendRequest(fCtx, http.MethodGet, fmt.Sprintf("%s/invited", organizationURL), nil)
+	if err != nil {
+		return nil, eris.Wrap(err, "Failed to get organizations")
+	}
+
+	orgs, err := parseResponse[[]organization](body)
+	if err != nil {
+		return nil, eris.Wrap(err, "Failed to parse response")
+	}
+
+	return *orgs, nil
+}
+
+func (o *organization) acceptOrganizationInvitation(fCtx ForgeContext) error {
+	_, err := sendRequest(fCtx, http.MethodPost, fmt.Sprintf("%s/%s/accept-invite", organizationURL, o.ID), nil)
+	if err != nil {
+		return eris.Wrap(err, "Failed to accept organization invitation")
+	}
+	return nil
+}
+
 func getListOfOrganizations(fCtx ForgeContext) ([]organization, error) {
 	// Send request
 	body, err := sendRequest(fCtx, http.MethodGet, organizationURL, nil)


### PR DESCRIPTION
# Add Organization Invitation Handling to Forge CLI

## Overview

This PR adds functionality to handle organization invitations in the Forge CLI. When users log in, they will now see any pending organization invitations and can choose to accept or decline them directly from the CLI.

## Brief Changelog

- Added `handleInvitedOrganizations` function to the initialization flow
- Implemented `getOrganizationsInvitedTo` to fetch pending invitations
- Added `acceptOrganizationInvitation` method to accept invitations
- Updated tests to cover the new invitation handling functionality
- Fixed project slug validation to properly handle empty inputs

## Testing and Verifying

This change is covered by new unit tests that validate:
- Accepting organization invitations
- Declining organization invitations
- Handling invalid inputs during the invitation process

The tests simulate various user responses to invitation prompts and verify the correct behavior in each case.

<!-- greptile_comment -->

## Greptile Summary

Added organization invitation handling to the World CLI, allowing users to manage pending invitations directly through the command line interface.

- Implemented invitation flow in `cmd/world/forge/flow_init.go` with `handleInvitedOrganizations` to process pending invites during login
- Added `getOrganizationsInvitedTo` and `acceptOrganizationInvitation` in `cmd/world/forge/organization.go` for fetching and accepting invites
- Enhanced project slug validation in `cmd/world/forge/project.go` to handle empty inputs gracefully
- Added comprehensive test coverage in `forge_internal_test.go` for invitation acceptance, rejection, and error scenarios



<!-- /greptile_comment -->