### PR TITLE
feat(CLI): invite via email

### DIFF
--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -250,8 +250,8 @@ type UserCmd struct {
 }
 
 type InviteUserToOrganizationCmd struct {
-	ID   string `flag:"" help:"The ID of the user to invite"`
-	Role string `flag:"" help:"The role of the user to invite"`
+	Email string `flag:"" help:"The email of the user to invite"`
+	Role  string `flag:"" help:"The role of the user to invite"`
 }
 
 func (c *InviteUserToOrganizationCmd) Run() error {
@@ -264,8 +264,8 @@ func (c *InviteUserToOrganizationCmd) Run() error {
 }
 
 type ChangeUserRoleInOrganizationCmd struct {
-	ID   string `flag:"" help:"The ID of the user to change the role of"`
-	Role string `flag:"" help:"The new role of the user"`
+	Email string `flag:"" help:"The email of the user to change the role of"`
+	Role  string `flag:"" help:"The new role of the user"`
 }
 
 func (c *ChangeUserRoleInOrganizationCmd) Run() error {

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -90,11 +90,11 @@ func (s *ForgeTestSuite) SetupTest() { //nolint: cyclop, gocyclo // test, don't 
 					s.handleGetRegions(w, r)
 				case "/api/organization/test-org-id/invite":
 					s.handleInvite(w, r)
-				case "/api/organization/test-org-id/role":
+				case "/api/organization/test-org-id/update-role":
 					s.handleRole(w, r)
 				case "/api/organization/invalid-org-id/invite":
 					http.Error(w, "Organization not found", http.StatusNotFound)
-				case "/api/organization/invalid-org-id/role":
+				case "/api/organization/invalid-org-id/update-role":
 					http.Error(w, "Organization not found", http.StatusNotFound)
 				case "/api/user":
 					s.handleGetUser(w, r)
@@ -5251,8 +5251,8 @@ func (s *ForgeTestSuite) TestInviteUserToOrganizationCmd() {
 				CurrRepoPath:   "/",
 			},
 			cmd: &InviteUserToOrganizationCmd{
-				ID:   "test-user-id",
-				Role: "member",
+				Email: "test-user-email",
+				Role:  "member",
 			},
 			expectedError: false,
 		},
@@ -5270,8 +5270,8 @@ func (s *ForgeTestSuite) TestInviteUserToOrganizationCmd() {
 				CurrRepoPath:   "/",
 			},
 			cmd: &InviteUserToOrganizationCmd{
-				ID:   "test-user-id",
-				Role: "member",
+				Email: "test-user-email",
+				Role:  "member",
 			},
 			expectedError: true,
 		},
@@ -5318,8 +5318,8 @@ func (s *ForgeTestSuite) TestChangeUserRoleInOrganizationCmd() {
 				CurrRepoPath:   "/",
 			},
 			cmd: &ChangeUserRoleInOrganizationCmd{
-				ID:   "test-user-id",
-				Role: "admin",
+				Email: "test-user-email",
+				Role:  "admin",
 			},
 			expectedError: false,
 		},
@@ -5337,8 +5337,8 @@ func (s *ForgeTestSuite) TestChangeUserRoleInOrganizationCmd() {
 				CurrRepoPath:   "/",
 			},
 			cmd: &ChangeUserRoleInOrganizationCmd{
-				ID:   "test-user-id",
-				Role: "admin",
+				Email: "test-user-email",
+				Role:  "admin",
 			},
 			expectedError: true,
 		},

--- a/cmd/world/forge/organization.go
+++ b/cmd/world/forge/organization.go
@@ -398,16 +398,16 @@ func (o *organization) inviteUser(fCtx ForgeContext, flags *InviteUserToOrganiza
 	printer.NewLine(1)
 	printer.Headerln("   Invite User to Organization   ")
 
-	userID := getInput("Enter user ID to invite", flags.ID)
-	if userID == "" {
-		return eris.New("User ID cannot be empty")
+	userEmail := getInput("Enter user email to invite", flags.Email)
+	if userEmail == "" {
+		return eris.New("User email cannot be empty")
 	}
 
 	userRole := getRoleInput(false, flags.Role)
 
 	payload := map[string]string{
-		"invited_user_id": userID,
-		"role":            userRole,
+		"invited_user_email": userEmail,
+		"role":               userRole,
 	}
 
 	// Send request
@@ -417,7 +417,7 @@ func (o *organization) inviteUser(fCtx ForgeContext, flags *InviteUserToOrganiza
 	}
 
 	printer.NewLine(1)
-	printer.Successf("Successfully invited user %s to organization!\n", userID)
+	printer.Successf("Successfully invited user %s to organization!\n", userEmail)
 	printer.Infof("Assigned role: %s\n", userRole)
 	return nil
 }
@@ -425,27 +425,28 @@ func (o *organization) inviteUser(fCtx ForgeContext, flags *InviteUserToOrganiza
 func (o *organization) updateUserRole(fCtx ForgeContext, flags *ChangeUserRoleInOrganizationCmd) error {
 	printer.NewLine(1)
 	printer.Headerln("  Update User Role in Organization  ")
-	userID := getInput("Enter user ID to update", flags.ID)
+	userEmail := getInput("Enter user email to update", flags.Email)
 
-	if userID == "" {
-		return eris.New("User ID cannot be empty")
+	if userEmail == "" {
+		return eris.New("User email cannot be empty")
 	}
 
 	userRole := getRoleInput(true, flags.Role)
 
 	payload := map[string]string{
-		"target_user_id": userID,
-		"role":           userRole,
+		"target_user_email": userEmail,
+		"role":              userRole,
 	}
 
 	// Send request
-	_, err := sendRequest(fCtx, http.MethodPost, fmt.Sprintf("%s/%s/role", organizationURL, o.ID), payload)
+	_, err := sendRequest(fCtx, http.MethodPost, fmt.Sprintf("%s/%s/update-role", organizationURL, o.ID), payload)
 	if err != nil {
+		printer.Errorf("Failed to set role in organization: %s\n", err)
 		return eris.Wrap(err, "Failed to set user role in organization")
 	}
 
 	printer.NewLine(1)
-	printer.Successf("Successfully updated role for user %s!\n", userID)
+	printer.Successf("Successfully updated role for user %s!\n", userEmail)
 	printer.Infof("New role: %s\n", userRole)
 	return nil
 }


### PR DESCRIPTION
# feat: Update organization user management to use email instead of ID


## Overview

This PR changes the organization user management commands to use email addresses instead of user IDs for inviting users and updating user roles. This makes the interface more user-friendly since emails are more recognizable than IDs.

## Brief Changelog

- Changed `InviteUserToOrganizationCmd` to use `Email` instead of `ID`
- Changed `ChangeUserRoleInOrganizationCmd` to use `Email` instead of `ID`
- Updated API endpoint for role changes from `/role` to `/update-role`
- Updated request payload fields to use `invited_user_email` and `target_user_email` instead of ID-based fields
- Updated error messages and success messages to reference email instead of ID

## Testing and Verifying

This change is covered by existing tests, which have been updated to reflect the new parameter names and API endpoints.

<!-- greptile_comment -->

## Greptile Summary

Updates organization user management to use email addresses instead of user IDs for better usability in the World CLI.

- Changed invite and role update commands in `cmd/world/forge/organization.go` to use email-based identification
- Updated API endpoint from `/role` to `/update-role` with new payload fields `invited_user_email` and `target_user_email`
- Enhanced error handling with additional validation for empty email addresses
- Modified test suite in `forge_internal_test.go` to cover new email-based approach



<!-- /greptile_comment -->