### PR TITLE
refactor(CLI): Display critical errors

### DIFF
--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -87,8 +87,7 @@ func handleArgusIDPostLogin(fCtx ForgeContext) error {
 		errStr := eris.ToString(err, false)
 		if strings.Contains(errStr, "503") {
 			printer.Errorln("World Forge is currently experiencing issues, please try again later.")
-		} else {
-			printer.Errorln(err.Error())
+			err = eris.Wrap(err, ErrHandledError.Error())
 		}
 		return err
 	}

--- a/cmd/world/forge/project.go
+++ b/cmd/world/forge/project.go
@@ -25,7 +25,10 @@ const MaxProjectNameLen = 50
 var regionSelector *tea.Program
 
 // ErrProjectSlugAlreadyExists is passed from forge to world-cli, Must always match.
-var ErrProjectSlugAlreadyExists = eris.New("project slug already exists")
+var (
+	ErrProjectSlugAlreadyExists  = eris.New("project slug already exists")
+	ErrCannotCreateSwitchProject = eris.New("Cannot create/switch Project, directory belongs to another project.")
+)
 
 type project struct {
 	ID           string        `json:"id"`
@@ -230,7 +233,7 @@ func projectPreCreateUpdateValidation() (string, string, error) {
 		return repoPath, repoURL, eris.Wrap(err, "Failed to check if in World project root")
 	} else if !inRoot {
 		printer.Errorln(" Not in a World project root")
-		return repoPath, repoURL, eris.New("Not in a World project root")
+		return repoPath, repoURL, ErrNotInWorldCardinalRoot
 	}
 
 	return repoPath, repoURL, nil
@@ -240,7 +243,7 @@ func createProject(fCtx ForgeContext, flags *CreateProjectCmd) (*project, error)
 	if fCtx.Config.CurrRepoKnown {
 		printer.Errorf("Cannot create Project, current git working directory belongs to project: %s.",
 			fCtx.Config.CurrProjectName)
-		return nil, eris.New("Cannot create Project, directory belongs to another project.")
+		return nil, ErrCannotCreateSwitchProject
 	}
 
 	repoPath, repoURL, err := projectPreCreateUpdateValidation()
@@ -595,7 +598,7 @@ func selectProject(fCtx ForgeContext, flags *SwitchProjectCmd, createNew bool) (
 	if fCtx.Config.CurrRepoKnown {
 		printer.Errorf("Cannot switch Project, current git working directory belongs to project: %s.",
 			fCtx.Config.CurrProjectName)
-		return nil, eris.New("Cannot switch Project, directory belongs to another project.")
+		return nil, ErrCannotCreateSwitchProject
 	}
 
 	// Get projects from selected organization

--- a/cmd/world/forge/repo.go
+++ b/cmd/world/forge/repo.go
@@ -14,7 +14,10 @@ import (
 
 const minimumURLParts = 2
 
-var ErrNotInGitRepository = eris.New("Not in a git repository")
+var (
+	ErrNotInGitRepository     = eris.New("Not in a git repository")
+	ErrNotInWorldCardinalRoot = eris.New("Not in a World Cadinal root")
+)
 
 // identifyProvider determines the Git provider based on the URL's host.
 func identifyProvider(repoURL string) (string, string, error) {
@@ -186,7 +189,7 @@ func FindGitPathAndURL() (string, string, error) {
 		if fallbackErr != nil {
 			return "", "", eris.Wrap(
 				fallbackErr,
-				fmt.Sprintf("%s: %s", ErrNotInGitRepository, "failed to get remote list"),
+				"Need to be in git repo: failed to get remote list",
 			)
 		}
 		lines := strings.Split(string(remoteList), "\n")


### PR DESCRIPTION
# Improved Error Handling in World Forge Commands


## Overview

This PR enhances error handling in the World Forge commands by implementing a centralized error handling system that provides clearer error messages to users and prevents duplicate error reporting.

## Brief Changelog

- Added `ErrHandledError` to mark errors that have already been handled with user-friendly messages
- Created `forgeErrorHandler` function to centralize error handling logic
- Implemented `forgeHandledErrorIgnoreList` to prevent duplicate error messages for known errors
- Updated error messages to be more descriptive and user-friendly
- Added specific error types for organization and project operations
- Improved handling of organization invite failures to clarify that invites are still created despite email failures
- Enhanced error reporting for login failures, particularly for service unavailability

## Testing and Verifying

This change can be verified by running various World Forge commands and observing the improved error messages when operations fail. The error handling now provides clearer guidance to users while preventing duplicate error messages.

<!-- greptile_comment -->

## Greptile Summary

Implements a centralized error handling system across World Forge CLI commands to improve user experience and prevent duplicate error reporting.

- Added `ErrHandledError` type in `cmd/world/forge/forge.go` to mark errors that have already been displayed to users
- Created `forgeErrorHandler` function in `cmd/world/forge/forge.go` to centralize error handling logic and provide consistent messaging
- Enhanced project validation in `cmd/world/forge/project.go` with new error type `ErrCannotCreateSwitchProject` for directory conflicts
- Improved organization invite error handling in `cmd/world/forge/organization.go` to clarify successful invites despite email failures
- Added service unavailability handling in `cmd/world/forge/login.go` for clearer user feedback during outages



<!-- /greptile_comment -->