### PR TITLE
refactor(CLI): update email via argus id and not CLI

### DIFF
--- a/cmd/world/forge/common.go
+++ b/cmd/world/forge/common.go
@@ -372,11 +372,6 @@ func CreateSlugFromName(name string, minLength int, maxLength int) string {
 	return slug
 }
 
-func isValidEmail(email string) bool {
-	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
-	return emailRegex.MatchString(email)
-}
-
 func isValidURL(urlStr string) error {
 	parsedURL, err := url.ParseRequestURI(urlStr)
 	if err != nil {

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -280,7 +280,6 @@ func (c *ChangeUserRoleInOrganizationCmd) Run() error {
 }
 
 type UpdateUserCmd struct {
-	Email     string `flag:"" help:"The email of the user to update"`
 	Name      string `flag:"" help:"The new name of the user"`
 	AvatarURL string `flag:"" help:"The new avatar URL of the user"  type:"url"`
 }
@@ -405,6 +404,8 @@ func forgeHandledErrorIgnoreList(err error) bool {
 	case strings.Contains(err.Error(), ErrCannotCreateSwitchProject.Error()):
 		return true
 	case strings.Contains(err.Error(), ErrOrganizationInviteFailed.Error()):
+		return true
+	case strings.Contains(err.Error(), ErrContextCanceled.Error()):
 		return true
 	default:
 		return false

--- a/cmd/world/forge/forge_internal_test.go
+++ b/cmd/world/forge/forge_internal_test.go
@@ -5380,7 +5380,6 @@ func (s *ForgeTestSuite) TestUpdateUserCmd() {
 				CurrRepoPath:   "/",
 			},
 			cmd: &UpdateUserCmd{
-				Email:     "test@example.com",
 				Name:      "admin",
 				AvatarURL: "https://github.com/test/avatar.png",
 			},

--- a/cmd/world/forge/login.go
+++ b/cmd/world/forge/login.go
@@ -93,6 +93,15 @@ func handleArgusIDPostLogin(fCtx ForgeContext) error {
 	}
 
 	fCtx.Config.Credential.ID = user.ID
+
+	// Update user email if it's different from the JWT token
+	if user.Email != fCtx.Config.Credential.Email {
+		err = updateUserRequest(fCtx, user.Name, user.Email, user.AvatarURL)
+		if err != nil {
+			return eris.Wrap(err, "Failed to update user email")
+		}
+	}
+
 	return fCtx.Config.Save()
 }
 
@@ -100,7 +109,8 @@ func displayLoginSuccess(config Config) {
 	printer.NewLine(1)
 	printer.Headerln("   Login successful!  ")
 	printer.Infof("Welcome, %s!\n", config.Credential.Name)
-	printer.Infof("Your ID is: %s\n", config.Credential.ID)
+	printer.Infof("ID: %s\n", config.Credential.ID)
+	printer.Infof("Email: %s\n", config.Credential.Email)
 	printer.NewLine(1)
 	printer.Infoln("You're all set to start using World Forge!")
 }
@@ -266,6 +276,7 @@ func parseJWTToken(jwtToken string) (Credential, error) {
 		TokenExpiresAt: time.Unix(claims.Exp, 0).Add(-tokenLeeway), // expire shortly before real expiration
 		Name:           claims.Name,
 		ID:             claims.Sub,
+		Email:          claims.Email,
 	}, nil
 }
 

--- a/cmd/world/forge/types.go
+++ b/cmd/world/forge/types.go
@@ -3,7 +3,11 @@ package forge
 import (
 	"context"
 	"time"
+
+	"github.com/rotisserie/eris"
 )
+
+var ErrContextCanceled = eris.New("context canceled")
 
 //nolint:revive // Name makes sense and is generally used within package
 type ForgeContext struct {
@@ -17,6 +21,7 @@ type Credential struct {
 	TokenExpiresAt time.Time `json:"token_expires_at,omitempty"`
 	ID             string    `json:"id"`
 	Name           string    `json:"name"`
+	Email          string    `json:"email"`
 }
 
 type CommandState struct {


### PR DESCRIPTION
# feat: Improve user management and login flow

## Overview

This PR enhances the user management functionality by removing the ability to update email addresses directly through the CLI, instead synchronizing email from JWT tokens during login. It also improves error handling and login success messaging.

## Brief Changelog

- Removed the ability to update user email through the CLI
- Added automatic email synchronization from JWT token during login
- Added email display in login success message
- Added handling for context cancellation errors
- Improved login success message formatting
- Refactored user update functionality to separate UI from API request logic

## Testing and Verifying

This change is covered by existing tests, with the test for UpdateUserCmd updated to reflect the removal of the email parameter.

<!-- greptile_comment -->

## Greptile Summary

Centralizes email management by removing direct CLI email updates in favor of JWT token synchronization during login, improving security and data consistency.

- Removed email update functionality from `cmd/world/forge/user.go` and `common.go`, centralizing email management through ArgusID
- Added automatic email synchronization from JWT tokens in `cmd/world/forge/login.go`
- Separated UI logic from API requests in user updates through new `updateUserRequest` function
- Updated test cases in `cmd/world/forge/forge_internal_test.go` to reflect removal of email parameter
- Extended `Credential` struct in `cmd/world/forge/types.go` to include email field for JWT synchronization



<!-- /greptile_comment -->