### PR TITLE
refactor(CLI): New directory structure

### DIFF
--- a/cmd/world/cardinal_refactor/build.go
+++ b/cmd/world/cardinal_refactor/build.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/cardinal.go
+++ b/cmd/world/cardinal_refactor/cardinal.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/cardinal_internal_test.go
+++ b/cmd/world/cardinal_refactor/cardinal_internal_test.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/dev.go
+++ b/cmd/world/cardinal_refactor/dev.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/mock.go
+++ b/cmd/world/cardinal_refactor/mock.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/purge.go
+++ b/cmd/world/cardinal_refactor/purge.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/restart.go
+++ b/cmd/world/cardinal_refactor/restart.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/start.go
+++ b/cmd/world/cardinal_refactor/start.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/stop.go
+++ b/cmd/world/cardinal_refactor/stop.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cardinal_refactor/types.go
+++ b/cmd/world/cardinal_refactor/types.go
@@ -1,0 +1,1 @@
+package cardinal

--- a/cmd/world/cloud_refactor/cloud.go
+++ b/cmd/world/cloud_refactor/cloud.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/cloud_internal_test.go
+++ b/cmd/world/cloud_refactor/cloud_internal_test.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/deploy.go
+++ b/cmd/world/cloud_refactor/deploy.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/destroy.go
+++ b/cmd/world/cloud_refactor/destroy.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/logs.go
+++ b/cmd/world/cloud_refactor/logs.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/mock.go
+++ b/cmd/world/cloud_refactor/mock.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/promote.go
+++ b/cmd/world/cloud_refactor/promote.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/reset.go
+++ b/cmd/world/cloud_refactor/reset.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/status.go
+++ b/cmd/world/cloud_refactor/status.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cloud_refactor/types.go
+++ b/cmd/world/cloud_refactor/types.go
@@ -1,0 +1,1 @@
+package cloud

--- a/cmd/world/cmdSetup_internal_test.go
+++ b/cmd/world/cmdSetup_internal_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/world/cmdSetup_refactor.go
+++ b/cmd/world/cmdSetup_refactor.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/world/evm_refactor/evm.go
+++ b/cmd/world/evm_refactor/evm.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/evm_refactor/evm_internal_test.go
+++ b/cmd/world/evm_refactor/evm_internal_test.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/evm_refactor/mock.go
+++ b/cmd/world/evm_refactor/mock.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/evm_refactor/start.go
+++ b/cmd/world/evm_refactor/start.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/evm_refactor/stop.go
+++ b/cmd/world/evm_refactor/stop.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/evm_refactor/types.go
+++ b/cmd/world/evm_refactor/types.go
@@ -1,0 +1,1 @@
+package evm

--- a/cmd/world/forge/forge.go
+++ b/cmd/world/forge/forge.go
@@ -281,7 +281,7 @@ func (c *ChangeUserRoleInOrganizationCmd) Run() error {
 
 type UpdateUserCmd struct {
 	Name      string `flag:"" help:"The new name of the user"`
-	AvatarURL string `flag:"" help:"The new avatar URL of the user"  type:"url"`
+	AvatarURL string `flag:"" help:"The new avatar URL of the user" type:"url"`
 }
 
 func (c *UpdateUserCmd) Run() error {

--- a/cmd/world/organization_refactor/create.go
+++ b/cmd/world/organization_refactor/create.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/organization_refactor/mock.go
+++ b/cmd/world/organization_refactor/mock.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/organization_refactor/organization_internal_test.go
+++ b/cmd/world/organization_refactor/organization_internal_test.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/organization_refactor/organiztion.go
+++ b/cmd/world/organization_refactor/organiztion.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/organization_refactor/switch.go
+++ b/cmd/world/organization_refactor/switch.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/organization_refactor/types.go
+++ b/cmd/world/organization_refactor/types.go
@@ -1,0 +1,1 @@
+package organization

--- a/cmd/world/project_refactor/create.go
+++ b/cmd/world/project_refactor/create.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/delete.go
+++ b/cmd/world/project_refactor/delete.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/mock.go
+++ b/cmd/world/project_refactor/mock.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/project.go
+++ b/cmd/world/project_refactor/project.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/project_internal_test.go
+++ b/cmd/world/project_refactor/project_internal_test.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/switch.go
+++ b/cmd/world/project_refactor/switch.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/types.go
+++ b/cmd/world/project_refactor/types.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/project_refactor/update.go
+++ b/cmd/world/project_refactor/update.go
@@ -1,0 +1,1 @@
+package project

--- a/cmd/world/root_refactor/create.go
+++ b/cmd/world/root_refactor/create.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/doctor.go
+++ b/cmd/world/root_refactor/doctor.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/login.go
+++ b/cmd/world/root_refactor/login.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/mock.go
+++ b/cmd/world/root_refactor/mock.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/root.go
+++ b/cmd/world/root_refactor/root.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/types.go
+++ b/cmd/world/root_refactor/types.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/root_refactor/version.go
+++ b/cmd/world/root_refactor/version.go
@@ -1,0 +1,1 @@
+package root

--- a/cmd/world/user_refactor/invite.go
+++ b/cmd/world/user_refactor/invite.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/mock.go
+++ b/cmd/world/user_refactor/mock.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/role.go
+++ b/cmd/world/user_refactor/role.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/types.go
+++ b/cmd/world/user_refactor/types.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/update.go
+++ b/cmd/world/user_refactor/update.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/user.go
+++ b/cmd/world/user_refactor/user.go
@@ -1,0 +1,1 @@
+package user

--- a/cmd/world/user_refactor/user_internal_test.go
+++ b/cmd/world/user_refactor/user_internal_test.go
@@ -1,0 +1,1 @@
+package user


### PR DESCRIPTION
Closes: WORLD-XXX

refactor: Prepare command structure for CLI refactoring

## Overview

This PR creates the foundation for a modular CLI command structure by setting up package directories for each command group. Each command group is organized into its own package with consistent file naming patterns.

## Brief Changelog

- Created package structure for cardinal commands (build, dev, purge, restart, start, stop)
- Created package structure for cloud commands (deploy, destroy, logs, promote, reset, status)
- Created package structure for EVM commands (start, stop)
- Created package structure for organization commands (create, switch)
- Created package structure for project commands (create, delete, switch, update)
- Created package structure for root commands (create, doctor, login, version)
- Created package structure for user commands (invite, role, update)
- Added internal test files for each command group
- Added mock implementations for testing
- Fixed spacing in forge.go UpdateUserCmd struct

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The files created are empty package declarations that will be populated in subsequent PRs.

<!-- greptile_comment -->

## Greptile Summary

Major structural refactoring of the World CLI codebase, establishing a new modular directory structure by organizing commands into dedicated packages for better maintainability and testing.

- Created separate package directories for 7 command groups (cardinal, cloud, evm, organization, project, root, user) with consistent file patterns
- Incorrect directory naming: 'organization_refactor.go' includes '.go' extension, should be 'organization_refactor'
- Typo in file name: 'organiztion.go' should be 'organization.go'
- Added mock implementations and internal test files for each command group
- All files contain only package declarations as placeholders, to be implemented in follow-up PRs



<!-- /greptile_comment -->