### PR TITLE
feat: setup CLI command centric refactor DEVP-172

### DIFF
--- a/cmd/world/cardinal_refactor/build.go
+++ b/cmd/world/cardinal_refactor/build.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/cardinal.go
+++ b/cmd/world/cardinal_refactor/cardinal.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/cardinal_internal_test.go
+++ b/cmd/world/cardinal_refactor/cardinal_internal_test.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/dev.go
+++ b/cmd/world/cardinal_refactor/dev.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/mock.go
+++ b/cmd/world/cardinal_refactor/mock.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/purge.go
+++ b/cmd/world/cardinal_refactor/purge.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/restart.go
+++ b/cmd/world/cardinal_refactor/restart.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/start.go
+++ b/cmd/world/cardinal_refactor/start.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/stop.go
+++ b/cmd/world/cardinal_refactor/stop.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cardinal_refactor/types.go
+++ b/cmd/world/cardinal_refactor/types.go
@@ -1,1 +1,0 @@
-package cardinal

--- a/cmd/world/cloud_refactor/cloud.go
+++ b/cmd/world/cloud_refactor/cloud.go
@@ -1,1 +1,67 @@
 package cloud
+
+var CmdPlugin struct {
+	Cloud *Cmd `cmd:""`
+}
+
+//nolint:lll // needed to put all the help text in the same line
+type Cmd struct {
+	Deploy  *DeployCmd  `cmd:"" group:"Cloud Management Commands:" help:"Deploy your World Forge project to a TEST environment in the cloud"`
+	Status  *StatusCmd  `cmd:"" group:"Cloud Management Commands:" help:"Check the status of your deployed World Forge project"`
+	Promote *PromoteCmd `cmd:"" group:"Cloud Management Commands:" help:"Deploy your game project to a LIVE environment in the cloud"`
+	Destroy *DestroyCmd `cmd:"" group:"Cloud Management Commands:" help:"Remove your game project's deployed infrastructure from the cloud"`
+	Reset   *ResetCmd   `cmd:"" group:"Cloud Management Commands:" help:"Restart your game project with a clean state"`
+	Logs    *LogsCmd    `cmd:"" group:"Cloud Management Commands:" help:"Tail logs for your game project"`
+}
+
+type DeployCmd struct {
+	Force bool `flag:"" help:"Force the deployment"`
+}
+
+func (c *DeployCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type StatusCmd struct {
+}
+
+func (c *StatusCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type PromoteCmd struct {
+}
+
+func (c *PromoteCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type DestroyCmd struct {
+}
+
+func (c *DestroyCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type ResetCmd struct {
+}
+
+func (c *ResetCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+//nolint:lll // needed to put all the help text in the same line
+type LogsCmd struct {
+	Region string `arg:"" enum:"ap-southeast-1,eu-central-1,us-east-1,us-west-2" default:"us-west-2" optional:"" help:"The region to tail logs for"`
+	Env    string `arg:"" enum:"test,live"                                       default:"test"      optional:"" help:"The environment to tail logs for"`
+}
+
+func (c *LogsCmd) Run() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/deploy.go
+++ b/cmd/world/cloud_refactor/deploy.go
@@ -1,1 +1,7 @@
 package cloud
+
+//nolint:revive // TODO: implement
+func (h *Handler) Deploy(force bool) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/destroy.go
+++ b/cmd/world/cloud_refactor/destroy.go
@@ -1,1 +1,6 @@
 package cloud
+
+func (h *Handler) Destroy() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/logs.go
+++ b/cmd/world/cloud_refactor/logs.go
@@ -1,1 +1,7 @@
 package cloud
+
+//nolint:revive // TODO: implement
+func (h *Handler) Logs(region string, env string) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/mock.go
+++ b/cmd/world/cloud_refactor/mock.go
@@ -1,1 +1,40 @@
 package cloud
+
+import "github.com/stretchr/testify/mock"
+
+// Interface guard.
+var _ HandlerInterface = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Deploy(force bool) error {
+	args := m.Called(force)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Status() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockHandler) Promote() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockHandler) Destroy() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockHandler) Reset() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockHandler) Logs(region string, env string) error {
+	args := m.Called(region, env)
+	return args.Error(0)
+}

--- a/cmd/world/cloud_refactor/promote.go
+++ b/cmd/world/cloud_refactor/promote.go
@@ -1,1 +1,6 @@
 package cloud
+
+func (h *Handler) Promote() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/reset.go
+++ b/cmd/world/cloud_refactor/reset.go
@@ -1,1 +1,6 @@
 package cloud
+
+func (h *Handler) Reset() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/status.go
+++ b/cmd/world/cloud_refactor/status.go
@@ -1,1 +1,6 @@
 package cloud
+
+func (h *Handler) Status() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/cloud_refactor/types.go
+++ b/cmd/world/cloud_refactor/types.go
@@ -1,1 +1,16 @@
 package cloud
+
+// Interface guard.
+var _ HandlerInterface = (*Handler)(nil)
+
+type Handler struct {
+}
+
+type HandlerInterface interface {
+	Deploy(force bool) error
+	Status() error
+	Promote() error
+	Destroy() error
+	Reset() error
+	Logs(region string, env string) error
+}

--- a/cmd/world/evm_refactor/evm.go
+++ b/cmd/world/evm_refactor/evm.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/evm_refactor/evm_internal_test.go
+++ b/cmd/world/evm_refactor/evm_internal_test.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/evm_refactor/mock.go
+++ b/cmd/world/evm_refactor/mock.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/evm_refactor/start.go
+++ b/cmd/world/evm_refactor/start.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/evm_refactor/stop.go
+++ b/cmd/world/evm_refactor/stop.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/evm_refactor/types.go
+++ b/cmd/world/evm_refactor/types.go
@@ -1,1 +1,0 @@
-package evm

--- a/cmd/world/organization_refactor/create.go
+++ b/cmd/world/organization_refactor/create.go
@@ -1,1 +1,10 @@
 package organization
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Create(ctx models.CommandContext, flags *models.CreateOrganizationFlags,
+) (*models.Organization, error) {
+	//nolint:nilnil // TODO: implement
+	return nil, nil
+}

--- a/cmd/world/organization_refactor/mock.go
+++ b/cmd/world/organization_refactor/mock.go
@@ -1,1 +1,25 @@
 package organization
+
+import (
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/world/pkg/models"
+)
+
+// Interface guard.
+var _ HandlerInterface = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Create(ctx models.CommandContext, flags *models.CreateOrganizationFlags,
+) (*models.Organization, error) {
+	args := m.Called(ctx, flags)
+	return args.Get(0).(*models.Organization), args.Error(1)
+}
+
+func (m *MockHandler) Switch(ctx models.CommandContext, flags *models.SwitchOrganizationFlags,
+) (*models.Organization, error) {
+	args := m.Called(ctx, flags)
+	return args.Get(0).(*models.Organization), args.Error(1)
+}

--- a/cmd/world/organization_refactor/organiztion.go
+++ b/cmd/world/organization_refactor/organiztion.go
@@ -1,1 +1,30 @@
 package organization
+
+var CmdPlugin struct {
+	Organization *Cmd `cmd:"" aliases:"org"  group:"Organization Commands:" help:"Manage your organizations"`
+}
+
+type Cmd struct {
+	Create *CreateCmd `cmd:"" group:"Organization Commands:" help:"Create a new organization"`
+	Switch *SwitchCmd `cmd:"" group:"Organization Commands:" help:"Switch to an organization"`
+}
+
+type CreateCmd struct {
+	Name      string `flag:"" help:"The name of the organization"`
+	Slug      string `flag:"" help:"The slug of the organization"`
+	AvatarURL string `flag:"" help:"The avatar URL of the organization" type:"url"`
+}
+
+func (c *CreateCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type SwitchCmd struct {
+	Slug string `flag:"" help:"The slug of the organization to switch to"`
+}
+
+func (c *SwitchCmd) Run() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/organization_refactor/switch.go
+++ b/cmd/world/organization_refactor/switch.go
@@ -1,1 +1,10 @@
 package organization
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Switch(ctx models.CommandContext, flags *models.SwitchOrganizationFlags,
+) (*models.Organization, error) {
+	//nolint:nilnil // TODO: implement
+	return nil, nil
+}

--- a/cmd/world/organization_refactor/types.go
+++ b/cmd/world/organization_refactor/types.go
@@ -1,1 +1,19 @@
 package organization
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+// Interface guard.
+var _ HandlerInterface = (*Handler)(nil)
+
+type Handler struct {
+	ProjectHandler ProjectHandler
+}
+
+type HandlerInterface interface {
+	Create(ctx models.CommandContext, flags *models.CreateOrganizationFlags) (*models.Organization, error)
+	Switch(ctx models.CommandContext, flags *models.SwitchOrganizationFlags) (*models.Organization, error)
+}
+
+type ProjectHandler interface {
+	Switch(ctx models.CommandContext, flags *models.SwitchProjectFlags) (*models.Project, error)
+}

--- a/cmd/world/pkg/clients/config/config.go
+++ b/cmd/world/pkg/clients/config/config.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rotisserie/eris"
+	commonConfig "pkg.world.dev/world-cli/common/config"
+	"pkg.world.dev/world-cli/common/logger"
+)
+
+// TODO: break this config into credentials and known projects. Don't save org/project id in the config.
+// consider adding a .forge directory with project config alongside the world.toml file.
+const (
+	EnvLocal = "LOCAL"
+	EnvDev   = "DEV"
+	EnvProd  = "PROD"
+
+	defaultFileName = "forge-config.json"
+)
+
+var ErrCannotSaveConfig = eris.New("Critical config update error could not save")
+
+func NewClient(env string) (ClientInterface, error) {
+	client := &Client{
+		Env:    env,
+		Config: Config{},
+	}
+
+	err := client.getSetConfig()
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to get config")
+	}
+	return client, nil
+}
+
+func (c *Client) GetConfig() *Config {
+	return &c.Config
+}
+
+func (c *Client) Save() error {
+	configFile, err := c.getConfigFileName()
+	if err != nil {
+		return eris.Wrap(err, "failed get config file name")
+	}
+
+	configJSON, err := json.Marshal(c.Config)
+	if err != nil {
+		return eris.Wrap(err, "failed to marshal config")
+	}
+
+	return os.WriteFile(configFile, configJSON, 0600)
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// internal functions
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+func (c *Client) getSetConfig() error {
+	var config Config
+
+	configFile, err := c.getConfigFileName()
+	if err != nil {
+		return eris.Wrap(err, "failed get config file name")
+	}
+
+	file, err := os.ReadFile(configFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // this is ok, just create empty config
+		}
+		return eris.Wrap(err, "failed to read config file")
+	}
+
+	// Unmarshal the config
+	err = json.Unmarshal(file, &config)
+	if err != nil {
+		logger.Error(eris.Wrap(err, "failed to unmarshal config"))
+		return err
+	}
+	// these will get set in forge/common.go's GetCurrentConfig()
+	config.CurrRepoKnown = false
+	config.CurrRepoURL = ""
+	config.CurrRepoPath = ""
+	config.CurrProjectName = ""
+
+	c.Config = config
+	return nil
+}
+
+func (c *Client) getConfigFileName() (string, error) {
+	fileName := defaultFileName
+	if c.Env == EnvDev || c.Env == EnvLocal {
+		fileName = strings.ToLower(c.Env) + "-" + fileName
+	}
+	fullConfigDir, err := commonConfig.GetCLIConfigDir()
+	if err != nil {
+		return "", eris.Wrap(err, "failed get config dir")
+	}
+	configFile := filepath.Join(fullConfigDir, fileName)
+	return configFile, nil
+}

--- a/cmd/world/pkg/clients/config/config_internal_test.go
+++ b/cmd/world/pkg/clients/config/config_internal_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	commonConfig "pkg.world.dev/world-cli/common/config"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+	tempDir    string
+	origGetDir func() (string, error)
+}
+
+func (s *ConfigTestSuite) SetupTest() {
+	s.tempDir = s.T().TempDir()
+
+	// Mock commonConfig.GetCLIConfigDir to return our temp directory
+	s.origGetDir = commonConfig.GetCLIConfigDir
+	//nolint:reassign // test code
+	commonConfig.GetCLIConfigDir = func() (string, error) {
+		return s.tempDir, nil
+	}
+}
+
+func (s *ConfigTestSuite) TearDownTest() {
+	// Restore original function
+	//nolint:reassign // test code
+	commonConfig.GetCLIConfigDir = s.origGetDir
+}
+
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (s *ConfigTestSuite) TestNewClient() {
+	client, err := NewClient(EnvDev)
+	s.Require().NoError(err)
+	s.NotNil(client)
+	s.Implements((*ClientInterface)(nil), client)
+
+	realClient := client.(*Client)
+	s.Equal(EnvDev, realClient.Env)
+}
+
+func (s *ConfigTestSuite) TestGetForgeConfig_NoFile() {
+	// Test the REAL Client implementation
+	client, err := NewClient(EnvDev)
+	s.Require().NoError(err)
+
+	config := client.GetConfig()
+	s.Empty(config.Credential.Token)
+	s.Empty(config.KnownProjects)
+	s.False(config.CurrRepoKnown)
+}
+
+func (s *ConfigTestSuite) TestGetForgeConfig_WithFile() {
+	// Create a real config file in the mocked config directory
+	testConfig := Config{
+		OrganizationID: "org-123",
+		ProjectID:      "proj-456",
+		Credential: Credential{
+			Token: "test-token",
+			ID:    "user-123",
+			Name:  "Test User",
+			Email: "test@example.com",
+		},
+		KnownProjects: []KnownProject{
+			{
+				ProjectID:      "proj-789",
+				ProjectName:    "test-project",
+				OrganizationID: "org-123",
+				RepoURL:        "https://github.com/test/repo",
+				RepoPath:       "test/path",
+			},
+		},
+	}
+
+	// Save it using the real file naming logic
+	configFile := filepath.Join(s.tempDir, "dev-forge-config.json")
+	data, err := json.Marshal(testConfig)
+	s.Require().NoError(err)
+	err = os.WriteFile(configFile, data, 0600)
+	s.Require().NoError(err)
+
+	// Test the REAL Client.GetForgeConfig() method
+	client, err := NewClient(EnvDev)
+	s.Require().NoError(err)
+	config := client.GetConfig()
+
+	// Verify it read the real file correctly
+	s.Equal("test-token", config.Credential.Token)
+	s.Equal("org-123", config.OrganizationID)
+	s.Equal("proj-456", config.ProjectID)
+	s.Len(config.KnownProjects, 1)
+	s.Equal("test-project", config.KnownProjects[0].ProjectName)
+
+	// Verify runtime fields are reset (line 54-57 in real implementation)
+	s.False(config.CurrRepoKnown)
+	s.Empty(config.CurrRepoURL)
+	s.Empty(config.CurrRepoPath)
+	s.Empty(config.CurrProjectName)
+}
+
+func (s *ConfigTestSuite) TestSave() {
+	testConfig := Config{
+		OrganizationID: "org-123",
+		Credential: Credential{
+			Token: "test-token",
+		},
+	}
+
+	// Test the REAL Client.Save() method
+	client, err := NewClient(EnvDev)
+	s.Require().NoError(err)
+
+	client.(*Client).Config = testConfig
+	err = client.Save()
+	s.Require().NoError(err)
+
+	// Verify the real implementation created the file with correct name
+	configFile := filepath.Join(s.tempDir, "dev-forge-config.json")
+	s.FileExists(configFile)
+
+	// Verify content was marshaled correctly
+	data, err := os.ReadFile(configFile)
+	s.Require().NoError(err)
+
+	var savedConfig Config
+	err = json.Unmarshal(data, &savedConfig)
+	s.Require().NoError(err)
+	s.Equal("test-token", savedConfig.Credential.Token)
+	s.Equal("org-123", savedConfig.OrganizationID)
+}
+
+func (s *ConfigTestSuite) TestGetConfigFileName() {
+	tests := []struct {
+		name         string
+		env          string
+		expectedFile string
+	}{
+		{
+			name:         "production config",
+			env:          EnvProd,
+			expectedFile: "forge-config.json",
+		},
+		{
+			name:         "development config",
+			env:          EnvDev,
+			expectedFile: "dev-forge-config.json",
+		},
+		{
+			name:         "local config",
+			env:          EnvLocal,
+			expectedFile: "local-forge-config.json",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			client, err := NewClient(tt.env)
+			s.Require().NoError(err)
+			filename, err := client.(*Client).getConfigFileName()
+			s.Require().NoError(err)
+			s.Contains(filename, tt.expectedFile)
+			s.Equal(filepath.Join(s.tempDir, tt.expectedFile), filename)
+		})
+	}
+}
+
+func (s *ConfigTestSuite) TestMockImplementsInterface() {
+	mockClient := &MockClient{}
+	s.Implements((*ClientInterface)(nil), mockClient)
+}

--- a/cmd/world/pkg/clients/config/mock.go
+++ b/cmd/world/pkg/clients/config/mock.go
@@ -1,0 +1,19 @@
+package config
+
+import "github.com/stretchr/testify/mock"
+
+var _ ClientInterface = (*MockClient)(nil)
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) GetConfig() *Config {
+	args := m.Called()
+	return args.Get(0).(*Config)
+}
+
+func (m *MockClient) Save() error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/cmd/world/pkg/clients/config/types.go
+++ b/cmd/world/pkg/clients/config/types.go
@@ -1,0 +1,46 @@
+package config
+
+import "time"
+
+type Config struct {
+	OrganizationID string         `json:"organization_id"`
+	ProjectID      string         `json:"project_id"`
+	Credential     Credential     `json:"credential"`
+	KnownProjects  []KnownProject `json:"known_projects"`
+	// the following are not saved in json
+	// TODO: get rid of these since they will be handled by the init flow state
+	CurrRepoKnown   bool   `json:"-"` // when true, the current repo and path are already in known_projects
+	CurrRepoURL     string `json:"-"`
+	CurrRepoPath    string `json:"-"`
+	CurrProjectName string `json:"-"`
+}
+
+type Credential struct {
+	Token          string    `json:"token"`
+	TokenExpiresAt time.Time `json:"token_expires_at,omitempty"`
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Email          string    `json:"email"`
+}
+
+type KnownProject struct {
+	RepoURL        string `json:"repo_url"`
+	RepoPath       string `json:"repo_path"`
+	OrganizationID string `json:"organization_id"`
+	ProjectID      string `json:"project_id"`
+	ProjectName    string `json:"project_name"`
+}
+
+var _ ClientInterface = (*Client)(nil)
+
+type Client struct {
+	Env    string
+	Config Config
+}
+
+type ClientInterface interface {
+	// GetConfig returns a copy of the config
+	GetConfig() *Config
+	// Save saves the config to the file system
+	Save() error
+}

--- a/cmd/world/pkg/clients/repo/mock.go
+++ b/cmd/world/pkg/clients/repo/mock.go
@@ -1,0 +1,28 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ ClientInterface = (*MockClient)(nil)
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) FindGitPathAndURL() (string, string, error) {
+	args := m.Called()
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *MockClient) ValidateRepoToken(ctx context.Context, repoURL, token string) error {
+	args := m.Called(ctx, repoURL, token)
+	return args.Error(0)
+}
+
+func (m *MockClient) ValidateRepoPath(ctx context.Context, repoURL, token, path string) error {
+	args := m.Called(ctx, repoURL, token, path)
+	return args.Error(0)
+}

--- a/cmd/world/pkg/clients/repo/repo.go
+++ b/cmd/world/pkg/clients/repo/repo.go
@@ -1,0 +1,236 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/rotisserie/eris"
+)
+
+const minimumURLParts = 2
+
+var (
+	ErrNotInGitRepository     = eris.New("Not in a git repository")
+	ErrNotInWorldCardinalRoot = eris.New("Not in a World Cardinal root")
+)
+
+func NewClient() ClientInterface {
+	return &Client{}
+}
+
+func (c *Client) FindGitPathAndURL() (string, string, error) {
+	// Try to get the 'origin' remote URL first
+	urlData, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+	if err != nil || strings.TrimSpace(string(urlData)) == "" {
+		// Fallback: get the first available remote URL
+		remoteList, fallbackErr := exec.Command("git", "remote", "-v").Output()
+		if fallbackErr != nil {
+			return "", "", eris.Wrap(
+				fallbackErr,
+				"Need to be in git repo: failed to get remote list",
+			)
+		}
+		lines := strings.Split(string(remoteList), "\n")
+		for _, line := range lines {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				urlData = []byte(parts[1])
+				break
+			}
+		}
+	}
+
+	url := strings.TrimSpace(string(urlData))
+	if url == "" {
+		return "", "", ErrNotInGitRepository
+	}
+	url = replaceLast(url, ".git", "")
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", url, err
+	}
+	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", url, err
+	}
+	rootPath := strings.TrimSpace(string(root))
+	path := strings.Replace(workingDir, rootPath, "", 1)
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+	return path, url, nil
+}
+
+func replaceLast(x, y, z string) string {
+	i := strings.LastIndex(x, y)
+	if i == -1 {
+		return x
+	}
+	return x[:i] + z + x[i+len(y):]
+}
+
+// identifyProvider determines the Git provider based on the URL's host.
+func identifyProvider(repoURL string) (string, string, error) {
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := parsedURL.Host
+	switch {
+	case strings.Contains(host, "github.com"):
+		return "GitHub", "https://api.github.com", nil
+	case strings.Contains(host, "gitlab.com"):
+		return "GitLab", "https://gitlab.com/api/v4", nil
+	case strings.Contains(host, "bitbucket.org"):
+		return "Bitbucket", "https://api.bitbucket.org/2.0", nil
+	default:
+		return "Unknown", "", fmt.Errorf("unknown provider: %s", host)
+	}
+}
+
+// ValidateRepoToken tests if the token and repo URL are valid using the provider's API.
+func (c *Client) ValidateRepoToken(ctx context.Context, repoURL, token string) error {
+	provider, apiBaseURL, err := identifyProvider(repoURL)
+	if err != nil {
+		return fmt.Errorf("failed to identify provider: %w", err)
+	}
+
+	switch provider {
+	case "GitHub":
+		return validateGitHub(ctx, repoURL, token, apiBaseURL)
+	case "GitLab":
+		return validateGitLab(ctx, repoURL, token, apiBaseURL)
+	case "Bitbucket":
+		return validateBitbucket(ctx, repoURL, token, apiBaseURL)
+	default:
+		return fmt.Errorf("provider %s is not supported", provider)
+	}
+}
+
+// params: ctx, repoURL, token, path
+func (c *Client) ValidateRepoPath(_ context.Context, _, _, path string) error {
+	if strings.Contains(path, " ") {
+		return fmt.Errorf("invalid path: %s", path)
+	}
+	// I don't think we need to verify that the path actually exists in the repo,
+	// but if we decide to here's where we would do that. If it doesn't exist then
+	// any deploy attempt will fail in the World Forge Worker at the checkout action
+	// Hints at possible GitHub implementation here: https://github.com/orgs/community/discussions/68413
+	return nil
+}
+
+// validateGitHub validates the token and repository for GitHub.
+func validateGitHub(ctx context.Context, repoURL, token, apiBaseURL string) error {
+	// Extract the owner and repo name from the URL
+	parts := strings.Split(repoURL, "/")
+	if len(parts) < minimumURLParts {
+		return eris.New("invalid github repository URL")
+	}
+	repo := strings.TrimSuffix(parts[len(parts)-1], ".git")
+	owner := parts[len(parts)-2]
+
+	// Construct the API request URL
+	apiURL := fmt.Sprintf("%s/repos/%s/%s", apiBaseURL, owner, repo)
+
+	// Make the API request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Only set authorization header if token is provided
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("GitHub validation failed: %s", resp.Status)
+}
+
+// validateGitLab validates the token and repository for GitLab.
+func validateGitLab(ctx context.Context, repoURL, token, apiBaseURL string) error {
+	// Extract the project path from the URL
+	parts := strings.Split(repoURL, "/")
+	if len(parts) < minimumURLParts {
+		return eris.New("invalid gitlab repository URL")
+	}
+	projectPath := fmt.Sprintf("%s/%s", parts[len(parts)-2], strings.TrimSuffix(parts[len(parts)-1], ".git"))
+
+	// Construct the API request URL
+	apiURL := fmt.Sprintf("%s/projects/%s", apiBaseURL, url.QueryEscape(projectPath))
+
+	// Make the API request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Only set token header if token is provided
+	if token != "" {
+		req.Header.Set("Private-Token", token)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("GitLab validation failed: %s", resp.Status)
+}
+
+// validateBitbucket validates the token and repository for Bitbucket.
+func validateBitbucket(ctx context.Context, repoURL, token, apiBaseURL string) error {
+	// Extract the workspace and repo slug from the URL
+	parts := strings.Split(repoURL, "/")
+	if len(parts) < minimumURLParts {
+		return eris.New("invalid bitbucket repository URL")
+	}
+	workspace := parts[len(parts)-2]
+	repoSlug := strings.TrimSuffix(parts[len(parts)-1], ".git")
+
+	// Construct the API request URL
+	apiURL := fmt.Sprintf("%s/repositories/%s/%s", apiBaseURL, workspace, repoSlug)
+
+	// Make the API request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Only set authorization header if token is provided
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("bitbucket validation failed: %s", resp.Status)
+}

--- a/cmd/world/pkg/clients/repo/repo_internal_test.go
+++ b/cmd/world/pkg/clients/repo/repo_internal_test.go
@@ -1,0 +1,450 @@
+package repo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RepoTestSuite struct {
+	suite.Suite
+	client ClientInterface
+	ctx    context.Context
+}
+
+func (s *RepoTestSuite) SetupTest() {
+	s.client = NewClient()
+	s.ctx = context.Background()
+}
+
+func TestRepoSuite(t *testing.T) {
+	suite.Run(t, new(RepoTestSuite))
+}
+
+func (s *RepoTestSuite) TestNewClient() {
+	client := NewClient()
+	s.NotNil(client)
+	s.Implements((*ClientInterface)(nil), client)
+}
+
+func (s *RepoTestSuite) TestFindGitPathAndURL() {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		s.T().Skip("git not available")
+	}
+
+	tests := []struct {
+		name          string
+		setupRepo     func(t *testing.T) string // returns repo dir
+		expectedPath  string
+		expectedURL   string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "valid git repo with origin",
+			setupRepo: func(t *testing.T) string {
+				dir := t.TempDir()
+
+				// Initialize git repo
+				cmd := exec.Command("git", "init")
+				cmd.Dir = dir
+				require.NoError(t, cmd.Run())
+
+				// Add origin remote
+				cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test/repo.git")
+				cmd.Dir = dir
+				require.NoError(t, cmd.Run())
+
+				// Create subdirectory
+				subDir := filepath.Join(dir, "subdir")
+				require.NoError(t, os.MkdirAll(subDir, 0755))
+
+				return subDir
+			},
+			expectedPath: "subdir",
+			expectedURL:  "https://github.com/test/repo",
+			expectError:  false,
+		},
+		{
+			name: "git repo at root",
+			setupRepo: func(t *testing.T) string {
+				dir := t.TempDir()
+
+				// Initialize git repo
+				cmd := exec.Command("git", "init")
+				cmd.Dir = dir
+				require.NoError(t, cmd.Run())
+
+				// Add origin remote
+				cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test/repo.git")
+				cmd.Dir = dir
+				require.NoError(t, cmd.Run())
+
+				return dir
+			},
+			expectedPath: "",
+			expectedURL:  "https://github.com/test/repo",
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			// Setup
+			originalDir, err := os.Getwd()
+			s.Require().NoError(err)
+			defer func() {
+				s.Require().NoError(os.Chdir(originalDir))
+			}()
+
+			repoDir := tt.setupRepo(s.T())
+			s.Require().NoError(os.Chdir(repoDir))
+
+			// Test
+			path, url, err := s.client.FindGitPathAndURL()
+
+			if tt.expectError {
+				s.Require().Error(err)
+				if tt.errorContains != "" {
+					s.Contains(err.Error(), tt.errorContains)
+				}
+			} else {
+				s.Require().NoError(err)
+				s.Equal(tt.expectedPath, path)
+				s.Equal(tt.expectedURL, url)
+			}
+		})
+	}
+}
+
+func (s *RepoTestSuite) TestFindGitPathAndURL_NotInGitRepo() {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		s.T().Skip("git not available")
+	}
+
+	// Setup - change to temp dir that's not a git repo
+	originalDir, err := os.Getwd()
+	s.Require().NoError(err)
+	defer func() {
+		s.Require().NoError(os.Chdir(originalDir))
+	}()
+
+	tempDir := s.T().TempDir()
+	s.Require().NoError(os.Chdir(tempDir))
+
+	// Test
+	_, _, err = s.client.FindGitPathAndURL()
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "git repo")
+}
+
+func (s *RepoTestSuite) TestValidateRepoPath() {
+	tests := []struct {
+		name        string
+		path        string
+		expectError bool
+	}{
+		{
+			name:        "valid path",
+			path:        "valid/path",
+			expectError: false,
+		},
+		{
+			name:        "empty path",
+			path:        "",
+			expectError: false,
+		},
+		{
+			name:        "path with spaces",
+			path:        "invalid path",
+			expectError: true,
+		},
+		{
+			name:        "complex valid path",
+			path:        "src/main/go",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			err := s.client.ValidateRepoPath(s.ctx, "https://github.com/test/repo", "token", tt.path)
+
+			if tt.expectError {
+				s.Require().Error(err)
+				s.Contains(err.Error(), "invalid path")
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (s *RepoTestSuite) TestValidateRepoToken_WithMockServer() {
+	tests := []struct {
+		name          string
+		provider      string
+		repoURL       string
+		token         string
+		mockResponse  int
+		mockBody      string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:         "valid github repo with token",
+			provider:     "github",
+			repoURL:      "https://github.com/test/repo",
+			token:        "valid-token",
+			mockResponse: http.StatusOK,
+			mockBody:     `{"id": 1, "name": "repo"}`,
+			expectError:  false,
+		},
+		{
+			name:         "valid github repo without token",
+			provider:     "github",
+			repoURL:      "https://github.com/test/repo",
+			token:        "",
+			mockResponse: http.StatusOK,
+			mockBody:     `{"id": 1, "name": "repo"}`,
+			expectError:  false,
+		},
+		{
+			name:          "invalid github repo",
+			provider:      "github",
+			repoURL:       "https://github.com/test/repo",
+			token:         "invalid-token",
+			mockResponse:  http.StatusNotFound,
+			mockBody:      `{"message": "Not Found"}`,
+			expectError:   true,
+			errorContains: "GitHub validation failed",
+		},
+		{
+			name:         "valid gitlab repo",
+			provider:     "gitlab",
+			repoURL:      "https://gitlab.com/test/repo",
+			token:        "valid-token",
+			mockResponse: http.StatusOK,
+			mockBody:     `{"id": 1, "name": "repo"}`,
+			expectError:  false,
+		},
+		{
+			name:         "valid bitbucket repo",
+			provider:     "bitbucket",
+			repoURL:      "https://bitbucket.org/test/repo",
+			token:        "valid-token",
+			mockResponse: http.StatusOK,
+			mockBody:     `{"name": "repo"}`,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			// Create mock server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify the correct headers are set
+				switch tt.provider {
+				case "github":
+					if tt.token != "" {
+						s.Equal("token "+tt.token, r.Header.Get("Authorization"))
+					}
+				case "gitlab":
+					if tt.token != "" {
+						s.Equal(tt.token, r.Header.Get("Private-Token"))
+					}
+				case "bitbucket":
+					if tt.token != "" {
+						s.Equal("Bearer "+tt.token, r.Header.Get("Authorization"))
+					}
+				}
+
+				w.WriteHeader(tt.mockResponse)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			// Test the individual provider validation functions directly
+			var err error
+			switch tt.provider {
+			case "github":
+				err = validateGitHub(s.ctx, tt.repoURL, tt.token, server.URL)
+			case "gitlab":
+				err = validateGitLab(s.ctx, tt.repoURL, tt.token, server.URL)
+			case "bitbucket":
+				err = validateBitbucket(s.ctx, tt.repoURL, tt.token, server.URL)
+			}
+
+			if tt.expectError {
+				s.Require().Error(err)
+				if tt.errorContains != "" {
+					s.Contains(err.Error(), tt.errorContains)
+				}
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (s *RepoTestSuite) TestValidateRepoToken_ProviderRouting() {
+	// Test that ValidateRepoToken correctly identifies providers and routes to the right validation function
+	// We can't easily test the HTTP calls without complex mocking, but we can test the routing logic
+
+	tests := []struct {
+		name          string
+		repoURL       string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "github URL routes correctly",
+			repoURL:       "https://github.com/test/repo",
+			expectError:   true, // Will fail HTTP call but should identify GitHub
+			errorContains: "GitHub validation failed",
+		},
+		{
+			name:          "gitlab URL routes correctly",
+			repoURL:       "https://gitlab.com/test/repo",
+			expectError:   true, // Will fail HTTP call but should identify GitLab
+			errorContains: "GitLab validation failed",
+		},
+		{
+			name:          "bitbucket URL routes correctly",
+			repoURL:       "https://bitbucket.org/test/repo",
+			expectError:   true, // Will fail HTTP call but should identify Bitbucket
+			errorContains: "bitbucket validation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			err := s.client.ValidateRepoToken(s.ctx, tt.repoURL, "fake-token")
+
+			if tt.expectError {
+				s.Require().Error(err)
+				s.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.errorContains))
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (s *RepoTestSuite) TestIdentifyProvider() {
+	tests := []struct {
+		name             string
+		repoURL          string
+		expectedProvider string
+		expectedAPIURL   string
+		expectError      bool
+	}{
+		{
+			name:             "github.com",
+			repoURL:          "https://github.com/user/repo",
+			expectedProvider: "GitHub",
+			expectedAPIURL:   "https://api.github.com",
+			expectError:      false,
+		},
+		{
+			name:             "gitlab.com",
+			repoURL:          "https://gitlab.com/user/repo",
+			expectedProvider: "GitLab",
+			expectedAPIURL:   "https://gitlab.com/api/v4",
+			expectError:      false,
+		},
+		{
+			name:             "bitbucket.org",
+			repoURL:          "https://bitbucket.org/user/repo",
+			expectedProvider: "Bitbucket",
+			expectedAPIURL:   "https://api.bitbucket.org/2.0",
+			expectError:      false,
+		},
+		{
+			name:        "unknown provider",
+			repoURL:     "https://example.com/user/repo",
+			expectError: true,
+		},
+		{
+			name:        "invalid URL",
+			repoURL:     "not-a-url",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			provider, apiURL, err := identifyProvider(tt.repoURL)
+
+			if tt.expectError {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Equal(tt.expectedProvider, provider)
+				s.Equal(tt.expectedAPIURL, apiURL)
+			}
+		})
+	}
+}
+
+func (s *RepoTestSuite) TestReplaceLast() {
+	tests := []struct {
+		name     string
+		input    string
+		old      string
+		new      string
+		expected string
+	}{
+		{
+			name:     "replace .git suffix",
+			input:    "https://github.com/user/repo.git",
+			old:      ".git",
+			new:      "",
+			expected: "https://github.com/user/repo",
+		},
+		{
+			name:     "no match",
+			input:    "https://github.com/user/repo",
+			old:      ".git",
+			new:      "",
+			expected: "https://github.com/user/repo",
+		},
+		{
+			name:     "multiple matches - replace last",
+			input:    "test.git.git",
+			old:      ".git",
+			new:      "",
+			expected: "test.git",
+		},
+	}
+
+	for _, tt := range tests {
+		// capture range variable
+		s.Run(tt.name, func() {
+			result := replaceLast(tt.input, tt.old, tt.new)
+			s.Equal(tt.expected, result)
+		})
+	}
+}
+
+// Test that mock implements interface (for other tests that use the mock).
+func (s *RepoTestSuite) TestMockImplementsInterface() {
+	mockClient := &MockClient{}
+	s.Implements((*ClientInterface)(nil), mockClient)
+}

--- a/cmd/world/pkg/clients/repo/types.go
+++ b/cmd/world/pkg/clients/repo/types.go
@@ -1,0 +1,14 @@
+package repo
+
+import "context"
+
+var _ ClientInterface = (*Client)(nil)
+
+type Client struct {
+}
+
+type ClientInterface interface {
+	FindGitPathAndURL() (string, string, error)
+	ValidateRepoToken(ctx context.Context, repoURL, token string) error
+	ValidateRepoPath(ctx context.Context, repoURL, token, path string) error
+}

--- a/cmd/world/pkg/models/cmd_context.go
+++ b/cmd/world/pkg/models/cmd_context.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"context"
+
+	"pkg.world.dev/world-cli/cmd/world/pkg/clients/config"
+)
+
+type CommandContext struct {
+	Context context.Context
+	State   CommandState
+	Config  *config.Config
+}
+
+type CommandState struct {
+	LoggedIn      bool
+	CurrRepoKnown bool
+	User          *User
+	Organization  *Organization
+	Project       *Project
+}

--- a/cmd/world/pkg/models/organization.go
+++ b/cmd/world/pkg/models/organization.go
@@ -1,0 +1,24 @@
+package models
+
+type Organization struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Slug             string `json:"slug"`
+	CreatedTime      string `json:"created_time"`
+	UpdatedTime      string `json:"updated_time"`
+	OwnerID          string `json:"owner_id"`
+	Deleted          bool   `json:"deleted"`
+	DeletedTime      string `json:"deleted_time"`
+	BaseShardAddress string `json:"base_shard_address"`
+	AvatarURL        string `json:"avatar_url"`
+}
+
+type CreateOrganizationFlags struct {
+	Name      string
+	Slug      string
+	AvatarURL string
+}
+
+type SwitchOrganizationFlags struct {
+	Slug string
+}

--- a/cmd/world/pkg/models/project.go
+++ b/cmd/world/pkg/models/project.go
@@ -1,0 +1,55 @@
+package models
+
+type Project struct {
+	ID           string        `json:"id"`
+	OrgID        string        `json:"org_id"`
+	OwnerID      string        `json:"owner_id"`
+	Name         string        `json:"name"`
+	Slug         string        `json:"slug"`
+	CreatedTime  string        `json:"created_time"`
+	UpdatedTime  string        `json:"updated_time"`
+	Deleted      bool          `json:"deleted"`
+	DeletedTime  string        `json:"deleted_time"`
+	RepoURL      string        `json:"repo_url"`
+	RepoToken    string        `json:"repo_token"`
+	RepoPath     string        `json:"repo_path"`
+	DeploySecret string        `json:"deploy_secret,omitempty"`
+	Config       ProjectConfig `json:"config"`
+	AvatarURL    string        `json:"avatar_url"`
+
+	Update bool `json:"-"`
+}
+
+type ProjectConfig struct {
+	Region  []string             `json:"region"`
+	Discord ProjectConfigDiscord `json:"discord"`
+	Slack   ProjectConfigSlack   `json:"slack"`
+}
+
+type ProjectConfigDiscord struct {
+	Enabled bool   `json:"enabled"`
+	Token   string `json:"token"`
+	Channel string `json:"channel"`
+}
+
+type ProjectConfigSlack struct {
+	Enabled bool   `json:"enabled"`
+	Token   string `json:"token"`
+	Channel string `json:"channel"`
+}
+
+type CreateProjectFlags struct {
+	Name      string
+	Slug      string
+	AvatarURL string
+}
+
+type SwitchProjectFlags struct {
+	Slug string
+}
+
+type UpdateProjectFlags struct {
+	Name      string
+	Slug      string
+	AvatarURL string
+}

--- a/cmd/world/pkg/models/user.go
+++ b/cmd/world/pkg/models/user.go
@@ -1,0 +1,23 @@
+package models
+
+type User struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+type InviteUserToOrganizationFlags struct {
+	Email string
+	Role  string
+}
+
+type ChangeUserRoleInOrganizationFlags struct {
+	Email string
+	Role  string
+}
+
+type UpdateUserFlags struct {
+	Name      string
+	AvatarURL string
+}

--- a/cmd/world/project_refactor/create.go
+++ b/cmd/world/project_refactor/create.go
@@ -1,1 +1,10 @@
 package project
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Create(ctx models.CommandContext, flags *models.CreateProjectFlags, createNew bool,
+) (*models.Project, error) {
+	//nolint:nilnil // TODO: implement
+	return nil, nil
+}

--- a/cmd/world/project_refactor/delete.go
+++ b/cmd/world/project_refactor/delete.go
@@ -1,1 +1,9 @@
 package project
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Delete(ctx models.CommandContext) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/project_refactor/mock.go
+++ b/cmd/world/project_refactor/mock.go
@@ -1,1 +1,35 @@
 package project
+
+import (
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/world/pkg/models"
+)
+
+// Interface guard.
+var _ HandlerInterface = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Create(ctx models.CommandContext, flags *models.CreateProjectFlags, createNew bool,
+) (*models.Project, error) {
+	args := m.Called(ctx, flags, createNew)
+	return args.Get(0).(*models.Project), args.Error(1)
+}
+
+func (m *MockHandler) Switch(ctx models.CommandContext, flags *models.SwitchProjectFlags,
+) (*models.Project, error) {
+	args := m.Called(ctx, flags)
+	return args.Get(0).(*models.Project), args.Error(1)
+}
+
+func (m *MockHandler) Update(ctx models.CommandContext, flags *models.UpdateProjectFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Delete(ctx models.CommandContext) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/cmd/world/project_refactor/project.go
+++ b/cmd/world/project_refactor/project.go
@@ -1,1 +1,51 @@
 package project
+
+var CmdPlugin struct {
+	Project *Cmd `cmd:"" aliases:"proj" group:"Project Commands:"      help:"Manage your projects"`
+}
+
+type Cmd struct {
+	Create *CreateCmd `cmd:"" group:"Project Commands:" help:"Create a new project"`
+	Switch *SwitchCmd `cmd:"" group:"Project Commands:" help:"Switch to a different project"`
+	Update *UpdateCmd `cmd:"" group:"Project Commands:" help:"Update your project"`
+	Delete *DeleteCmd `cmd:"" group:"Project Commands:" help:"Delete your project"`
+}
+
+type CreateCmd struct {
+	Name      string `flag:"" help:"The name of the project"`
+	Slug      string `flag:"" help:"The slug of the project"`
+	AvatarURL string `flag:"" help:"The avatar URL of the project" type:"url"`
+}
+
+func (c *CreateCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type SwitchCmd struct {
+	Slug string `flag:"" help:"The slug of the project to switch to"`
+}
+
+func (c *SwitchCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type UpdateCmd struct {
+	Name      string `flag:"" help:"The new name of the project"`
+	Slug      string `flag:"" help:"The new slug of the project"`
+	AvatarURL string `flag:"" help:"The new avatar URL of the project" type:"url"`
+}
+
+func (c *UpdateCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type DeleteCmd struct {
+}
+
+func (c *DeleteCmd) Run() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/project_refactor/switch.go
+++ b/cmd/world/project_refactor/switch.go
@@ -1,1 +1,10 @@
 package project
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Switch(ctx models.CommandContext, flags *models.SwitchProjectFlags,
+) (*models.Project, error) {
+	//nolint:nilnil // TODO: implement
+	return nil, nil
+}

--- a/cmd/world/project_refactor/types.go
+++ b/cmd/world/project_refactor/types.go
@@ -1,1 +1,18 @@
 package project
+
+import (
+	"pkg.world.dev/world-cli/cmd/world/pkg/models"
+)
+
+// Interface guard.
+var _ HandlerInterface = (*Handler)(nil)
+
+type Handler struct {
+}
+
+type HandlerInterface interface {
+	Create(ctx models.CommandContext, flags *models.CreateProjectFlags, createNew bool) (*models.Project, error)
+	Switch(ctx models.CommandContext, flags *models.SwitchProjectFlags) (*models.Project, error)
+	Update(ctx models.CommandContext, flags *models.UpdateProjectFlags) error
+	Delete(ctx models.CommandContext) error
+}

--- a/cmd/world/project_refactor/update.go
+++ b/cmd/world/project_refactor/update.go
@@ -1,1 +1,9 @@
 package project
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Update(ctx models.CommandContext, flags *models.UpdateProjectFlags) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/root_refactor/create.go
+++ b/cmd/world/root_refactor/create.go
@@ -1,1 +1,7 @@
 package root
+
+//nolint:revive // TODO: implement
+func (h *Handler) Create(directory string) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/root_refactor/doctor.go
+++ b/cmd/world/root_refactor/doctor.go
@@ -1,1 +1,6 @@
 package root
+
+func (h *Handler) Doctor() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/root_refactor/login.go
+++ b/cmd/world/root_refactor/login.go
@@ -1,1 +1,9 @@
 package root
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Login(ctx models.CommandContext) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/root_refactor/mock.go
+++ b/cmd/world/root_refactor/mock.go
@@ -1,1 +1,33 @@
 package root
+
+import (
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/world/pkg/models"
+)
+
+// Interface guard.
+var _ HandlerInterface = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Create(directory string) error {
+	args := m.Called(directory)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Doctor() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockHandler) Version(check bool) error {
+	args := m.Called(check)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Login(ctx models.CommandContext) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/cmd/world/root_refactor/root.go
+++ b/cmd/world/root_refactor/root.go
@@ -1,1 +1,53 @@
 package root
+
+import "github.com/alecthomas/kong"
+
+var CLI Cmd
+
+//nolint:lll // must be on one line
+type Cmd struct {
+	Create       *CreateCmd  `cmd:"" group:"Getting Started:"     help:"Create a new World Engine project"`
+	Doctor       *DoctorCmd  `cmd:"" group:"Getting Started:"     help:"Check your development environment"`
+	Login        *LoginCmd   `cmd:"" group:"Getting Started:"     help:"Login to World Forge, creating a new account if necessary"`
+	kong.Plugins             // put this here so tools will be in the right place
+	Version      *VersionCmd `cmd:"" group:"Additional Commands:" help:"Show the version of the CLI"`
+	Verbose      bool        `                                    help:"Enable World CLI Debug logs"                               flag:"" short:"v"`
+}
+
+type CreateCmd struct {
+	Parent    *Cmd   `kong:"-"`
+	Directory string `         arg:"" optional:"" type:"path" help:"The directory to create the project in"`
+}
+
+func (c *CreateCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type DoctorCmd struct {
+	Parent *Cmd `kong:"-"`
+}
+
+func (c *DoctorCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type VersionCmd struct {
+	Parent *Cmd `kong:"-"`
+	Check  bool `         help:"Check for the latest version of the CLI"`
+}
+
+func (c *VersionCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type LoginCmd struct {
+	Parent *Cmd `kong:"-"`
+}
+
+func (c *LoginCmd) Run() error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/root_refactor/types.go
+++ b/cmd/world/root_refactor/types.go
@@ -1,1 +1,16 @@
 package root
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+// Interface guard.
+var _ HandlerInterface = (*Handler)(nil)
+
+type Handler struct {
+}
+
+type HandlerInterface interface {
+	Create(directory string) error
+	Doctor() error
+	Version(check bool) error
+	Login(ctx models.CommandContext) error
+}

--- a/cmd/world/root_refactor/version.go
+++ b/cmd/world/root_refactor/version.go
@@ -1,1 +1,7 @@
 package root
+
+//nolint:revive // TODO: implement
+func (h *Handler) Version(check bool) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/user_refactor/invite.go
+++ b/cmd/world/user_refactor/invite.go
@@ -1,1 +1,12 @@
 package user
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) InviteToOrganization(
+	ctx models.CommandContext,
+	flags *models.InviteUserToOrganizationFlags,
+) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/user_refactor/mock.go
+++ b/cmd/world/user_refactor/mock.go
@@ -1,1 +1,34 @@
 package user
+
+import (
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/world/pkg/models"
+)
+
+// Interface guard.
+var _ HandlerInterface = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) InviteToOrganization(
+	ctx models.CommandContext,
+	flags *models.InviteUserToOrganizationFlags,
+) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) ChangeRoleInOrganization(
+	ctx models.CommandContext,
+	flags *models.ChangeUserRoleInOrganizationFlags,
+) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Update(ctx models.CommandContext, flags *models.UpdateUserFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}

--- a/cmd/world/user_refactor/role.go
+++ b/cmd/world/user_refactor/role.go
@@ -1,1 +1,12 @@
 package user
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) ChangeRoleInOrganization(
+	ctx models.CommandContext,
+	flags *models.ChangeUserRoleInOrganizationFlags,
+) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/user_refactor/types.go
+++ b/cmd/world/user_refactor/types.go
@@ -1,1 +1,15 @@
 package user
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+// Interface guard.
+var _ HandlerInterface = (*Handler)(nil)
+
+type Handler struct {
+}
+
+type HandlerInterface interface {
+	InviteToOrganization(ctx models.CommandContext, flags *models.InviteUserToOrganizationFlags) error
+	ChangeRoleInOrganization(ctx models.CommandContext, flags *models.ChangeUserRoleInOrganizationFlags) error
+	Update(ctx models.CommandContext, flags *models.UpdateUserFlags) error
+}

--- a/cmd/world/user_refactor/update.go
+++ b/cmd/world/user_refactor/update.go
@@ -1,1 +1,9 @@
 package user
+
+import "pkg.world.dev/world-cli/cmd/world/pkg/models"
+
+//nolint:revive // TODO: implement
+func (h *Handler) Update(ctx models.CommandContext, flags *models.UpdateUserFlags) error {
+	// TODO: implement
+	return nil
+}

--- a/cmd/world/user_refactor/user.go
+++ b/cmd/world/user_refactor/user.go
@@ -1,1 +1,42 @@
 package user
+
+var CmdPlugin struct {
+	User *Cmd `cmd:""`
+}
+
+//nolint:lll // needed to put all the help text in the same line
+type Cmd struct {
+	Invite *InviteToOrganizationCmd     `cmd:"" group:"User Commands:" optional:"" help:"Invite a user to an organization"`
+	Role   *ChangeRoleInOrganizationCmd `cmd:"" group:"User Commands:" optional:"" help:"Change a user's role in an organization"`
+	Update *UpdateCmd                   `cmd:"" group:"User Commands:" optional:"" help:"Update a user"`
+}
+
+type InviteToOrganizationCmd struct {
+	Email string `flag:"" help:"The email of the user to invite"`
+	Role  string `flag:"" help:"The role of the user to invite"`
+}
+
+func (c *InviteToOrganizationCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type ChangeRoleInOrganizationCmd struct {
+	Email string `flag:"" help:"The email of the user to change the role of"`
+	Role  string `flag:"" help:"The new role of the user"`
+}
+
+func (c *ChangeRoleInOrganizationCmd) Run() error {
+	// TODO: implement
+	return nil
+}
+
+type UpdateCmd struct {
+	Name      string `flag:"" help:"The new name of the user"`
+	AvatarURL string `flag:"" help:"The new avatar URL of the user" type:"url"`
+}
+
+func (c *UpdateCmd) Run() error {
+	// TODO: implement
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
# feat: Implement CLI command structure and client packages

## Overview

This PR implements the command structure for the World CLI, adding command interfaces, models, and client packages. It establishes the foundation for the CLI's functionality by defining command structures, service interfaces, and mock implementations for testing.

## Brief Changelog

- Added command structure for organization, project, user, and cloud management
- Implemented client packages for configuration and repository operations
- Created model definitions for core entities (Organization, Project, User)
- Added command context and state management structures
- Implemented mock interfaces for testing
- Removed unused cardinal and evm refactor packages

## Testing and Verifying

This change is covered by unit tests for the client packages, particularly for the config and repo clients. The command structure interfaces have been defined with mock implementations to facilitate future testing.

<!-- greptile_comment -->

## Greptile Summary

Major refactoring of the World CLI that transitions from a plugin-based to a command-centric architecture, introducing new service interfaces, models, and client packages while removing legacy cardinal/evm implementations.

- Added new command service interfaces in `cmd/world/pkg/models` for organizations, projects, users, and cloud management with proper mock implementations
- Implemented configuration client in `cmd/world/pkg/clients/config` with environment-aware settings (LOCAL, DEV, PROD)
- Added repository validation client in `cmd/world/pkg/clients/repo` supporting GitHub, GitLab, and Bitbucket providers
- Replaced Cobra with Kong for CLI argument parsing in `cmd/world/root_refactor`
- **Warning**: Most command implementations are currently TODO stubs and need actual implementation before release



<!-- /greptile_comment -->