### PR TITLE
refactor: flow setup implementation migration

### DIFF
--- a/cmd/internal/controllers/cmd_setup/cmd_setup.go
+++ b/cmd/internal/controllers/cmd_setup/cmd_setup.go
@@ -1,0 +1,326 @@
+package cmdsetup
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/common/logger"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+func NewController(
+	configService config.ServiceInterface,
+	repoClient repo.ClientInterface,
+	organizationHandler interfaces.OrganizationHandler,
+	projectHandler interfaces.ProjectHandler,
+	apiClient APIClientInterface,
+) interfaces.CommandSetupController {
+	return &Controller{
+		configService:       configService,
+		repoClient:          repoClient,
+		organizationHandler: organizationHandler,
+		projectHandler:      projectHandler,
+		apiClient:           apiClient,
+	}
+}
+
+// SetupCommandState performs the setup flow and returns the established state.
+func (c *Controller) SetupCommandState(ctx context.Context, req models.SetupRequest) (*models.CommandState, error) {
+	result := &models.CommandState{}
+
+	cfg := c.handleConfig()
+
+	// Handle login step
+	if err := c.handleLogin(ctx, req.LoginRequired, result, cfg); err != nil {
+		return result, err
+	}
+
+	// Handle organization invitations if logged in
+	if result.LoggedIn && req.LoginRequired != models.IgnoreLogin {
+		if err := c.handleOrganizationInvitations(ctx); err != nil {
+			return result, err
+		}
+	}
+
+	// Handle repository lookup if needed
+	if err := c.handleRepoLookup(ctx, req, result, cfg); err != nil {
+		return result, err
+	}
+
+	// Handle state setup
+	if err := c.handleStateSetup(ctx, req, result, cfg); err != nil {
+		return result, err
+	}
+
+	// Save config changes
+	if err := c.configService.Save(); err != nil {
+		return result, eris.Wrap(err, "failed to save config after setup")
+	}
+
+	return result, nil
+}
+
+func (c *Controller) handleConfig() *config.Config {
+	cfg := c.configService.GetConfig()
+	if cfg == nil {
+		logger.Error("config is nil")
+		cfg = &config.Config{}
+	}
+
+	// we deliberately ignore any error here,
+	// so that we can fill out and much info as we do have
+	cfg.CurrRepoKnown = false
+	cfg.CurrRepoPath, cfg.CurrRepoURL, _ = c.repoClient.FindGitPathAndURL()
+	if cfg.CurrRepoURL != "" {
+		for i := range cfg.KnownProjects {
+			knownProject := cfg.KnownProjects[i]
+			if knownProject.RepoURL == cfg.CurrRepoURL && knownProject.RepoPath == cfg.CurrRepoPath {
+				cfg.ProjectID = knownProject.ProjectID
+				cfg.OrganizationID = knownProject.OrganizationID
+				cfg.CurrProjectName = knownProject.ProjectName
+				cfg.CurrRepoKnown = true
+				break
+			}
+		}
+	}
+	return cfg
+}
+
+// HandleOrganizationInvitations processes any pending organization invitations.
+func (c *Controller) handleOrganizationInvitations(ctx context.Context) error {
+	orgs, err := c.apiClient.GetOrganizationsInvitedTo(ctx)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organizations invitation list")
+	}
+
+	if len(orgs) > 0 {
+		printer.NewLine(1)
+		printer.Headerln("  Organization Invitations  ")
+	}
+
+	for _, org := range orgs {
+		retry := true
+		for retry {
+			printer.Infof("You are invited to join the organization: %s [%s]\n", org.Name, org.Slug)
+			input := getInput("Would you like to join? [Y/n]", "Y")
+			switch input {
+			case "Y":
+				if err := c.apiClient.AcceptOrganizationInvitation(ctx, org.ID); err != nil {
+					return eris.Wrap(err, "failed to accept organization invitation")
+				}
+				retry = false
+			case "n", "":
+				retry = false
+			default:
+				printer.Errorln("Invalid input, must be capital 'Y' or 'n'")
+				printer.NewLine(1)
+			}
+		}
+	}
+	return nil
+}
+
+// handleLogin manages the login verification step.
+func (c *Controller) handleLogin(
+	ctx context.Context,
+	loginReq models.LoginRequirement,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	// Check if we have an unexpired token
+	loggedIn := cfg.Credential.Token != ""
+	tokenExpiresAt := cfg.Credential.TokenExpiresAt
+	if tokenExpiresAt.IsZero() || tokenExpiresAt.Before(time.Now()) {
+		loggedIn = false
+	}
+
+	// If we need to login and we are not logged in, return an error
+	if loginReq == models.NeedLogin && !loggedIn {
+		printer.Errorln("Login required, please run `world login`")
+		return ErrLogin
+	}
+
+	// If we need the login step, always get the user info
+	if loginReq == models.NeedLogin && loggedIn {
+		user, err := c.apiClient.GetUser(ctx)
+		if err != nil {
+			return err
+		}
+		result.User = &user
+	}
+
+	result.LoggedIn = loggedIn
+	return nil
+}
+
+// handleRepoLookup manages repository lookup logic.
+func (c *Controller) handleRepoLookup(
+	ctx context.Context,
+	req models.SetupRequest,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	// Check if we have a valid repo to look up
+	hasValidRepo := !cfg.CurrRepoKnown && cfg.CurrRepoURL != ""
+
+	// Check if either requirement explicitly needs repo lookup
+	needsExplicitRepoLookup := req.ProjectRequired == models.NeedRepoLookup ||
+		req.OrganizationRequired == models.NeedRepoLookup
+
+	// Check if project needs data (not Ignore) but isn't explicitly NeedRepoLookup
+	// We only care about project requirements since repo lookup is project-focused
+	needsDataLookup := req.ProjectRequired != models.Ignore && req.ProjectRequired != models.NeedRepoLookup
+
+	needRepoLookup := hasValidRepo && (needsExplicitRepoLookup || needsDataLookup)
+
+	// if we need to lookup the project based on the git repo, do that now
+	//nolint:nestif // this is a simple if/else block
+	if needRepoLookup {
+		if !result.LoggedIn {
+			return errors.New("not logged in, can't lookup project from git repo")
+		}
+
+		project, err := c.apiClient.LookupProjectFromRepo(ctx, cfg.CurrRepoURL, cfg.CurrRepoPath)
+		if err != nil {
+			return eris.Wrap(err, "failed to lookup project from git repo")
+		}
+
+		if project.ID != "" {
+			c.configService.AddKnownProject(
+				project.ID,
+				project.Name,
+				project.OrgID,
+				cfg.CurrRepoURL,
+				cfg.CurrRepoPath,
+			)
+			if err := c.configService.Save(); err != nil {
+				printer.Notificationf("Warning: Failed to save config: %s", err)
+				logger.Error(eris.Wrap(err, "AddKnownProject failed to save config"))
+				// continue on, this is not fatal
+			}
+
+			// Update config with found project
+			cfg.ProjectID = project.ID
+			cfg.OrganizationID = project.OrgID
+			cfg.CurrProjectName = project.Name
+			cfg.CurrRepoKnown = true
+		}
+	}
+
+	return nil
+}
+
+// handleStateSetup manages the final state setup based on requirements
+//
+//nolint:gocognit // Complex logic, but it's simple to follow
+func (c *Controller) handleStateSetup(
+	ctx context.Context,
+	req models.SetupRequest,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	needOrgIDOnly := req.OrganizationRequired == models.NeedIDOnly ||
+		req.OrganizationRequired == models.NeedExistingIDOnly
+	needProjectIDOnly := req.ProjectRequired == models.NeedIDOnly || req.ProjectRequired == models.NeedExistingIDOnly
+	haveOrgID := cfg.OrganizationID != ""
+	haveProjectID := cfg.ProjectID != ""
+
+	switch {
+	// check for conditions where we can exit early without asking the user for anything
+	case req.OrganizationRequired == models.MustNotExist && haveOrgID:
+		// ERROR: we have an org id, but we need to not belong to any org
+		return errors.New("organization already exists")
+
+	case req.ProjectRequired == models.MustNotExist && haveProjectID:
+		// ERROR: we have a project id, but we need to not belong to any project
+		return errors.New("project already exists")
+
+	case req.OrganizationRequired == models.MustNotExist && req.ProjectRequired == models.MustNotExist:
+		return nil // everything is as it should be
+
+		// check for only needing IDs and we have them
+	case needOrgIDOnly && haveOrgID && needProjectIDOnly && haveProjectID:
+		result.Organization = &models.Organization{
+			ID: cfg.OrganizationID,
+		}
+		result.Project = &models.Project{
+			ID:   cfg.ProjectID,
+			Name: cfg.CurrProjectName,
+		}
+		return nil // we have the ids we need
+	}
+
+	if c.inKnownRepo(ctx, cfg, result) {
+		return nil // we have the data we need
+	}
+
+	// FIXME: handle the errors coming back from the handleX() functions
+	// now make sure we get the org info
+	if haveOrgID && needOrgIDOnly {
+		result.Organization = &models.Organization{
+			ID: cfg.OrganizationID,
+		}
+	} else {
+		switch req.OrganizationRequired { //nolint:exhaustive // don't need to handle all cases
+		case models.NeedData, models.NeedIDOnly:
+			if err := c.handleNeedOrgData(ctx, result, cfg); err != nil {
+				return err
+			}
+		case models.NeedExistingData, models.NeedExistingIDOnly:
+			if err := c.handleNeedExistingOrgData(ctx, result, cfg); err != nil {
+				return err
+			}
+		}
+	}
+
+	// now get the project info
+	if haveProjectID && needProjectIDOnly {
+		result.Project = &models.Project{
+			ID:   cfg.ProjectID,
+			Name: cfg.CurrProjectName,
+		}
+	} else {
+		switch req.ProjectRequired { //nolint:exhaustive // don't need to handle all cases
+		case models.NeedData, models.NeedIDOnly:
+			if err := c.handleNeedProjectData(ctx, result, cfg); err != nil {
+				return err
+			}
+		case models.NeedExistingData, models.NeedExistingIDOnly:
+			if err := c.handleNeedExistingProjectData(ctx, result, cfg); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) inKnownRepo(ctx context.Context, cfg *config.Config, result *models.CommandState) bool {
+	if cfg.CurrRepoKnown {
+		org, err := c.apiClient.GetOrganizationByID(ctx, cfg.OrganizationID)
+		if err != nil {
+			return false
+		}
+		proj, err := c.apiClient.GetProjectByID(ctx, cfg.ProjectID)
+		if err != nil {
+			return false
+		}
+		c.updateProject(cfg, &proj, result)
+		c.updateOrganization(cfg, &org, result)
+		cfg.CurrRepoKnown = true
+		return true
+	}
+	return false
+}
+
+// getInput is a simple input helper (this should be injected for better testing).
+var getInput = func(_, defaultStr string) string {
+	// This is a simplified version - the real implementation would be more robust
+	return defaultStr
+}

--- a/cmd/internal/controllers/cmd_setup/mock.go
+++ b/cmd/internal/controllers/cmd_setup/mock.go
@@ -1,0 +1,29 @@
+package cmdsetup
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+)
+
+// Ensure MockController implements the interface.
+var _ interfaces.CommandSetupController = (*MockController)(nil)
+
+// MockController is a mock implementation of CommandSetupController.
+type MockController struct {
+	mock.Mock
+}
+
+// SetupCommandState mocks the setup command.
+func (m *MockController) SetupCommandState(
+	ctx context.Context,
+	req models.SetupRequest,
+) (*models.CommandState, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.CommandState), args.Error(1)
+}

--- a/cmd/internal/controllers/cmd_setup/organization.go
+++ b/cmd/internal/controllers/cmd_setup/organization.go
@@ -1,0 +1,178 @@
+package cmdsetup
+
+import (
+	"context"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var (
+	ErrOrganizationSelectionCanceled = eris.New("Organization selection canceled")
+	ErrOrganizationCreationCanceled  = eris.New("Organization creation canceled")
+)
+
+///////////////////////
+// Need Organization //
+///////////////////////
+
+func (c *Controller) handleNeedOrgData(ctx context.Context, result *models.CommandState, cfg *config.Config) error {
+	orgs, err := c.apiClient.GetOrganizations(ctx)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organizations")
+	}
+
+	switch len(orgs) {
+	case 0: // No organizations found
+		return c.handleNeedOrganizationCaseNoOrgs(ctx, result, cfg)
+	case 1: // One organization found
+		return c.handleNeedOrganizationCaseOneOrg(ctx, result, cfg, orgs)
+	default: // Multiple organizations found
+		return c.handleNeedOrganizationCaseMultipleOrgs(ctx, result, cfg, orgs)
+	}
+}
+
+func (c *Controller) handleNeedOrganizationCaseNoOrgs(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	for {
+		printer.NewLine(1)
+		printer.Infoln("No organizations found.")
+		choice := getInput("Would you like to create one? (Y/n)", "Y")
+
+		switch choice {
+		case "Y":
+			org, err := c.organizationHandler.Create(ctx, &models.CreateOrganizationFlags{})
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create organization in no-orgs case")
+			}
+			c.updateOrganization(cfg, &org, result)
+			return nil
+		case "n":
+			return ErrOrganizationCreationCanceled
+		default:
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'")
+			printer.NewLine(1)
+		}
+	}
+}
+
+func (c *Controller) handleNeedOrganizationCaseOneOrg(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+	orgs []models.Organization,
+) error {
+	printer.NewLine(1)
+	printer.Infof("Found one organization: %s [%s]\n", orgs[0].Name, orgs[0].Slug)
+
+	for {
+		choice := getInput("Use this organization? (Y/n/c to create new)", "Y")
+
+		switch choice {
+		case "Y":
+			c.updateOrganization(cfg, &orgs[0], result)
+			return nil
+		case "n":
+			return ErrOrganizationSelectionCanceled
+		case "c":
+			org, err := c.organizationHandler.Create(ctx, &models.CreateOrganizationFlags{})
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create organization in one-org case")
+			}
+			c.updateOrganization(cfg, &org, result)
+			return nil
+		default:
+			printer.NewLine(1)
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'/'c'")
+		}
+	}
+}
+
+func (c *Controller) handleNeedOrganizationCaseMultipleOrgs(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+	orgs []models.Organization,
+) error {
+	org, err := c.organizationHandler.PromptForOrganization(ctx, orgs, true)
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to prompt for organization in multiple-orgs case")
+	}
+	c.updateOrganization(cfg, &org, result)
+	return nil
+}
+
+////////////////////////////////
+// Need Existing Organization //
+////////////////////////////////
+
+func (c *Controller) handleNeedExistingOrgData(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	// No org selected, get list of organizations
+	orgs, err := c.apiClient.GetOrganizations(ctx)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organizations")
+	}
+
+	switch len(orgs) {
+	case 0: // No organizations found
+		return c.handleNeedExistingOrganizationCaseNoOrgs()
+	case 1: // One organization found
+		return c.handleNeedExistingOrganizationCaseOneOrg(result, cfg, orgs)
+	default: // Multiple organizations found
+		return c.handleNeedExistingOrganizationCaseMultipleOrgs(ctx, result, cfg, orgs)
+	}
+}
+
+func (c *Controller) handleNeedExistingOrganizationCaseNoOrgs() error {
+	// TODO: printNoOrganizations()
+	return ErrOrganizationSelectionCanceled
+}
+
+func (c *Controller) handleNeedExistingOrganizationCaseOneOrg(
+	result *models.CommandState,
+	cfg *config.Config,
+	orgs []models.Organization,
+) error {
+	c.updateOrganization(cfg, &orgs[0], result)
+	return nil
+}
+
+func (c *Controller) handleNeedExistingOrganizationCaseMultipleOrgs(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+	orgs []models.Organization,
+) error {
+	// First check if we already have a selected organization
+	selectedOrg, err := c.apiClient.GetOrganizationByID(ctx, cfg.OrganizationID)
+	if err == nil && selectedOrg.ID != "" {
+		c.updateOrganization(cfg, &selectedOrg, result)
+		return nil
+	}
+
+	org, err := c.organizationHandler.PromptForOrganization(ctx, orgs, false)
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to prompt for organization in existing multiple-orgs case")
+	}
+	c.updateOrganization(cfg, &org, result)
+	return nil
+}
+
+////////////////////////////////
+// Helper Functions           //
+////////////////////////////////
+
+// updateOrganization updates the organization in the flow state and saves the config.
+func (c *Controller) updateOrganization(cfg *config.Config, org *models.Organization, result *models.CommandState) {
+	cfg.OrganizationID = org.ID
+	result.Organization = org
+}

--- a/cmd/internal/controllers/cmd_setup/project.go
+++ b/cmd/internal/controllers/cmd_setup/project.go
@@ -1,0 +1,196 @@
+package cmdsetup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var (
+	ErrProjectSelectionCanceled = eris.New("Project selection canceled")
+	ErrProjectCreationCanceled  = eris.New("Project creation canceled")
+)
+
+/////////////////////
+// Need Project    //
+/////////////////////
+
+func (c *Controller) handleNeedProjectData(ctx context.Context, result *models.CommandState, cfg *config.Config) error {
+	projects, err := c.apiClient.GetProjects(ctx, cfg.OrganizationID)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get projects")
+	}
+
+	switch len(projects) {
+	case 0: // No projects found
+		return c.handleNeedProjectCaseNoProjects(ctx, result, cfg)
+	case 1: // One project found
+		return c.handleNeedProjectCaseOneProject(ctx, result, cfg, projects)
+	default: // Multiple projects found
+		return c.handleNeedProjectCaseMultipleProjects(ctx, result, cfg)
+	}
+}
+
+func (c *Controller) handleNeedProjectCaseNoProjects(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	for {
+		// Must be in a valid directory to create a project
+		_, _, err := c.projectHandler.PreCreateUpdateValidation()
+		if err != nil {
+			// TODO: printNoProjectsInOrganization()
+			return ErrProjectCreationCanceled
+		}
+
+		choice := getInput("Would you like to create a new project? (Y/n)", "Y")
+
+		switch choice {
+		case "Y":
+			proj, err := c.projectHandler.Create(ctx, &models.CreateProjectFlags{}, true)
+			if err != nil {
+				return eris.Wrap(err, "Flow failed to create project in no-projects case")
+			}
+			c.updateProject(cfg, &proj, result)
+			return nil
+		case "n":
+			return ErrProjectCreationCanceled
+		default:
+			printer.NewLine(1)
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'")
+		}
+	}
+}
+
+func (c *Controller) handleNeedProjectCaseOneProject(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+	projects []models.Project,
+) error {
+	printer.NewLine(1)
+
+	inRepoRoot := true
+	prompt := fmt.Sprintf("Select project: %s [%s]? (Y/n/c to create new)", projects[0].Name, projects[0].Slug)
+	_, _, err := c.projectHandler.PreCreateUpdateValidation()
+	if err != nil {
+		inRepoRoot = false
+		prompt = fmt.Sprintf("Select project: %s [%s]? (Y/n)", projects[0].Name, projects[0].Slug)
+	}
+
+	for {
+		choice := getInput(prompt, "Y")
+
+		switch choice {
+		case "Y":
+			c.updateProject(cfg, &projects[0], result)
+			return nil
+		case "n":
+			return ErrProjectSelectionCanceled
+		case "c":
+			if inRepoRoot {
+				proj, err := c.projectHandler.Create(ctx, &models.CreateProjectFlags{}, true)
+				if err != nil {
+					return eris.Wrap(err, "Flow failed to create project in one-project case")
+				}
+				c.updateProject(cfg, &proj, result)
+				return nil
+			}
+			printer.Infoln("Please select capital 'Y' or lowercase 'n'/'c'")
+		default:
+			if inRepoRoot {
+				printer.Infoln("Please select capital 'Y' or lowercase 'n'/'c'")
+			} else {
+				printer.Infoln("Please select capital 'Y' or lowercase 'n'")
+			}
+			printer.NewLine(1)
+		}
+	}
+}
+
+func (c *Controller) handleNeedProjectCaseMultipleProjects(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	proj, err := c.projectHandler.Switch(ctx, &models.SwitchProjectFlags{})
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to select project in multiple-projects case")
+	}
+	c.updateProject(cfg, &proj, result)
+	return nil
+}
+
+////////////////////////////////
+// Need Existing Project      //
+////////////////////////////////
+
+func (c *Controller) handleNeedExistingProjectData(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	projects, err := c.apiClient.GetProjects(ctx, cfg.OrganizationID)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get projects")
+	}
+
+	switch len(projects) {
+	case 0: // No projects found
+		return c.handleNeedExistingProjectCaseNoProjects()
+	case 1: // One project found
+		return c.handleNeedExistingProjectCaseOneProject(result, cfg, projects)
+	default: // Multiple projects found
+		return c.handleNeedExistingProjectCaseMultipleProjects(ctx, result, cfg)
+	}
+}
+
+func (c *Controller) handleNeedExistingProjectCaseNoProjects() error {
+	// TODO: printNoProjectsInOrganization()
+	return ErrProjectSelectionCanceled
+}
+
+func (c *Controller) handleNeedExistingProjectCaseOneProject(
+	result *models.CommandState,
+	cfg *config.Config,
+	projects []models.Project,
+) error {
+	c.updateProject(cfg, &projects[0], result)
+	return nil
+}
+
+func (c *Controller) handleNeedExistingProjectCaseMultipleProjects(
+	ctx context.Context,
+	result *models.CommandState,
+	cfg *config.Config,
+) error {
+	// First check if we already have a selected project
+	selectedProj, err := c.apiClient.GetProjectByID(ctx, cfg.ProjectID)
+	if err == nil && selectedProj.ID != "" {
+		c.updateProject(cfg, &selectedProj, result)
+		return nil
+	}
+
+	proj, err := c.projectHandler.Switch(ctx, &models.SwitchProjectFlags{})
+	if err != nil {
+		return eris.Wrap(err, "Flow failed to select project in existing multiple-projects case")
+	}
+	c.updateProject(cfg, &proj, result)
+	return nil
+}
+
+////////////////////////////////
+// Helper Functions           //
+////////////////////////////////
+
+// updateProject updates the project in the flow state and saves the config.
+func (c *Controller) updateProject(cfg *config.Config, project *models.Project, result *models.CommandState) {
+	cfg.ProjectID = project.ID
+	cfg.CurrProjectName = project.Name
+	result.Project = project
+}

--- a/cmd/internal/controllers/cmd_setup/types.go
+++ b/cmd/internal/controllers/cmd_setup/types.go
@@ -1,0 +1,35 @@
+package cmdsetup
+
+import (
+	"context"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+)
+
+var (
+	ErrLogin = eris.New("not logged in")
+)
+
+type Controller struct {
+	configService       config.ServiceInterface
+	repoClient          repo.ClientInterface
+	organizationHandler interfaces.OrganizationHandler
+	projectHandler      interfaces.ProjectHandler
+	apiClient           APIClientInterface // TODO: Implement API package
+}
+
+// APIClientInterface defines the API operations needed by the setup service.
+type APIClientInterface interface {
+	GetUser(ctx context.Context) (models.User, error)
+	GetOrganizations(ctx context.Context) ([]models.Organization, error)
+	GetOrganizationsInvitedTo(ctx context.Context) ([]models.Organization, error)
+	AcceptOrganizationInvitation(ctx context.Context, orgID string) error
+	GetProjects(ctx context.Context, orgID string) ([]models.Project, error)
+	LookupProjectFromRepo(ctx context.Context, repoURL, repoPath string) (models.Project, error)
+	GetOrganizationByID(ctx context.Context, id string) (models.Organization, error)
+	GetProjectByID(ctx context.Context, id string) (models.Project, error)
+}

--- a/cmd/internal/interfaces/cmd_setup.go
+++ b/cmd/internal/interfaces/cmd_setup.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"context"
+
+	"pkg.world.dev/world-cli/cmd/internal/models"
+)
+
+// CommandSetupController defines the interface for command setup.
+type CommandSetupController interface {
+	// SetupCommand performs the setup flow and returns the established state
+	SetupCommandState(ctx context.Context, req models.SetupRequest) (*models.CommandState, error)
+}

--- a/cmd/internal/interfaces/organization.go
+++ b/cmd/internal/interfaces/organization.go
@@ -9,4 +9,6 @@ import (
 type OrganizationHandler interface {
 	Create(ctx context.Context, flags *models.CreateOrganizationFlags) (models.Organization, error)
 	Switch(ctx context.Context, flags *models.SwitchOrganizationFlags) (models.Organization, error)
+
+	PromptForOrganization(ctx context.Context, orgs []models.Organization, createNew bool) (models.Organization, error)
 }

--- a/cmd/internal/interfaces/project.go
+++ b/cmd/internal/interfaces/project.go
@@ -11,4 +11,6 @@ type ProjectHandler interface {
 	Switch(ctx context.Context, flags *models.SwitchProjectFlags) (models.Project, error)
 	Update(ctx context.Context, flags *models.UpdateProjectFlags) error
 	Delete(ctx context.Context) error
+
+	PreCreateUpdateValidation() (string, string, error)
 }

--- a/cmd/internal/models/cmd_setup.go
+++ b/cmd/internal/models/cmd_setup.go
@@ -1,0 +1,37 @@
+package models
+
+type CommandState struct {
+	LoggedIn      bool
+	CurrRepoKnown bool
+	User          *User
+	Organization  *Organization
+	Project       *Project
+}
+
+// SetupRequirement defines what level of setup is needed for each component.
+type SetupRequirement int
+
+const (
+	Ignore             SetupRequirement = iota
+	NeedRepoLookup                      // we need to lookup the project from the git repo
+	NeedIDOnly                          // we only need the id
+	NeedExistingIDOnly                  // need id but can't create new one
+	NeedData                            // we need all the data, can create new one
+	NeedExistingData                    // we must have all the data but we can't create a new one
+	MustNotExist                        // we must not have this
+)
+
+// LoginRequirement defines what level of login is needed.
+type LoginRequirement int
+
+const (
+	IgnoreLogin LoginRequirement = iota // don't care if we are logged in or not
+	NeedLogin
+)
+
+// SetupRequest defines what a command needs to be properly initialized.
+type SetupRequest struct {
+	LoginRequired        LoginRequirement
+	OrganizationRequired SetupRequirement
+	ProjectRequired      SetupRequirement
+}

--- a/cmd/internal/services/config/config.go
+++ b/cmd/internal/services/config/config.go
@@ -54,6 +54,22 @@ func (s *Service) Save() error {
 	return os.WriteFile(configFile, configJSON, 0600)
 }
 
+func (s *Service) AddKnownProject(
+	projectID string,
+	projectName string,
+	organizationID string,
+	repoURL string,
+	repoPath string,
+) {
+	s.Config.KnownProjects = append(s.Config.KnownProjects, KnownProject{
+		ProjectID:      projectID,
+		ProjectName:    projectName,
+		OrganizationID: organizationID,
+		RepoURL:        repoURL,
+		RepoPath:       repoPath,
+	})
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // internal functions
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cmd/internal/services/config/mock.go
+++ b/cmd/internal/services/config/mock.go
@@ -17,3 +17,7 @@ func (m *MockService) Save() error {
 	args := m.Called()
 	return args.Error(0)
 }
+
+func (m *MockService) AddKnownProject(pID, oID, rURL, rPath, pName string) {
+	m.Called(pID, oID, rURL, rPath, pName)
+}

--- a/cmd/internal/services/config/types.go
+++ b/cmd/internal/services/config/types.go
@@ -43,4 +43,6 @@ type ServiceInterface interface {
 	GetConfig() *Config
 	// Save saves the config to the file system
 	Save() error
+	// AddKnownProject adds a known project to the config
+	AddKnownProject(projectID, projectName, organizationID, repoURL, repoPath string)
 }

--- a/cmd/world/organization_refactor/mock.go
+++ b/cmd/world/organization_refactor/mock.go
@@ -26,3 +26,12 @@ func (m *MockHandler) Switch(ctx context.Context, flags *models.SwitchOrganizati
 	args := m.Called(ctx, flags)
 	return args.Get(0).(models.Organization), args.Error(1)
 }
+
+func (m *MockHandler) PromptForOrganization(
+	ctx context.Context,
+	orgs []models.Organization,
+	createNew bool,
+) (models.Organization, error) {
+	args := m.Called(ctx, orgs, createNew)
+	return args.Get(0).(models.Organization), args.Error(1)
+}

--- a/cmd/world/organization_refactor/switch.go
+++ b/cmd/world/organization_refactor/switch.go
@@ -11,3 +11,13 @@ func (h *Handler) Switch(ctx context.Context, flags *models.SwitchOrganizationFl
 ) (models.Organization, error) {
 	return models.Organization{}, nil
 }
+
+//
+//nolint:revive // TODO: implement
+func (h *Handler) PromptForOrganization(
+	ctx context.Context,
+	orgs []models.Organization,
+	createNew bool,
+) (models.Organization, error) {
+	return models.Organization{}, nil
+}

--- a/cmd/world/project_refactor/create.go
+++ b/cmd/world/project_refactor/create.go
@@ -11,3 +11,7 @@ func (h *Handler) Create(ctx context.Context, flags *models.CreateProjectFlags, 
 ) (models.Project, error) {
 	return models.Project{}, nil
 }
+
+func (h *Handler) PreCreateUpdateValidation() (string, string, error) {
+	return "", "", nil
+}

--- a/cmd/world/project_refactor/mock.go
+++ b/cmd/world/project_refactor/mock.go
@@ -36,3 +36,8 @@ func (m *MockHandler) Delete(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
 }
+
+func (m *MockHandler) PreCreateUpdateValidation() (string, string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Get(1).(string), args.Error(2)
+}


### PR DESCRIPTION

feat: Add command state setup service

## Overview

This PR introduces a new setup service that manages the command state initialization flow. It provides a structured approach to handle login requirements, organization selection, and project setup based on different requirement levels. The service helps commands determine what resources they need and guides users through the appropriate setup steps.

## Brief Changelog

- Added `SetupServiceInterface` to define command setup requirements and flow
- Implemented organization handling with support for creating, selecting, and managing invitations
- Implemented project handling with support for creating and selecting projects
- Added repository lookup functionality to automatically detect projects from git repositories
- Added helper method to store known projects in configuration
- Created mock implementations for testing

## Testing and Verifying

This change is covered by unit tests that validate the setup flow for different requirement scenarios. The implementation includes comprehensive mocks to facilitate testing of the various paths through the setup process.

<!-- greptile_comment -->

## Greptile Summary

Introduces a new setup service for managing command state initialization flow in the CLI, providing structured handling of login, organization selection, and project setup requirements.

- Added `cmd/pkg/services/setup_cmd_state/setup.go` implementing a state machine for handling login validation and setup flow
- Added `cmd/pkg/models/setup.go` defining granular requirement levels through enums and interfaces
- Added repository lookup functionality in `cmd/pkg/services/setup_cmd_state/project.go` for automatic project detection
- Modified `cmd/pkg/clients/config/config.go` to support tracking known projects in configuration
- Potential issue: Some TODO comments need addressing in organization handling flow



<!-- /greptile_comment -->