### PR TITLE
refactor: input handling

### DIFF
--- a/cmd/internal/controllers/cmd_setup/organization.go
+++ b/cmd/internal/controllers/cmd_setup/organization.go
@@ -42,7 +42,10 @@ func (c *Controller) handleNeedOrganizationCaseNoOrgs(
 	for {
 		printer.NewLine(1)
 		printer.Infoln("No organizations found.")
-		choice := getInput("Would you like to create one? (Y/n)", "Y")
+		choice, err := c.inputService.Prompt(ctx, "Would you like to create one? (Y/n)", "Y")
+		if err != nil {
+			return eris.Wrap(err, "failed to get input")
+		}
 
 		switch choice {
 		case "Y":
@@ -71,7 +74,10 @@ func (c *Controller) handleNeedOrganizationCaseOneOrg(
 	printer.Infof("Found one organization: %s [%s]\n", orgs[0].Name, orgs[0].Slug)
 
 	for {
-		choice := getInput("Use this organization? (Y/n/c to create new)", "Y")
+		choice, err := c.inputService.Prompt(ctx, "Use this organization? (Y/n/c to create new)", "Y")
+		if err != nil {
+			return eris.Wrap(err, "failed to get input")
+		}
 
 		switch choice {
 		case "Y":

--- a/cmd/internal/controllers/cmd_setup/project.go
+++ b/cmd/internal/controllers/cmd_setup/project.go
@@ -48,7 +48,10 @@ func (c *Controller) handleNeedProjectCaseNoProjects(
 			return ErrProjectCreationCanceled
 		}
 
-		choice := getInput("Would you like to create a new project? (Y/n)", "Y")
+		choice, err := c.inputService.Prompt(ctx, "Would you like to create a new project? (Y/n)", "Y")
+		if err != nil {
+			return eris.Wrap(err, "failed to get input")
+		}
 
 		switch choice {
 		case "Y":
@@ -84,7 +87,10 @@ func (c *Controller) handleNeedProjectCaseOneProject(
 	}
 
 	for {
-		choice := getInput(prompt, "Y")
+		choice, err := c.inputService.Prompt(ctx, prompt, "Y")
+		if err != nil {
+			return eris.Wrap(err, "failed to get input")
+		}
 
 		switch choice {
 		case "Y":

--- a/cmd/internal/controllers/cmd_setup/types.go
+++ b/cmd/internal/controllers/cmd_setup/types.go
@@ -6,6 +6,7 @@ import (
 	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
 	"pkg.world.dev/world-cli/cmd/internal/interfaces"
 	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/cmd/internal/services/input"
 )
 
 var (
@@ -18,4 +19,5 @@ type Controller struct {
 	organizationHandler interfaces.OrganizationHandler
 	projectHandler      interfaces.ProjectHandler
 	apiClient           api.ClientInterface
+	inputService        input.ServiceInterface
 }

--- a/cmd/internal/services/input/input.go
+++ b/cmd/internal/services/input/input.go
@@ -1,0 +1,222 @@
+package input
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var (
+	ErrInputCanceled = eris.New("input canceled")
+	ErrInvalidInput  = eris.New("invalid input")
+)
+
+// NewService creates a new input service with standard stdin/stdout.
+func NewService() Service {
+	return Service{
+		Input:  nil, // Will use os.Stdin if nil
+		Output: nil, // Will use os.Stdout if nil
+	}
+}
+
+// NewTestService creates a new input service for testing with custom input/output.
+func NewTestService(input io.Reader, output io.Writer) Service {
+	return Service{
+		Input:  input,
+		Output: output,
+	}
+}
+
+// Prompt displays a prompt and returns user input.
+func (s *Service) Prompt(ctx context.Context, prompt, defaultValue string) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+		// Display prompt
+		if prompt != "" {
+			s.printf("%s", prompt)
+		}
+		if defaultValue != "" {
+			s.printf(" [%s]: ", defaultValue)
+		} else {
+			s.printf(": ")
+		}
+
+		// Read input
+		input, err := s.readLine()
+		if err != nil {
+			return "", eris.Wrap(err, "failed to read input")
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" && defaultValue != "" {
+			// Display the default value as if they typed it in
+			s.moveCursorUp(1)
+			s.moveCursorRight(len(defaultValue) + 4 + len(prompt))
+			s.println(defaultValue)
+			return defaultValue, nil
+		}
+		return input, nil
+	}
+}
+
+// Confirm asks for Y/n confirmation with default.
+func (s *Service) Confirm(ctx context.Context, prompt, defaultValue string) (bool, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+			input, err := s.Prompt(ctx, prompt, defaultValue)
+			if err != nil {
+				return false, err
+			}
+
+			switch strings.ToLower(input) {
+			case "y", "yes":
+				return true, nil
+			case "n", "no":
+				return false, nil
+			case "":
+				// Use default value logic
+				switch strings.ToLower(defaultValue) {
+				case "y", "yes":
+					return true, nil
+				case "n", "no":
+					return false, nil
+				default:
+					s.println("Invalid input. Please enter 'y' or 'n'")
+					continue
+				}
+			default:
+				s.println("Invalid input. Please enter 'y' or 'n'")
+				continue
+			}
+		}
+	}
+}
+
+// Select allows user to select from multiple options by number.
+//
+//nolint:gocognit // This function is complex but separated into smaller functions would make it harder to read.
+func (s *Service) Select(ctx context.Context, prompt string, options []string, defaultIndex int) (int, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			// Display options
+			s.println("")
+			for i, option := range options {
+				s.printf("  %d. %s\n", i+1, option)
+			}
+
+			defaultStr := ""
+			if defaultIndex >= 0 && defaultIndex < len(options) {
+				defaultStr = strconv.Itoa(defaultIndex + 1)
+			}
+
+			input, err := s.Prompt(ctx, prompt, defaultStr)
+			if err != nil {
+				return 0, err
+			}
+
+			if input == "q" || input == "quit" {
+				return -1, ErrInputCanceled
+			}
+
+			// Parse selection
+			num, err := strconv.Atoi(input)
+			if err != nil || num < 1 || num > len(options) {
+				s.printf("Please enter a number between 1 and %d\n", len(options))
+				continue
+			}
+
+			return num - 1, nil // Convert to 0-based index
+		}
+	}
+}
+
+// SelectString allows user to select from multiple options, returns the selected string.
+func (s *Service) SelectString(
+	ctx context.Context,
+	prompt string,
+	options []string,
+	defaultValue string,
+) (string, error) {
+	defaultIndex := -1
+	for i, option := range options {
+		if option == defaultValue {
+			defaultIndex = i
+			break
+		}
+	}
+
+	selectedIndex, err := s.Select(ctx, prompt, options, defaultIndex)
+	if err != nil {
+		return "", err
+	}
+	if selectedIndex == -1 {
+		return "", ErrInputCanceled
+	}
+
+	return options[selectedIndex], nil
+}
+
+// Helper methods for I/O operations
+
+func (s *Service) readLine() (string, error) {
+	input := s.Input
+	if input == nil {
+		input = os.Stdin
+	}
+
+	reader := bufio.NewReader(input)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return line, nil
+}
+
+func (s *Service) printf(format string, args ...interface{}) {
+	output := s.Output
+	if output == nil {
+		printer.Info(fmt.Sprintf(format, args...))
+		return
+	}
+	fmt.Fprintf(output, format, args...)
+}
+
+func (s *Service) println(text string) {
+	output := s.Output
+	if output == nil {
+		printer.Infoln(text)
+		return
+	}
+	fmt.Fprintln(output, text)
+}
+
+func (s *Service) moveCursorUp(lines int) {
+	if s.Output == nil {
+		printer.MoveCursorUp(lines)
+		return
+	}
+	// If using custom output, skip cursor movements
+}
+
+func (s *Service) moveCursorRight(chars int) {
+	if s.Output == nil {
+		printer.MoveCursorRight(chars)
+		return
+	}
+	// If using custom output, skip cursor movements
+}

--- a/cmd/internal/services/input/input_internal_test.go
+++ b/cmd/internal/services/input/input_internal_test.go
@@ -1,0 +1,534 @@
+package input
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+	client := NewService()
+	require.NotNil(t, client)
+	require.Nil(t, client.Input)  // Should be nil to use os.Stdin
+	require.Nil(t, client.Output) // Should be nil to use os.Stdout
+}
+
+func TestNewTestClient(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("test input")
+	output := &bytes.Buffer{}
+
+	client := NewTestService(input, output)
+	require.Equal(t, input, client.Input)
+	require.Equal(t, output, client.Output)
+}
+
+func TestPrompt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		prompt       string
+		defaultValue string
+		input        string
+		expected     string
+		shouldError  bool
+	}{
+		{
+			name:     "simple prompt with input",
+			prompt:   "Enter name",
+			input:    "John\n",
+			expected: "John",
+		},
+		{
+			name:         "prompt with default value used",
+			prompt:       "Enter name",
+			defaultValue: "DefaultName",
+			input:        "\n",
+			expected:     "DefaultName",
+		},
+		{
+			name:     "prompt with whitespace input",
+			prompt:   "Enter value",
+			input:    "  test value  \n",
+			expected: "test value",
+		},
+		{
+			name:     "empty prompt",
+			prompt:   "",
+			input:    "test\n",
+			expected: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(tt.input)
+			output := &bytes.Buffer{}
+			client := NewTestService(input, output)
+
+			ctx := t.Context()
+			result, err := client.Prompt(ctx, tt.prompt, tt.defaultValue)
+
+			if tt.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestPromptWithContextCancellation(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("test\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	_, err := client.Prompt(ctx, "Test prompt", "")
+	require.Error(t, err)
+	require.Equal(t, context.Canceled, err)
+}
+
+func TestPromptWithTimeout(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("") // Empty input to simulate hanging
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
+	defer cancel()
+
+	_, err := client.Prompt(ctx, "Test prompt", "")
+	assert.Error(t, err)
+	// The actual error might be EOF when reader is exhausted, not necessarily timeout
+}
+
+func TestConfirm(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		prompt       string
+		defaultValue string
+		inputs       []string // Multiple inputs to test retry logic
+		expected     bool
+		shouldError  bool
+	}{
+		{
+			name:     "confirm with y",
+			prompt:   "Continue?",
+			inputs:   []string{"y\n"},
+			expected: true,
+		},
+		{
+			name:     "confirm with yes",
+			prompt:   "Continue?",
+			inputs:   []string{"yes\n"},
+			expected: true,
+		},
+		{
+			name:     "confirm with Y (uppercase)",
+			prompt:   "Continue?",
+			inputs:   []string{"Y\n"},
+			expected: true,
+		},
+		{
+			name:     "confirm with n",
+			prompt:   "Continue?",
+			inputs:   []string{"n\n"},
+			expected: false,
+		},
+		{
+			name:     "confirm with no",
+			prompt:   "Continue?",
+			inputs:   []string{"no\n"},
+			expected: false,
+		},
+		{
+			name:         "confirm with default yes",
+			prompt:       "Continue?",
+			defaultValue: "y",
+			inputs:       []string{"\n"},
+			expected:     true,
+		},
+		{
+			name:         "confirm with default no",
+			prompt:       "Continue?",
+			defaultValue: "n",
+			inputs:       []string{"\n"},
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(strings.Join(tt.inputs, ""))
+			output := &bytes.Buffer{}
+			client := NewTestService(input, output)
+
+			ctx := t.Context()
+			result, err := client.Confirm(ctx, tt.prompt, tt.defaultValue)
+
+			if tt.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestConfirmWithContextCancellation(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("y\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	_, err := client.Confirm(ctx, "Continue?", "")
+	require.Error(t, err)
+	require.Equal(t, context.Canceled, err)
+}
+
+func TestSelect(t *testing.T) {
+	t.Parallel()
+	options := []string{"Option 1", "Option 2", "Option 3"}
+
+	tests := []struct {
+		name         string
+		prompt       string
+		options      []string
+		defaultIndex int
+		inputs       []string
+		expected     int
+		shouldError  bool
+	}{
+		{
+			name:     "select first option",
+			prompt:   "Choose option",
+			options:  options,
+			inputs:   []string{"1\n"},
+			expected: 0,
+		},
+		{
+			name:     "select second option",
+			prompt:   "Choose option",
+			options:  options,
+			inputs:   []string{"2\n"},
+			expected: 1,
+		},
+		{
+			name:     "select third option",
+			prompt:   "Choose option",
+			options:  options,
+			inputs:   []string{"3\n"},
+			expected: 2,
+		},
+		{
+			name:         "select with default",
+			prompt:       "Choose option",
+			options:      options,
+			defaultIndex: 1,
+			inputs:       []string{"\n"},
+			expected:     1,
+		},
+
+		{
+			name:        "select with quit",
+			prompt:      "Choose option",
+			options:     options,
+			inputs:      []string{"q\n"},
+			expected:    -1,
+			shouldError: true,
+		},
+		{
+			name:        "select with quit (full word)",
+			prompt:      "Choose option",
+			options:     options,
+			inputs:      []string{"quit\n"},
+			expected:    -1,
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(strings.Join(tt.inputs, ""))
+			output := &bytes.Buffer{}
+			client := NewTestService(input, output)
+
+			ctx := t.Context()
+			result, err := client.Select(ctx, tt.prompt, tt.options, tt.defaultIndex)
+
+			if tt.shouldError {
+				require.Error(t, err)
+				if tt.expected == -1 {
+					require.Equal(t, ErrInputCanceled, err)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSelectWithContextCancellation(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("1\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	options := []string{"Option 1", "Option 2"}
+	_, err := client.Select(ctx, "Choose", options, -1)
+	require.Error(t, err)
+	require.Equal(t, context.Canceled, err)
+}
+
+func TestSelectString(t *testing.T) {
+	t.Parallel()
+	options := []string{"apple", "banana", "cherry"}
+
+	tests := []struct {
+		name         string
+		prompt       string
+		options      []string
+		defaultValue string
+		inputs       []string
+		expected     string
+		shouldError  bool
+	}{
+		{
+			name:     "select string first option",
+			prompt:   "Choose fruit",
+			options:  options,
+			inputs:   []string{"1\n"},
+			expected: "apple",
+		},
+		{
+			name:     "select string second option",
+			prompt:   "Choose fruit",
+			options:  options,
+			inputs:   []string{"2\n"},
+			expected: "banana",
+		},
+		{
+			name:         "select string with default",
+			prompt:       "Choose fruit",
+			options:      options,
+			defaultValue: "banana",
+			inputs:       []string{"\n"},
+			expected:     "banana",
+		},
+		{
+			name:         "select string with invalid default",
+			prompt:       "Choose fruit",
+			options:      options,
+			defaultValue: "orange",        // Not in options
+			inputs:       []string{"1\n"}, // Should select first option manually
+			expected:     "apple",
+		},
+		{
+			name:        "select string with quit",
+			prompt:      "Choose fruit",
+			options:     options,
+			inputs:      []string{"q\n"},
+			expected:    "",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(strings.Join(tt.inputs, ""))
+			output := &bytes.Buffer{}
+			client := NewTestService(input, output)
+
+			ctx := t.Context()
+			result, err := client.SelectString(ctx, tt.prompt, tt.options, tt.defaultValue)
+
+			if tt.shouldError {
+				require.Error(t, err)
+				if strings.Contains(tt.inputs[0], "q") {
+					require.Equal(t, ErrInputCanceled, err)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSelectStringWithContextCancellation(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("1\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	options := []string{"Option 1", "Option 2"}
+	_, err := client.SelectString(ctx, "Choose", options, "")
+	require.Error(t, err)
+	require.Equal(t, context.Canceled, err)
+}
+
+func TestServiceImplementsInterface(t *testing.T) {
+	t.Parallel()
+	// Ensure Client implements ClientInterface
+	var _ ServiceInterface = (*Service)(nil)
+
+	// Test that we can create and use the client
+	client := NewService()
+	assert.NotNil(t, client)
+}
+
+func TestErrorVariables(t *testing.T) {
+	t.Parallel()
+	// Test that our error variables are defined
+	require.Error(t, ErrInputCanceled)
+	require.Error(t, ErrInvalidInput)
+
+	// Test error messages
+	require.Contains(t, ErrInputCanceled.Error(), "input canceled")
+	require.Contains(t, ErrInvalidInput.Error(), "invalid input")
+}
+
+// Integration-style tests
+
+func TestPromptIntegration(t *testing.T) {
+	t.Parallel()
+	// Test the actual output formatting
+	input := strings.NewReader("test input\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx := t.Context()
+	result, err := client.Prompt(ctx, "Enter value", "default")
+
+	require.NoError(t, err)
+	require.Equal(t, "test input", result)
+
+	// Check that prompt was written to output
+	outputStr := output.String()
+	assert.Contains(t, outputStr, "Enter value")
+	assert.Contains(t, outputStr, "[default]")
+}
+
+func TestSelectIntegration(t *testing.T) {
+	t.Parallel()
+	// Test that options are displayed correctly
+	input := strings.NewReader("2\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	options := []string{"First", "Second", "Third"}
+	ctx := t.Context()
+	result, err := client.Select(ctx, "Choose", options, -1)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+	// Check that options were displayed
+	outputStr := output.String()
+	assert.Contains(t, outputStr, "1. First")
+	assert.Contains(t, outputStr, "2. Second")
+	assert.Contains(t, outputStr, "3. Third")
+}
+
+func TestConfirmEdgeCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		defaultValue string
+		input        string
+		expected     bool
+	}{
+		{
+			name:         "empty input with y default",
+			defaultValue: "y",
+			input:        "\n",
+			expected:     true,
+		},
+		{
+			name:         "empty input with yes default",
+			defaultValue: "yes",
+			input:        "\n",
+			expected:     true,
+		},
+		{
+			name:         "empty input with n default",
+			defaultValue: "n",
+			input:        "\n",
+			expected:     false,
+		},
+		{
+			name:         "empty input with no default",
+			defaultValue: "no",
+			input:        "\n",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(tt.input)
+			output := &bytes.Buffer{}
+			client := NewTestService(input, output)
+
+			ctx := t.Context()
+			result, err := client.Confirm(ctx, "Continue?", tt.defaultValue)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSelectWithEmptyOptions(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("1\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx := t.Context()
+	_, err := client.Select(ctx, "Choose", []string{}, -1)
+
+	// Should get an error when trying to parse "1" with no options
+	require.Error(t, err)
+}
+
+func TestSelectStringWithEmptyOptions(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader("1\n")
+	output := &bytes.Buffer{}
+	client := NewTestService(input, output)
+
+	ctx := t.Context()
+	_, err := client.SelectString(ctx, "Choose", []string{}, "")
+
+	// Should get an error when trying to parse "1" with no options
+	require.Error(t, err)
+}

--- a/cmd/internal/services/input/mock.go
+++ b/cmd/internal/services/input/mock.go
@@ -1,0 +1,116 @@
+package input
+
+import (
+	"context"
+	"errors"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockService provides a mock implementation of ServiceInterface for testing.
+type MockService struct {
+	mock.Mock
+}
+
+// Ensure MockService implements ServiceInterface.
+var _ ServiceInterface = (*MockService)(nil)
+
+// Prompt mocks the Prompt method.
+func (m *MockService) Prompt(ctx context.Context, prompt, defaultValue string) (string, error) {
+	args := m.Called(ctx, prompt, defaultValue)
+	return args.String(0), args.Error(1)
+}
+
+// Confirm mocks the Confirm method.
+func (m *MockService) Confirm(ctx context.Context, prompt, defaultValue string) (bool, error) {
+	args := m.Called(ctx, prompt, defaultValue)
+	return args.Bool(0), args.Error(1)
+}
+
+// Select mocks the Select method.
+func (m *MockService) Select(ctx context.Context, prompt string, options []string, defaultIndex int) (int, error) {
+	args := m.Called(ctx, prompt, options, defaultIndex)
+	return args.Int(0), args.Error(1)
+}
+
+// SelectString mocks the SelectString method.
+func (m *MockService) SelectString(
+	ctx context.Context,
+	prompt string,
+	options []string,
+	defaultValue string,
+) (string, error) {
+	args := m.Called(ctx, prompt, options, defaultValue)
+	return args.String(0), args.Error(1)
+}
+
+// TestInputService provides a simple test implementation with predefined responses.
+type TestInputService struct {
+	Responses       []string // Predefined responses in order
+	ResponseIndex   int      // Current index in responses
+	ConfirmResponse bool     // Default confirm response
+}
+
+// NewTestInputService creates a new test service with predefined responses.
+func NewTestInputService(responses []string) *TestInputService {
+	return &TestInputService{
+		Responses:       responses,
+		ResponseIndex:   0,
+		ConfirmResponse: true,
+	}
+}
+
+// Prompt returns the next predefined response.
+func (t *TestInputService) Prompt(_ context.Context, _, defaultValue string) (string, error) {
+	if t.ResponseIndex >= len(t.Responses) {
+		if defaultValue != "" {
+			return defaultValue, nil
+		}
+		return "", errors.New("no more test responses available")
+	}
+
+	response := t.Responses[t.ResponseIndex]
+	t.ResponseIndex++
+
+	if response == "" && defaultValue != "" {
+		return defaultValue, nil
+	}
+
+	return response, nil
+}
+
+// Confirm returns the predefined confirm response.
+func (t *TestInputService) Confirm(_ context.Context, _, _ string) (bool, error) {
+	return t.ConfirmResponse, nil
+}
+
+// Select returns the first option by default.
+func (t *TestInputService) Select(_ context.Context, _ string, options []string, defaultIndex int) (int, error) {
+	if defaultIndex >= 0 && defaultIndex < len(options) {
+		return defaultIndex, nil
+	}
+	if len(options) > 0 {
+		return 0, nil
+	}
+	return -1, errors.New("no options available")
+}
+
+// SelectString returns the default value or first option.
+func (t *TestInputService) SelectString(
+	_ context.Context,
+	_ string,
+	options []string,
+	defaultValue string,
+) (string, error) {
+	if defaultValue != "" {
+		for _, option := range options {
+			if option == defaultValue {
+				return defaultValue, nil
+			}
+		}
+	}
+	if len(options) > 0 {
+		return options[0], nil
+	}
+	return "", errors.New("no options available")
+}

--- a/cmd/internal/services/input/types.go
+++ b/cmd/internal/services/input/types.go
@@ -1,0 +1,27 @@
+package input
+
+import (
+	"context"
+	"io"
+)
+
+// ServiceInterface defines methods for handling user input.
+type ServiceInterface interface {
+	// Prompt displays a prompt and returns user input
+	Prompt(ctx context.Context, prompt, defaultValue string) (string, error)
+
+	// Confirm asks for Y/n confirmation with default
+	Confirm(ctx context.Context, prompt, defaultValue string) (bool, error)
+
+	// Select allows user to select from multiple options by number
+	Select(ctx context.Context, prompt string, options []string, defaultIndex int) (int, error)
+
+	// SelectString allows user to select from multiple options, returns the selected string
+	SelectString(ctx context.Context, prompt string, options []string, defaultValue string) (string, error)
+}
+
+// Service implements the input interface using standard input/output.
+type Service struct {
+	Input  io.Reader // Allows injection of different input sources for testing
+	Output io.Writer // Allows injection of different output destinations for testing
+}


### PR DESCRIPTION
# Add input client for interactive CLI prompts

Closes: WORLD-XXX

## Overview

This PR adds a new input client package to handle interactive CLI prompts in a testable way. The implementation provides methods for prompting users for text input, confirmation (Y/n), and selection from a list of options.

## Brief Changelog

- Created a new `input` package with a client interface for handling user input
- Implemented methods for text prompts, confirmations, and option selection
- Added support for default values and context cancellation
- Created mock and test implementations for testing
- Integrated the input client with the setup service, replacing the hardcoded `getInput` function
- Updated organization and project handlers to use the new input client

## Testing and Verifying

This change added tests and can be verified as follows:
- Added mock implementations for unit testing
- Added a test client for integration testing
- The implementation handles various edge cases like default values, cancellation, and invalid inputs

<!-- greptile_comment -->

## Greptile Summary

Introduces a new input client package to handle interactive CLI prompts, improving testability and maintainability of user interactions throughout the codebase.

- Added `cmd/pkg/clients/input` package with ClientInterface for text prompts, confirmations, and option selection
- Integrated input client with setup service, replacing hardcoded `getInput` functions in organization and project handlers
- Added mock implementations (MockClient and TestInputClient) for testing with predefined responses
- Improved error handling with proper context cancellation support across input operations
- Implemented default value support and validation for different input types (text, Y/n, selections)



<!-- /greptile_comment -->