### PR TITLE
refactor: migrate org/proj commands for cmd setup

### DIFF
--- a/cmd/internal/clients/api/client.go
+++ b/cmd/internal/clients/api/client.go
@@ -41,7 +41,7 @@ func (c *Client) SetAuthToken(token string) {
 
 // sendRequest sends an HTTP request with auth token and returns the response body.
 //
-//nolint:unparam // body is used for all requests
+
 func (c *Client) sendRequest(ctx context.Context, method, endpoint string, body interface{}) ([]byte, error) {
 	// Prepare request body and headers
 	req, err := c.prepareRequest(ctx, method, endpoint, body)

--- a/cmd/internal/clients/api/mock.go
+++ b/cmd/internal/clients/api/mock.go
@@ -66,7 +66,34 @@ func (m *MockClient) GetProjectByID(ctx context.Context, id string) (models.Proj
 	return args.Get(0).(models.Project), args.Error(1)
 }
 
-// Authentication
+// CreateOrganization mocks creating an organization.
+func (m *MockClient) CreateOrganization(
+	ctx context.Context,
+	name, slug, avatarURL string,
+) (models.Organization, error) {
+	args := m.Called(ctx, name, slug, avatarURL)
+	return args.Get(0).(models.Organization), args.Error(1)
+}
+
+// GetListRegions mocks getting list of regions.
+func (m *MockClient) GetListRegions(ctx context.Context, orgID, projID string) ([]string, error) {
+	args := m.Called(ctx, orgID, projID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+// CheckProjectSlugIsTaken mocks checking if a project slug is taken.
+func (m *MockClient) CheckProjectSlugIsTaken(ctx context.Context, orgID, projID, slug string) error {
+	args := m.Called(ctx, orgID, projID, slug)
+	return args.Error(0)
+}
+
+// CreateProject mocks creating a project.
+func (m *MockClient) CreateProject(ctx context.Context, orgID string, project models.Project) (models.Project, error) {
+	args := m.Called(ctx, orgID, project)
+	return args.Get(0).(models.Project), args.Error(1)
+}
+
+// Utility methods
 
 // SetAuthToken mocks setting auth token.
 func (m *MockClient) SetAuthToken(token string) {

--- a/cmd/internal/clients/api/types.go
+++ b/cmd/internal/clients/api/types.go
@@ -27,8 +27,12 @@ type ClientInterface interface {
 	LookupProjectFromRepo(ctx context.Context, repoURL, repoPath string) (models.Project, error)
 	GetOrganizationByID(ctx context.Context, id string) (models.Organization, error)
 	GetProjectByID(ctx context.Context, id string) (models.Project, error)
+	CreateOrganization(ctx context.Context, name, slug, avatarURL string) (models.Organization, error)
+	GetListRegions(ctx context.Context, orgID, projID string) ([]string, error)
+	CheckProjectSlugIsTaken(ctx context.Context, orgID, projID, slug string) error
+	CreateProject(ctx context.Context, orgID string, project models.Project) (models.Project, error)
 
-	// Authentication
+	// Utility methods
 	SetAuthToken(token string)
 }
 

--- a/cmd/internal/controllers/cmd_setup/cmd_setup.go
+++ b/cmd/internal/controllers/cmd_setup/cmd_setup.go
@@ -6,33 +6,11 @@ import (
 	"time"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-cli/cmd/internal/clients/api"
-	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
-	"pkg.world.dev/world-cli/cmd/internal/interfaces"
 	"pkg.world.dev/world-cli/cmd/internal/models"
 	"pkg.world.dev/world-cli/cmd/internal/services/config"
-	"pkg.world.dev/world-cli/cmd/internal/services/input"
 	"pkg.world.dev/world-cli/common/logger"
 	"pkg.world.dev/world-cli/common/printer"
 )
-
-func NewController(
-	configService config.ServiceInterface,
-	repoClient repo.ClientInterface,
-	organizationHandler interfaces.OrganizationHandler,
-	projectHandler interfaces.ProjectHandler,
-	apiClient api.ClientInterface,
-	inputService input.ServiceInterface,
-) interfaces.CommandSetupController {
-	return &Controller{
-		configService:       configService,
-		repoClient:          repoClient,
-		organizationHandler: organizationHandler,
-		projectHandler:      projectHandler,
-		apiClient:           apiClient,
-		inputService:        inputService,
-	}
-}
 
 // SetupCommandState performs the setup flow and returns the established state.
 func (c *Controller) SetupCommandState(ctx context.Context, req models.SetupRequest) (*models.CommandState, error) {

--- a/cmd/internal/controllers/cmd_setup/cmd_setup_test.go
+++ b/cmd/internal/controllers/cmd_setup/cmd_setup_test.go
@@ -1,0 +1,819 @@
+package cmdsetup_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
+	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
+	cmdsetup "pkg.world.dev/world-cli/cmd/internal/controllers/cmd_setup"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/cmd/internal/services/input"
+	organization "pkg.world.dev/world-cli/cmd/world/organization_refactor"
+	project "pkg.world.dev/world-cli/cmd/world/project_refactor"
+)
+
+// Helper function to create a controller with fresh mocks for each test.
+func createTestController() (
+	interfaces.CommandSetupController,
+	*api.MockClient,
+	*config.MockService,
+	*input.MockService,
+	*repo.MockClient,
+	*organization.MockHandler,
+	*project.MockHandler,
+) {
+	mockAPI := &api.MockClient{}
+	mockConfig := &config.MockService{}
+	mockInput := &input.MockService{}
+	mockRepo := &repo.MockClient{}
+	mockOrgHandler := &organization.MockHandler{}
+	mockProjectHandler := &project.MockHandler{}
+
+	controller := cmdsetup.NewController(
+		mockConfig,
+		mockRepo,
+		mockOrgHandler,
+		mockProjectHandler,
+		mockAPI,
+		mockInput,
+	)
+
+	return controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler
+}
+
+func TestSetupCommandState_IgnoreLogin_Success(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		OrganizationID: "org-123",
+		ProjectID:      "proj-456",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.IgnoreLogin,
+		OrganizationRequired: models.Ignore,
+		ProjectRequired:      models.Ignore,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.LoggedIn)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedLogin_NotLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token: "", // No token
+		},
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+
+	req := models.SetupRequest{
+		LoginRequired: models.NeedLogin,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not logged in")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedLogin_Success(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{
+		ID:    "user-123",
+		Name:  "Test User",
+		Email: "test@example.com",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired: models.NeedLogin,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.LoggedIn)
+	require.Equal(t, "user-123", result.User.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	pastTime := time.Now().Add(-time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "expired-token",
+			TokenExpiresAt: pastTime,
+		},
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+
+	req := models.SetupRequest{
+		LoginRequired: models.NeedLogin,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not logged in")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestHandleOrganizationInvitations_AcceptInvitation(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{ID: "user-123"}
+	orgs := []models.Organization{
+		{ID: "org-123", Name: "Test Org", Slug: "test-org"},
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return(orgs, nil)
+	mockInput.On("Confirm", ctx, "Would you like to join? [Y/n]", "Y").Return(true, nil)
+	mockAPI.On("AcceptOrganizationInvitation", ctx, "org-123").Return(nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired: models.NeedLogin,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestHandleOrganizationInvitations_DeclineInvitation(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{ID: "user-123"}
+	orgs := []models.Organization{
+		{ID: "org-123", Name: "Test Org", Slug: "test-org"},
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return(orgs, nil)
+	mockInput.On("Confirm", ctx, "Would you like to join? [Y/n]", "Y").Return(false, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired: models.NeedLogin,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_RepoLookup_Success(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+		CurrRepoURL:  "https://github.com/test/repo",
+		CurrRepoPath: "path",
+		KnownProjects: []config.KnownProject{
+			{
+				ProjectID:      "proj-789",
+				ProjectName:    "Found Project",
+				OrganizationID: "org-789",
+				RepoURL:        "https://github.com/test/repo",
+				RepoPath:       "path",
+			},
+		},
+	}
+	user := models.User{ID: "user-123"}
+	foundProject := models.Project{
+		ID:    "proj-789",
+		Name:  "Found Project",
+		OrgID: "org-789",
+	}
+	foundOrg := models.Organization{
+		ID:   "org-789",
+		Name: "Found Org",
+		Slug: "found-org",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("path", "https://github.com/test/repo", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetOrganizationByID", ctx, "org-789").Return(foundOrg, nil)
+	mockAPI.On("GetProjectByID", ctx, "proj-789").Return(foundProject, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:   models.NeedLogin,
+		ProjectRequired: models.NeedRepoLookup,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.LoggedIn)
+	require.NotNil(t, result.Organization)
+	require.NotNil(t, result.Project)
+	require.Equal(t, "org-789", result.Organization.ID)
+	require.Equal(t, "proj-789", result.Project.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_RepoLookup_NotLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		CurrRepoURL:  "https://github.com/test/repo",
+		CurrRepoPath: "path",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("path", "https://github.com/test/repo", nil)
+
+	req := models.SetupRequest{
+		LoginRequired:   models.IgnoreLogin,
+		ProjectRequired: models.NeedRepoLookup,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not logged in, can't lookup project from git repo")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedOrgData_NoOrgs_CreateNew(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{ID: "user-123"}
+	newOrg := models.Organization{
+		ID:   "new-org-123",
+		Name: "New Org",
+		Slug: "new-org",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetOrganizations", ctx).Return([]models.Organization{}, nil)
+	mockInput.On("Prompt", ctx, "Would you like to create one? (Y/n)", "Y").Return("Y", nil)
+	mockOrgHandler.On("Create", ctx, mock.AnythingOfType("*models.CommandState"), models.CreateOrganizationFlags{}).
+		Return(newOrg, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.NeedLogin,
+		OrganizationRequired: models.NeedData,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Organization)
+	require.Equal(t, "new-org-123", result.Organization.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedOrgData_OneOrg_UseExisting(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{ID: "user-123"}
+	existingOrg := models.Organization{
+		ID:   "existing-org-123",
+		Name: "Existing Org",
+		Slug: "existing-org",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetOrganizations", ctx).Return([]models.Organization{existingOrg}, nil)
+	mockInput.On("Prompt", ctx, "Use this organization? (Y/n/c to create new)", "Y").Return("Y", nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.NeedLogin,
+		OrganizationRequired: models.NeedData,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Organization)
+	require.Equal(t, "existing-org-123", result.Organization.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedOrgData_MultipleOrgs(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+	}
+	user := models.User{ID: "user-123"}
+	orgs := []models.Organization{
+		{ID: "org-1", Name: "Org 1", Slug: "org-1"},
+		{ID: "org-2", Name: "Org 2", Slug: "org-2"},
+	}
+	selectedOrg := orgs[0]
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetOrganizations", ctx).Return(orgs, nil)
+	mockOrgHandler.On("PromptForSwitch", ctx, mock.AnythingOfType("*models.CommandState"), orgs, true).
+		Return(selectedOrg, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.NeedLogin,
+		OrganizationRequired: models.NeedData,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Organization)
+	require.Equal(t, "org-1", result.Organization.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedProjectData_NoProjects_CreateNew(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+		OrganizationID: "org-123",
+	}
+	user := models.User{ID: "user-123"}
+	newProject := models.Project{
+		ID:    "new-proj-123",
+		Name:  "New Project",
+		OrgID: "org-123",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetProjects", ctx, "org-123").Return([]models.Project{}, nil)
+	mockProjectHandler.On("PreCreateUpdateValidation").Return("", "", nil)
+	mockInput.On("Prompt", ctx, "Would you like to create a new project? (Y/n)", "Y").Return("Y", nil)
+	mockProjectHandler.On("Create", ctx, mock.AnythingOfType("*models.CommandState"), models.CreateProjectFlags{}).
+		Return(newProject, nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.NeedLogin,
+		OrganizationRequired: models.NeedIDOnly,
+		ProjectRequired:      models.NeedData,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Project)
+	require.Equal(t, "new-proj-123", result.Project.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_NeedProjectData_OneProject_UseExisting(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+		OrganizationID: "org-123",
+	}
+	user := models.User{ID: "user-123"}
+	existingProject := models.Project{
+		ID:    "existing-proj-123",
+		Name:  "Existing Project",
+		Slug:  "existing-project",
+		OrgID: "org-123",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("GetProjects", ctx, "org-123").Return([]models.Project{existingProject}, nil)
+	mockProjectHandler.On("PreCreateUpdateValidation").Return("", "", repo.ErrNotInGitRepository)
+	mockInput.On("Prompt", ctx, "Select project: Existing Project [existing-project]? (Y/n)", "Y").Return("Y", nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.NeedLogin,
+		OrganizationRequired: models.NeedIDOnly,
+		ProjectRequired:      models.NeedData,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Project)
+	require.Equal(t, "existing-proj-123", result.Project.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_MustNotExist_OrganizationExists(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		OrganizationID: "org-123", // Has organization
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+
+	req := models.SetupRequest{
+		OrganizationRequired: models.MustNotExist,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "organization already exists")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_MustNotExist_ProjectExists(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		ProjectID: "proj-123", // Has project
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+
+	req := models.SetupRequest{
+		ProjectRequired: models.MustNotExist,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "project already exists")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_ConfigSaveError(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockConfig.On("Save").Return(config.ErrCannotSaveConfig)
+
+	req := models.SetupRequest{
+		LoginRequired: models.IgnoreLogin,
+	}
+
+	_, err := controller.SetupCommandState(ctx, req)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to save config after setup")
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_IDOnly_Success(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	cfg := &config.Config{
+		OrganizationID:  "org-123",
+		ProjectID:       "proj-456",
+		CurrProjectName: "Test Project",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("", "", nil)
+	mockConfig.On("Save").Return(nil)
+
+	req := models.SetupRequest{
+		LoginRequired:        models.IgnoreLogin,
+		OrganizationRequired: models.NeedIDOnly,
+		ProjectRequired:      models.NeedIDOnly,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Organization)
+	require.NotNil(t, result.Project)
+	require.Equal(t, "org-123", result.Organization.ID)
+	require.Equal(t, "proj-456", result.Project.ID)
+	require.Equal(t, "Test Project", result.Project.Name)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}
+
+func TestSetupCommandState_RepoLookup_NewProjectDiscovered(t *testing.T) {
+	t.Parallel()
+
+	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := createTestController()
+	ctx := t.Context()
+
+	futureTime := time.Now().Add(time.Hour)
+	cfg := &config.Config{
+		Credential: config.Credential{
+			Token:          "valid-token",
+			TokenExpiresAt: futureTime,
+		},
+		CurrRepoURL:  "https://github.com/test/repo",
+		CurrRepoPath: "path",
+		// No KnownProjects initially - this is a new discovery
+	}
+	user := models.User{ID: "user-123"}
+	foundProject := models.Project{
+		ID:    "proj-789",
+		Name:  "Found Project",
+		OrgID: "org-789",
+	}
+	foundOrg := models.Organization{
+		ID:   "org-789",
+		Name: "Found Org",
+		Slug: "found-org",
+	}
+
+	mockConfig.On("GetConfig").Return(cfg)
+	mockRepo.On("FindGitPathAndURL").Return("path", "https://github.com/test/repo", nil)
+	mockAPI.On("GetUser", ctx).Return(user, nil)
+	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
+	mockAPI.On("LookupProjectFromRepo", ctx, "https://github.com/test/repo", "path").Return(foundProject, nil)
+	mockConfig.On("AddKnownProject", "proj-789", "Found Project", "org-789", "https://github.com/test/repo", "path")
+	// After discovery, the service will call inKnownRepo which needs these API calls
+	mockAPI.On("GetOrganizationByID", ctx, "org-789").Return(foundOrg, nil)
+	mockAPI.On("GetProjectByID", ctx, "proj-789").Return(foundProject, nil)
+	mockConfig.On("Save").Return(nil).Twice() // Once for AddKnownProject, once at the end
+
+	req := models.SetupRequest{
+		LoginRequired:   models.NeedLogin,
+		ProjectRequired: models.NeedRepoLookup,
+	}
+
+	result, err := controller.SetupCommandState(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.LoggedIn)
+	require.NotNil(t, result.Organization)
+	require.NotNil(t, result.Project)
+	require.Equal(t, "org-789", result.Organization.ID)
+	require.Equal(t, "proj-789", result.Project.ID)
+
+	mockAPI.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+	mockInput.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+	mockOrgHandler.AssertExpectations(t)
+	mockProjectHandler.AssertExpectations(t)
+}

--- a/cmd/internal/controllers/cmd_setup/organization.go
+++ b/cmd/internal/controllers/cmd_setup/organization.go
@@ -49,7 +49,7 @@ func (c *Controller) handleNeedOrganizationCaseNoOrgs(
 
 		switch choice {
 		case "Y":
-			org, err := c.organizationHandler.Create(ctx, &models.CreateOrganizationFlags{})
+			org, err := c.organizationHandler.Create(ctx, result, models.CreateOrganizationFlags{})
 			if err != nil {
 				return eris.Wrap(err, "Flow failed to create organization in no-orgs case")
 			}
@@ -86,7 +86,7 @@ func (c *Controller) handleNeedOrganizationCaseOneOrg(
 		case "n":
 			return ErrOrganizationSelectionCanceled
 		case "c":
-			org, err := c.organizationHandler.Create(ctx, &models.CreateOrganizationFlags{})
+			org, err := c.organizationHandler.Create(ctx, result, models.CreateOrganizationFlags{})
 			if err != nil {
 				return eris.Wrap(err, "Flow failed to create organization in one-org case")
 			}
@@ -105,7 +105,7 @@ func (c *Controller) handleNeedOrganizationCaseMultipleOrgs(
 	cfg *config.Config,
 	orgs []models.Organization,
 ) error {
-	org, err := c.organizationHandler.PromptForOrganization(ctx, orgs, true)
+	org, err := c.organizationHandler.PromptForSwitch(ctx, result, orgs, true)
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to prompt for organization in multiple-orgs case")
 	}
@@ -165,7 +165,7 @@ func (c *Controller) handleNeedExistingOrganizationCaseMultipleOrgs(
 		return nil
 	}
 
-	org, err := c.organizationHandler.PromptForOrganization(ctx, orgs, false)
+	org, err := c.organizationHandler.PromptForSwitch(ctx, result, orgs, false)
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to prompt for organization in existing multiple-orgs case")
 	}

--- a/cmd/internal/controllers/cmd_setup/project.go
+++ b/cmd/internal/controllers/cmd_setup/project.go
@@ -55,7 +55,7 @@ func (c *Controller) handleNeedProjectCaseNoProjects(
 
 		switch choice {
 		case "Y":
-			proj, err := c.projectHandler.Create(ctx, &models.CreateProjectFlags{}, true)
+			proj, err := c.projectHandler.Create(ctx, result, models.CreateProjectFlags{})
 			if err != nil {
 				return eris.Wrap(err, "Flow failed to create project in no-projects case")
 			}
@@ -100,7 +100,7 @@ func (c *Controller) handleNeedProjectCaseOneProject(
 			return ErrProjectSelectionCanceled
 		case "c":
 			if inRepoRoot {
-				proj, err := c.projectHandler.Create(ctx, &models.CreateProjectFlags{}, true)
+				proj, err := c.projectHandler.Create(ctx, result, models.CreateProjectFlags{})
 				if err != nil {
 					return eris.Wrap(err, "Flow failed to create project in one-project case")
 				}
@@ -124,7 +124,7 @@ func (c *Controller) handleNeedProjectCaseMultipleProjects(
 	result *models.CommandState,
 	cfg *config.Config,
 ) error {
-	proj, err := c.projectHandler.Switch(ctx, &models.SwitchProjectFlags{})
+	proj, err := c.projectHandler.Switch(ctx, result, models.SwitchProjectFlags{}, true)
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to select project in multiple-projects case")
 	}
@@ -182,7 +182,7 @@ func (c *Controller) handleNeedExistingProjectCaseMultipleProjects(
 		return nil
 	}
 
-	proj, err := c.projectHandler.Switch(ctx, &models.SwitchProjectFlags{})
+	proj, err := c.projectHandler.Switch(ctx, result, models.SwitchProjectFlags{}, false)
 	if err != nil {
 		return eris.Wrap(err, "Flow failed to select project in existing multiple-projects case")
 	}

--- a/cmd/internal/controllers/cmd_setup/types.go
+++ b/cmd/internal/controllers/cmd_setup/types.go
@@ -15,9 +15,27 @@ var (
 
 type Controller struct {
 	configService       config.ServiceInterface
+	inputService        input.ServiceInterface
+	apiClient           api.ClientInterface
 	repoClient          repo.ClientInterface
 	organizationHandler interfaces.OrganizationHandler
 	projectHandler      interfaces.ProjectHandler
-	apiClient           api.ClientInterface
-	inputService        input.ServiceInterface
+}
+
+func NewController(
+	configService config.ServiceInterface,
+	repoClient repo.ClientInterface,
+	organizationHandler interfaces.OrganizationHandler,
+	projectHandler interfaces.ProjectHandler,
+	apiClient api.ClientInterface,
+	inputService input.ServiceInterface,
+) interfaces.CommandSetupController {
+	return &Controller{
+		configService:       configService,
+		inputService:        inputService,
+		repoClient:          repoClient,
+		organizationHandler: organizationHandler,
+		projectHandler:      projectHandler,
+		apiClient:           apiClient,
+	}
 }

--- a/cmd/internal/interfaces/organization.go
+++ b/cmd/internal/interfaces/organization.go
@@ -7,8 +7,20 @@ import (
 )
 
 type OrganizationHandler interface {
-	Create(ctx context.Context, flags *models.CreateOrganizationFlags) (models.Organization, error)
-	Switch(ctx context.Context, flags *models.SwitchOrganizationFlags) (models.Organization, error)
-
-	PromptForOrganization(ctx context.Context, orgs []models.Organization, createNew bool) (models.Organization, error)
+	Create(
+		ctx context.Context,
+		state *models.CommandState,
+		flags models.CreateOrganizationFlags,
+	) (models.Organization, error)
+	Switch(
+		ctx context.Context,
+		state *models.CommandState,
+		flags models.SwitchOrganizationFlags,
+	) (models.Organization, error)
+	PromptForSwitch(
+		ctx context.Context,
+		state *models.CommandState,
+		orgs []models.Organization,
+		createNew bool,
+	) (models.Organization, error)
 }

--- a/cmd/internal/interfaces/project.go
+++ b/cmd/internal/interfaces/project.go
@@ -7,10 +7,15 @@ import (
 )
 
 type ProjectHandler interface {
-	Create(ctx context.Context, flags *models.CreateProjectFlags, createNew bool) (models.Project, error)
-	Switch(ctx context.Context, flags *models.SwitchProjectFlags) (models.Project, error)
-	Update(ctx context.Context, flags *models.UpdateProjectFlags) error
-	Delete(ctx context.Context) error
+	Create(ctx context.Context, state *models.CommandState, flags models.CreateProjectFlags) (models.Project, error)
+	Switch(
+		ctx context.Context,
+		state *models.CommandState,
+		flags models.SwitchProjectFlags,
+		createNew bool,
+	) (models.Project, error)
+	Update(ctx context.Context, state *models.CommandState, flags models.UpdateProjectFlags) error
+	Delete(ctx context.Context, state *models.CommandState) error
 
 	PreCreateUpdateValidation() (string, string, error)
 }

--- a/cmd/internal/services/input/input_internal_test.go
+++ b/cmd/internal/services/input/input_internal_test.go
@@ -110,7 +110,7 @@ func TestPromptWithTimeout(t *testing.T) {
 	defer cancel()
 
 	_, err := client.Prompt(ctx, "Test prompt", "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	// The actual error might be EOF when reader is exhausted, not necessarily timeout
 }
 

--- a/cmd/internal/utils/slug.go
+++ b/cmd/internal/utils/slug.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
+)
+
+// Pre-compiled regex for merging multiple underscores.
+var underscoreRegex = regexp.MustCompile(`_+`)
+
+// SlugToSaneCheck checks that slug is valid, and returns a sanitized version.
+func SlugToSaneCheck(slug string, minLength int, maxLength int) (string, error) {
+	if len(slug) < minLength {
+		return slug, eris.Errorf("Slug must be at least %d characters", minLength)
+	}
+
+	// Check if slug contains only allowed characters.
+	matched, err := regexp.MatchString("^[a-z0-9_]+$", slug)
+	if err != nil {
+		return slug, eris.Wrap(err, "Error validating slug format")
+	}
+	if !matched {
+		return slug, eris.New("Slug can only contain lowercase letters, numbers, and underscores")
+	}
+
+	// Process the slug, and ensure it's in sane format.
+	returnSlug := strings.ToLower(strings.TrimSpace(slug))
+	returnSlug = strings.ReplaceAll(returnSlug, " ", "_")
+	returnSlug = underscoreRegex.ReplaceAllString(returnSlug, "_")
+	returnSlug = strings.Trim(returnSlug, "_")
+
+	if len(returnSlug) > maxLength {
+		return returnSlug[:maxLength], nil
+	}
+
+	return returnSlug, nil
+}
+
+func CreateSlugFromName(name string, minLength int, maxLength int) string {
+	shorten := len(name) > maxLength
+
+	var slug string
+	wroteUnderscore := false
+	hadCapital := false
+	for i, r := range name {
+		switch {
+		case unicode.IsLower(r) || unicode.IsNumber(r):
+			// copy lowercase letters and numbers
+			slug += string(r)
+			wroteUnderscore = false
+			hadCapital = unicode.IsNumber(r) // treat numbers as capital letters
+		case unicode.IsUpper(r):
+			// convert capital letter to lower, with _ if dealing with CamelCase ( -> camel_case )
+			if !shorten && i != 0 && !wroteUnderscore && !hadCapital {
+				slug += "_"
+			}
+			slug += string(unicode.ToLower(r))
+			wroteUnderscore = false
+			hadCapital = true
+		case (r == '_' || !shorten) && !wroteUnderscore:
+			// underscore is preserved (but many fused into one)
+			// unless the input was too long, other characters are converted to underscores (but many fused into one)
+			slug += "_"
+			wroteUnderscore = true
+			hadCapital = false
+		}
+	}
+	slug = strings.Trim(slug, "_")
+	if len(slug) < minLength {
+		slug += "_" + uuid.NewString()[:8] // add the first 8 characters of the UUID
+		slug = strings.TrimLeft(slug, "_")
+	}
+	if len(slug) > maxLength {
+		slug = slug[:maxLength]
+		slug = strings.TrimRight(slug, "_")
+	}
+	return slug
+}

--- a/cmd/internal/utils/validation.go
+++ b/cmd/internal/utils/validation.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+var ErrNotInWorldCardinalRoot = eris.New("Not in a World Cardinal root")
+
+func ValidateName(name string, maxLength int) error {
+	if name == "" {
+		printer.Errorln("Name cannot be empty")
+		printer.NewLine(1)
+		return eris.New("empty name")
+	}
+
+	if len(name) > maxLength {
+		printer.Errorf("Name cannot be longer than %d characters\n", maxLength)
+		printer.NewLine(1)
+		return eris.New("name too long")
+	}
+
+	if strings.ContainsAny(name, "<>:\"/\\|?*") {
+		printer.Errorln("Name contains invalid characters" +
+			"   Invalid characters: < > : \" / \\ | ? *")
+		printer.NewLine(1)
+		return eris.New("invalid characters")
+	}
+
+	for i, r := range name {
+		if !unicode.IsPrint(r) {
+			printer.Errorf("Name contains non-printable characters at index %d\n", i)
+			printer.NewLine(1)
+			return eris.New("non-printable character in name")
+		}
+	}
+	return nil
+}
+
+func IsValidURL(urlStr string) error {
+	parsedURL, err := url.ParseRequestURI(urlStr)
+	if err != nil {
+		return eris.New("Invalid URL: Must start with http:// or https://")
+	}
+
+	// Check if hostname has a TLD (at least one dot with characters after it)
+	hostname := parsedURL.Hostname()
+	parts := strings.Split(hostname, ".")
+	if len(parts) < 2 || parts[len(parts)-1] == "" {
+		return eris.New("Invalid URL: Must have a TLD")
+	}
+
+	// Skip DNS lookup for localhost
+	if hostname == "localhost" {
+		return eris.New("Invalid URL: Cannot use localhost")
+	}
+
+	// Perform DNS lookup to verify domain exists
+	_, err = net.LookupHost(hostname)
+	return eris.Wrap(err, "Invalid URL")
+}
+
+// IsInWorldCardinalRoot checks if the current working directory is a World project.
+// It checks for the presence of world.toml and cardinal directory.
+func IsInWorldCardinalRoot() (bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, eris.Wrap(err, "failed to get working directory")
+	}
+
+	worldTomlPath := filepath.Join(cwd, "world.toml")
+	cardinalDirPath := filepath.Join(cwd, "cardinal")
+
+	tomlInfo, err := os.Stat(worldTomlPath)
+	if err != nil || tomlInfo.IsDir() {
+		return false, nil //nolint:nilerr // false return gives all the information we need
+	}
+
+	cardinalInfo, err := os.Stat(cardinalDirPath)
+	if err != nil || !cardinalInfo.IsDir() {
+		return false, nil //nolint:nilerr // false return gives all the information we need
+	}
+	return true, nil
+}

--- a/cmd/world/organization_refactor/create.go
+++ b/cmd/world/organization_refactor/create.go
@@ -2,12 +2,128 @@ package organization
 
 import (
 	"context"
+	"strings"
 
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
 	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/utils"
+	"pkg.world.dev/world-cli/common/printer"
 )
 
-//nolint:revive // TODO: implement
-func (h *Handler) Create(ctx context.Context, flags *models.CreateOrganizationFlags,
+const MaxOrgNameLen = 50
+
+//nolint:gocognit,funlen // Belongs in a single function
+func (h *Handler) Create(ctx context.Context, _ *models.CommandState, flags models.CreateOrganizationFlags,
 ) (models.Organization, error) {
-	return models.Organization{}, nil
+	var orgName, orgSlug, orgAvatarURL string
+	var err error
+
+	for {
+		// Get organization name
+		printer.NewLine(1)
+		printer.Headerln("  Create New Organization  ")
+		for {
+			orgName, err = h.inputService.Prompt(ctx, "Enter organization name", flags.Name)
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to get organization name")
+			}
+			err = utils.ValidateName(orgName, MaxOrgNameLen)
+			if err != nil {
+				printer.Errorf("%s\n", err)
+				printer.NewLine(1)
+				continue
+			}
+			break
+		}
+
+		// Used to create slug from name
+		orgSlug = orgName
+		if flags.Slug != "" {
+			orgSlug = flags.Slug
+		}
+
+		// Get and validate organization slug
+		for {
+			minLength := 3
+			maxLength := 15
+			orgSlug = utils.CreateSlugFromName(orgSlug, minLength, maxLength)
+			orgSlug, err = h.inputService.Prompt(ctx, "Enter organization slug", orgSlug)
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to get organization slug")
+			}
+
+			// Validate slug
+			orgSlug, err = utils.SlugToSaneCheck(orgSlug, minLength, maxLength)
+			if err != nil {
+				printer.Errorf("%s\n", err)
+				printer.NewLine(1)
+				continue
+			}
+			break
+		}
+
+		// Get and validate organization avatar URL
+		for {
+			orgAvatarURL, err = h.inputService.Prompt(
+				ctx,
+				"Enter organization avatar URL (Empty Valid)",
+				flags.AvatarURL,
+			)
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to get organization avatar URL")
+			}
+
+			if orgAvatarURL == "" {
+				break
+			}
+
+			if err := utils.IsValidURL(orgAvatarURL); err != nil {
+				printer.Errorln(err.Error())
+				printer.NewLine(1)
+				continue
+			}
+
+			break
+		}
+
+		// Show confirmation
+		printer.NewLine(1)
+		printer.Headerln("  Organization Details  ")
+		printer.Infof("Name: %s\n", orgName)
+		printer.Infof("Slug: %s\n", orgSlug)
+		if orgAvatarURL != "" {
+			printer.Infof("Avatar URL: %s\n", orgAvatarURL)
+		} else {
+			printer.Infoln("Avatar URL: None")
+		}
+
+		// Get confirmation
+		printer.NewLine(1)
+		confirm, err := h.inputService.Confirm(ctx, "Create organization with these details? (Y/n)", "n")
+		if err != nil {
+			return models.Organization{}, eris.Wrap(err, "Failed to get confirmation")
+		}
+		if confirm {
+			org, err := h.apiClient.CreateOrganization(ctx, orgName, orgSlug, orgAvatarURL)
+			if err != nil {
+				if strings.Contains(err.Error(), api.ErrOrganizationSlugAlreadyExists.Error()) {
+					printer.Errorf(
+						"An Organization already exists with slug: %s, please choose a different slug.\n",
+						orgSlug,
+					)
+					printer.NewLine(1)
+				}
+				return models.Organization{}, eris.Wrap(err, "Failed to create organization")
+			}
+			printer.NewLine(1)
+			printer.Successf("Organization '%s' with slug '%s' created successfully!\n", org.Name, org.Slug)
+
+			err = h.saveOrganization(org)
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to save organization")
+			}
+			return org, nil
+		}
+	}
 }

--- a/cmd/world/organization_refactor/mock.go
+++ b/cmd/world/organization_refactor/mock.go
@@ -15,23 +15,24 @@ type MockHandler struct {
 	mock.Mock
 }
 
-func (m *MockHandler) Create(ctx context.Context, flags *models.CreateOrganizationFlags,
+func (m *MockHandler) Create(ctx context.Context, state *models.CommandState, flags models.CreateOrganizationFlags,
 ) (models.Organization, error) {
-	args := m.Called(ctx, flags)
+	args := m.Called(ctx, state, flags)
 	return args.Get(0).(models.Organization), args.Error(1)
 }
 
-func (m *MockHandler) Switch(ctx context.Context, flags *models.SwitchOrganizationFlags,
+func (m *MockHandler) Switch(ctx context.Context, state *models.CommandState, flags models.SwitchOrganizationFlags,
 ) (models.Organization, error) {
-	args := m.Called(ctx, flags)
+	args := m.Called(ctx, state, flags)
 	return args.Get(0).(models.Organization), args.Error(1)
 }
 
-func (m *MockHandler) PromptForOrganization(
+func (m *MockHandler) PromptForSwitch(
 	ctx context.Context,
+	state *models.CommandState,
 	orgs []models.Organization,
 	createNew bool,
 ) (models.Organization, error) {
-	args := m.Called(ctx, orgs, createNew)
+	args := m.Called(ctx, state, orgs, createNew)
 	return args.Get(0).(models.Organization), args.Error(1)
 }

--- a/cmd/world/organization_refactor/switch.go
+++ b/cmd/world/organization_refactor/switch.go
@@ -2,22 +2,85 @@ package organization
 
 import (
 	"context"
+	"strconv"
 
+	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/common/printer"
 )
 
+var ErrOrganizationSelectionCanceled = eris.New("Organization selection canceled")
+
 //nolint:revive // TODO: implement
-func (h *Handler) Switch(ctx context.Context, flags *models.SwitchOrganizationFlags,
+func (h *Handler) Switch(ctx context.Context, state *models.CommandState, flags models.SwitchOrganizationFlags,
 ) (models.Organization, error) {
 	return models.Organization{}, nil
 }
 
-//
-//nolint:revive // TODO: implement
-func (h *Handler) PromptForOrganization(
-	ctx context.Context,
-	orgs []models.Organization,
-	createNew bool,
+//nolint:gocognit // Belongs in a single function
+func (h *Handler) PromptForSwitch(
+	ctx context.Context, state *models.CommandState, orgs []models.Organization, createNew bool,
 ) (models.Organization, error) {
-	return models.Organization{}, nil
+	// Display organizations as a numbered list
+	printer.NewLine(1)
+	printer.Headerln("   Available Organizations  ")
+	for i, org := range orgs {
+		printer.Infof("  %d. %s\n    └─ Slug: %s\n", i+1, org.Name, org.Slug)
+	}
+
+	// Get user input
+	var input string
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return models.Organization{}, ctx.Err()
+		default:
+			printer.NewLine(1)
+			if createNew {
+				input, err = h.inputService.Prompt(
+					ctx,
+					"Enter organization number ('c' to create new or 'q' to quit)",
+					"",
+				)
+				if err != nil {
+					return models.Organization{}, eris.Wrap(err, "Failed to get organization number")
+				}
+			} else {
+				input, err = h.inputService.Prompt(ctx, "Enter organization number ('q' to quit)", "")
+				if err != nil {
+					return models.Organization{}, eris.Wrap(err, "Failed to get organization number")
+				}
+			}
+
+			if input == "q" {
+				return models.Organization{}, ErrOrganizationSelectionCanceled
+			}
+
+			if input == "c" && createNew {
+				org, err := h.Create(ctx, state, models.CreateOrganizationFlags{})
+				if err != nil {
+					return models.Organization{}, eris.Wrap(err, "Failed to create organization")
+				}
+				return org, nil
+			}
+
+			// Parse selection
+			num, err := strconv.Atoi(input)
+			if err != nil || num < 1 || num > len(orgs) {
+				printer.Errorf("Invalid selection. Please enter a number between 1 and %d\n", len(orgs))
+				continue
+			}
+
+			selectedOrg := orgs[num-1]
+
+			err = h.saveOrganization(selectedOrg)
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to save organization")
+			}
+
+			printer.Successf("Selected organization: %s\n", selectedOrg.Name)
+			return selectedOrg, nil
+		}
+	}
 }

--- a/cmd/world/organization_refactor/types.go
+++ b/cmd/world/organization_refactor/types.go
@@ -1,12 +1,32 @@
 package organization
 
 import (
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
 	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/cmd/internal/services/input"
 )
 
 // Interface guard.
 var _ interfaces.OrganizationHandler = (*Handler)(nil)
 
 type Handler struct {
-	ProjectHandler interfaces.ProjectHandler
+	projectHandler interfaces.ProjectHandler
+	inputService   input.ServiceInterface
+	apiClient      api.ClientInterface
+	configService  config.ServiceInterface
+}
+
+func NewHandler(
+	projectHandler interfaces.ProjectHandler,
+	inputService input.ServiceInterface,
+	apiClient api.ClientInterface,
+	configService config.ServiceInterface,
+) interfaces.OrganizationHandler {
+	return &Handler{
+		projectHandler: projectHandler,
+		inputService:   inputService,
+		apiClient:      apiClient,
+		configService:  configService,
+	}
 }

--- a/cmd/world/organization_refactor/utils.go
+++ b/cmd/world/organization_refactor/utils.go
@@ -1,0 +1,15 @@
+package organization
+
+import (
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+)
+
+func (h *Handler) saveOrganization(org models.Organization) error {
+	h.configService.GetConfig().OrganizationID = org.ID
+	err := h.configService.Save()
+	if err != nil {
+		return eris.Wrap(err, "Failed to save organization")
+	}
+	return nil
+}

--- a/cmd/world/project_refactor/create.go
+++ b/cmd/world/project_refactor/create.go
@@ -2,16 +2,636 @@ package project
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
 	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/utils"
+	"pkg.world.dev/world-cli/common/printer"
+	"pkg.world.dev/world-cli/common/tomlutil"
+	"pkg.world.dev/world-cli/common/util"
+	"pkg.world.dev/world-cli/tea/component/multiselect"
+)
+
+const MaxProjectNameLen = 50
+
+// TODO: un global this but atleast with new command refactor not affecting other command tests!
+var regionSelector *tea.Program
+
+var (
+	// ErrProjectSlugAlreadyExists is passed from forge to world-cli, Must always match.
+	ErrProjectSlugAlreadyExists = eris.New("project slug already exists")
+
+	ErrCannotCreateSwitchProject = eris.New("Cannot create/switch Project, directory belongs to another project.")
 )
 
 //nolint:revive // TODO: implement
-func (h *Handler) Create(ctx context.Context, flags *models.CreateProjectFlags, createNew bool,
+func (h *Handler) Create(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.CreateProjectFlags,
 ) (models.Project, error) {
-	return models.Project{}, nil
+	if h.configService.GetConfig().CurrRepoKnown {
+		printer.Errorf("Cannot create Project, current git working directory belongs to project: %s.",
+			h.configService.GetConfig().CurrProjectName)
+		return models.Project{}, ErrCannotCreateSwitchProject
+	}
+
+	repoPath, repoURL, err := h.PreCreateUpdateValidation()
+	if err != nil {
+		printRequiredStepsToCreateProject()
+		return models.Project{}, eris.Wrap(err, "Failed to validate project creation")
+	}
+
+	regions, err := h.getListOfAvailableRegionsForNewProject(ctx)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to get available regions")
+	}
+
+	printer.NewLine(1)
+	printer.Headerln("   Project Creation   ")
+
+	p := models.Project{
+		Name:      flags.Name,
+		Slug:      flags.Slug,
+		AvatarURL: flags.AvatarURL,
+		RepoPath:  repoPath,
+		RepoURL:   repoURL,
+		Update:    false,
+	}
+	err = h.getSetupInput(ctx, &p, regions)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to get project input")
+	}
+
+	// Send request
+	prj, err := h.apiClient.CreateProject(ctx, p.OrgID, p)
+	if err != nil {
+		if eris.Is(err, ErrProjectSlugAlreadyExists) {
+			printer.Errorf("Project already exists with slug: %s, please choose a different slug.\n", p.Slug)
+			printer.NewLine(1)
+		}
+		return models.Project{}, eris.Wrap(err, "Failed to create project")
+	}
+
+	// Select project
+	err = h.saveToConfig(&prj)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to save project configuration")
+	}
+
+	displayProjectDetails(&prj)
+	printer.Infof("• Deploy Secret (for deploy via CI/CD pipeline tools): ")
+	printer.Infof("%s\n", prj.DeploySecret)
+	printer.Notificationln("Note: Deploy Secret will not be shown again. Save it now in a secure location.")
+
+	printer.NewLine(1)
+	printer.Successf("Created project: %s [%s]\n", prj.Name, prj.Slug)
+	return prj, nil
 }
 
-func (h *Handler) PreCreateUpdateValidation() (string, string, error) {
-	return "", "", nil
+func (h *Handler) getSetupInput(ctx context.Context, project *models.Project, regions []string) error {
+	// Get organization
+	org, err := h.apiClient.GetOrganizationByID(ctx, h.configService.GetConfig().OrganizationID)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get organization")
+	}
+
+	if org.ID == "" || eris.Is(err, api.ErrNoOrganizationID) {
+		printNoSelectedOrganization()
+		return nil
+	}
+
+	project.OrgID = org.ID
+
+	err = h.inputName(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get project name")
+	}
+
+	err = h.inputSlug(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get project slug")
+	}
+
+	err = h.inputRepoURLAndToken(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get repository URL and token")
+	}
+
+	h.inputRepoPath(ctx, project)
+
+	// Regions
+	err = h.chooseRegion(ctx, project, regions)
+	if err != nil {
+		return eris.Wrap(err, "Failed to choose region")
+	}
+
+	// Discord
+	err = h.inputDiscord(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to input discord")
+	}
+
+	// Slack
+	err = h.inputSlack(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to input slack")
+	}
+
+	err = h.inputAvatarURL(ctx, project)
+	if err != nil {
+		return eris.Wrap(err, "Failed to input avatar URL")
+	}
+
+	return nil
+}
+
+func (h *Handler) inputName(ctx context.Context, project *models.Project) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// If name is not set from cmd flags, get it from world.toml
+		if project.Name == "" {
+			// Get project name from world.toml if it exists, fails silently
+			err := getForgeProjectNameFromWorldToml(project)
+			if err != nil {
+				project.Name = ""
+			}
+		}
+
+		name, err := h.inputService.Prompt(ctx, "Enter project name", project.Name)
+		if err != nil {
+			return eris.Wrap(err, "Failed to get project name")
+		}
+
+		err = validateAndSetName(name, project)
+		if err == nil {
+			return nil
+		}
+		// If validation fails, clear the name to attempt from toml
+		project.Name = ""
+	}
+}
+
+func getForgeProjectNameFromWorldToml(project *models.Project) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return eris.Wrap(err, "Failed to get current working directory")
+	}
+
+	absProjectDir := filepath.Join(cwd, "world.toml")
+
+	// Get the forge section from world.toml
+	forgeSection, err := tomlutil.GetTOMLSection(absProjectDir, "forge")
+	if err != nil {
+		return eris.Wrap(err, "Failed to read forge section from world.toml")
+	}
+	if forgeSection == nil {
+		return eris.New("forge section not found in world.toml")
+	}
+
+	projectName, ok := forgeSection["PROJECT_NAME"].(string)
+	if !ok {
+		return eris.New("PROJECT_NAME not found in forge section")
+	}
+
+	if err := validateAndSetName(projectName, project); err != nil {
+		return eris.Wrap(err, "invalid project name in world.toml")
+	}
+	return nil
+}
+
+func validateAndSetName(name string, project *models.Project) error {
+	if err := utils.ValidateName(name, MaxProjectNameLen); err != nil {
+		return err
+	}
+	project.Name = name
+	return nil
+}
+
+//nolint:gocognit // Belongs in a single function
+func (h *Handler) inputSlug(ctx context.Context, project *models.Project) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			// if no slug exists, create a default one from the name
+			minLength := 3
+			maxLength := 25
+			if project.Slug == "" {
+				project.Slug = utils.CreateSlugFromName(project.Name, minLength, maxLength)
+			} else {
+				project.Slug = utils.CreateSlugFromName(project.Slug, minLength, maxLength)
+			}
+
+			slug, err := h.inputService.Prompt(ctx, "Slug", project.Slug)
+			if err != nil {
+				return eris.Wrap(err, "Failed to get project slug")
+			}
+
+			// Validate slug
+			slug, err = utils.SlugToSaneCheck(slug, minLength, maxLength)
+			if err != nil {
+				printer.Errorf("%s\n", err)
+				printer.NewLine(1)
+				continue
+			}
+
+			if err := h.checkIfProjectSlugIsTaken(ctx, project, slug); err != nil {
+				if eris.Is(err, ErrProjectSlugAlreadyExists) {
+					printer.Errorf("Project already exists with slug: %s\n", slug)
+				} else {
+					printer.Errorf("%s\n", err)
+				}
+				printer.NewLine(1)
+				continue
+			}
+			return nil
+		}
+	}
+}
+
+func (h *Handler) checkIfProjectSlugIsTaken(ctx context.Context, project *models.Project, slug string) error {
+	var projectID string
+	if project.ID == "" {
+		projectID = nilUUID
+	} else {
+		projectID = project.ID
+	}
+
+	err := h.apiClient.CheckProjectSlugIsTaken(ctx, project.OrgID, projectID, slug)
+	if err != nil {
+		return err
+	}
+	project.Slug = slug
+	return nil
+}
+
+//nolint:gocognit // Feel free to refactor this function
+func (h *Handler) inputRepoURLAndToken(ctx context.Context, project *models.Project) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			repoURL, err := h.inputService.Prompt(ctx, "Enter Repository URL", project.RepoURL)
+			if err != nil {
+				return eris.Wrap(err, "Failed to get repository URL")
+			}
+
+			// if repoURL prefix is not http or https, add https:// to the repoURL
+			if !strings.HasPrefix(repoURL, "http://") && !strings.HasPrefix(repoURL, "https://") {
+				repoURL = "https://" + repoURL
+			}
+
+			if err := validateRepoURL(repoURL); err != nil {
+				continue
+			}
+
+			// Try to access the repo with public token
+			repoToken := ""
+			if err := h.repoClient.ValidateRepoToken(ctx, repoURL, repoToken); err != nil {
+				// If the repo is private, we need to get a token
+				repoToken, err = h.promptForRepoToken(ctx, project)
+				if err != nil {
+					return eris.Wrap(err, "Failed to get repository token")
+				}
+				repoToken = processRepoToken(repoToken, project)
+
+				if err := h.repoClient.ValidateRepoToken(ctx, repoURL, repoToken); err != nil {
+					printer.Errorf("%v\n", err)
+					printer.NewLine(1)
+					continue
+				}
+			}
+
+			project.RepoURL = repoURL
+			project.RepoToken = repoToken
+			return nil
+		}
+	}
+}
+
+func validateRepoURL(repoURL string) error {
+	if !strings.HasPrefix(repoURL, "http://") && !strings.HasPrefix(repoURL, "https://") {
+		printer.NewLine(1)
+		printer.Errorln("Invalid Repository URL Format")
+		printer.Infoln("The URL must start with:")
+		printer.Infoln("• http://")
+		printer.Infoln("• https://")
+		printer.NewLine(1)
+		return eris.New("invalid URL format")
+	}
+	return nil
+}
+
+func (h *Handler) promptForRepoToken(ctx context.Context, project *models.Project) (string, error) {
+	if project.Update {
+		printer.NewLine(1)
+		printer.Headerln("  Update Repository Access Token   ")
+		printer.Infoln("Enter new token (options):")
+		printer.Infoln("• Press Enter to keep existing token")
+		printer.Infoln("• Type 'public' for public repositories")
+		printer.Infoln("• Enter new token for private repositories")
+	}
+	repoToken, err := h.inputService.Prompt(ctx, "\nEnter Token", project.RepoToken)
+	if err != nil {
+		return "", eris.Wrap(err, "Failed to get repository token")
+	}
+
+	return repoToken, nil
+}
+
+func processRepoToken(repoToken string, project *models.Project) string {
+	// During update, empty input means keep existing token
+	if repoToken == "" && project.Update {
+		return project.RepoToken
+	}
+	if strings.ToLower(repoToken) == "public" {
+		return ""
+	}
+	return repoToken
+}
+
+func (h *Handler) inputRepoPath(ctx context.Context, project *models.Project) {
+	// Get repository Path
+	for {
+		repoPath, err := h.inputService.Prompt(
+			ctx,
+			"Enter path to Cardinal within Repo (Empty Valid)",
+			project.RepoPath,
+		)
+		if err != nil {
+			printer.Errorf("%v\n", err)
+			printer.NewLine(1)
+			continue
+		}
+
+		// strip off any leading slash
+		repoPath = strings.TrimPrefix(repoPath, "/")
+
+		// Validate the path exists using the new validateRepoPath function
+		if len(repoPath) > 0 {
+			if err := h.repoClient.ValidateRepoPath(ctx, project.RepoURL, project.RepoToken, repoPath); err != nil {
+				printer.Errorf("%v\n", err)
+				printer.NewLine(1)
+				continue
+			}
+		}
+
+		project.RepoPath = repoPath
+		return
+	}
+}
+
+// configureNotifications handles configuration for both Discord and Slack notifications.
+func (h *Handler) configureNotifications(
+	ctx context.Context,
+	config notificationConfig,
+) (bool, string, string, error) {
+	enabled, err := h.promptEnableNotifications(ctx, config.name)
+	if err != nil {
+		return false, "", "", err
+	}
+	if !enabled {
+		return false, "", "", nil
+	}
+
+	token, err := h.promptForToken(ctx, config)
+	if err != nil {
+		return false, "", "", err
+	}
+
+	channelID, err := h.promptForChannelID(ctx, config.name)
+	if err != nil {
+		return false, "", "", err
+	}
+	return true, token, channelID, nil
+}
+
+func (h *Handler) promptEnableNotifications(
+	ctx context.Context,
+	serviceName string,
+) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		prompt := fmt.Sprintf("Do you want to set up %s notifications? (y/n)", serviceName)
+		return h.inputService.Confirm(ctx, prompt, "n")
+	}
+}
+
+func (h *Handler) promptForToken(
+	ctx context.Context,
+	config notificationConfig,
+) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+		prompt := fmt.Sprintf("Enter %s %s", config.name, config.tokenName)
+		token, err := h.inputService.Prompt(ctx, prompt, "")
+		if err != nil {
+			return "", eris.Wrap(err, "Failed to get token")
+		}
+		return token, nil
+	}
+}
+
+func (h *Handler) promptForChannelID(ctx context.Context, serviceName string) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+		prompt := fmt.Sprintf("Enter %s channel ID", serviceName)
+		channelID, err := h.inputService.Prompt(ctx, prompt, "")
+		if err != nil {
+			return "", eris.Wrap(err, "Failed to get channel ID")
+		}
+		return channelID, nil
+	}
+}
+
+func (h *Handler) inputDiscord(ctx context.Context, project *models.Project) error {
+	enabled, token, channelID, err := h.configureNotifications(ctx, notificationConfig{
+		name:      "Discord",
+		tokenName: "bot token",
+	})
+	if err != nil {
+		return err
+	}
+
+	project.Config.Discord = models.ProjectConfigDiscord{
+		Enabled: enabled,
+		Token:   token,
+		Channel: channelID,
+	}
+	return nil
+}
+
+func (h *Handler) inputSlack(ctx context.Context, project *models.Project) error {
+	enabled, token, channelID, err := h.configureNotifications(ctx, notificationConfig{
+		name:      "Slack",
+		tokenName: "token",
+	})
+	if err != nil {
+		return err
+	}
+
+	project.Config.Slack = models.ProjectConfigSlack{
+		Enabled: enabled,
+		Token:   token,
+		Channel: channelID,
+	}
+	return nil
+}
+
+// chooseRegion displays an interactive menu for selecting one or more AWS regions
+// using the bubbletea TUI library. Returns error if no regions selected after max attempts
+// or context cancellation.
+func (h *Handler) chooseRegion(ctx context.Context, project *models.Project, regions []string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			aborted, err := h.runRegionSelector(ctx, project, regions)
+			if err != nil {
+				printer.Errorln(err.Error())
+				printer.NewLine(1)
+				if aborted {
+					return err
+				}
+				continue
+			}
+			if len(project.Config.Region) > 0 {
+				return nil
+			}
+			printer.NewLine(1)
+			printer.Errorln("At least one region must be selected")
+			printer.Infoln("🔄 Please try again")
+		}
+	}
+}
+
+func (h *Handler) runRegionSelector(ctx context.Context, project *models.Project, regions []string) (bool, error) {
+	if regionSelector == nil {
+		if project.Update {
+			selectedRegions := make(map[int]bool)
+			for i, region := range regions {
+				if slices.Contains(project.Config.Region, region) {
+					selectedRegions[i] = true
+				}
+			}
+			regionSelector = util.NewTeaProgram(multiselect.UpdateMultiselectModel(ctx, regions, selectedRegions))
+		} else {
+			regionSelector = util.NewTeaProgram(multiselect.InitialMultiselectModel(ctx, regions))
+		}
+	}
+	m, err := regionSelector.Run()
+	regionSelector = nil
+	if err != nil {
+		return false, eris.Wrap(err, "failed to run region selector")
+	}
+
+	model, ok := m.(multiselect.Model)
+	if !ok {
+		return false, eris.New("failed to get selected regions")
+	}
+	if model.Aborted {
+		return true, eris.New("Region selection aborted")
+	}
+
+	var selectedRegions []string
+	for i, item := range regions {
+		if model.Selected[i] {
+			selectedRegions = append(selectedRegions, item)
+		}
+	}
+
+	project.Config.Region = selectedRegions
+
+	return false, nil
+}
+
+func (h *Handler) inputAvatarURL(ctx context.Context, project *models.Project) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			avatarURL, err := h.inputService.Prompt(ctx, "Enter avatar URL (Empty Valid)", project.AvatarURL)
+			if err != nil {
+				return eris.Wrap(err, "Failed to get avatar URL")
+			}
+
+			if avatarURL == "" {
+				// No avatar URL provided
+				project.AvatarURL = ""
+				return nil
+			}
+
+			if err := utils.IsValidURL(avatarURL); err != nil {
+				printer.Errorln(err.Error())
+				printer.NewLine(1)
+				project.AvatarURL = ""
+				continue
+			}
+
+			project.AvatarURL = avatarURL
+			return nil
+		}
+	}
+}
+
+func displayProjectDetails(project *models.Project) {
+	printer.NewLine(1)
+	printer.Infoln("Project Details:")
+	printer.Infof("• Name: %s\n", project.Name)
+	printer.Infof("• Slug: %s\n", project.Slug)
+	printer.Infof("• ID: %s\n", project.ID)
+	printer.Infof("• Repository URL: %s\n", project.RepoURL)
+	printer.Infof("• Repository Path: %s\n", project.RepoPath)
+	printer.Infoln("• Regions:")
+	for _, region := range project.Config.Region {
+		printer.Infof("    - %s\n", region)
+	}
+	printer.Infoln("• Discord Configuration:")
+	if project.Config.Discord.Enabled {
+		printer.Infoln("  - Enabled: Yes")
+		printer.Infof("  - Channel ID: %s\n", project.Config.Discord.Channel)
+		printer.Infof("  - Bot Token: %s\n", project.Config.Discord.Token)
+	} else {
+		printer.Infoln("  - Enabled: No")
+	}
+	printer.Infoln("• Slack Configuration:")
+	if project.Config.Slack.Enabled {
+		printer.Infoln("  - Enabled: Yes")
+		printer.Infof("  - Channel ID: %s\n", project.Config.Slack.Channel)
+		printer.Infof("  - Token: %s\n", project.Config.Slack.Token)
+	} else {
+		printer.Infoln("  - Enabled: No")
+	}
+	printer.Infof("• Avatar URL: %s\n", project.AvatarURL)
+}
+
+func printRequiredStepsToCreateProject() {
+	printer.NewLine(1)
+	printer.Headerln(" To create a new project follow these steps ")
+	printer.Infoln("1. Move to the root of your World project.")
+	printer.Infoln("   This is the directory that contains world.toml and the cardinal directory")
+	printer.Infoln("2. Must be within a git repository")
+	printer.Info("3. Use command ")
+	printer.Notificationln("'world project create'")
 }

--- a/cmd/world/project_refactor/delete.go
+++ b/cmd/world/project_refactor/delete.go
@@ -2,10 +2,15 @@ package project
 
 import (
 	"context"
+
+	"pkg.world.dev/world-cli/cmd/internal/models"
 )
 
 //nolint:revive // TODO: implement
-func (h *Handler) Delete(ctx context.Context) error {
+func (h *Handler) Delete(
+	ctx context.Context,
+	state *models.CommandState,
+) error {
 	// TODO: implement
 	return nil
 }

--- a/cmd/world/project_refactor/mock.go
+++ b/cmd/world/project_refactor/mock.go
@@ -15,25 +15,39 @@ type MockHandler struct {
 	mock.Mock
 }
 
-func (m *MockHandler) Create(ctx context.Context, flags *models.CreateProjectFlags, createNew bool,
+func (m *MockHandler) Create(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.CreateProjectFlags,
 ) (models.Project, error) {
-	args := m.Called(ctx, flags, createNew)
+	args := m.Called(ctx, state, flags)
 	return args.Get(0).(models.Project), args.Error(1)
 }
 
-func (m *MockHandler) Switch(ctx context.Context, flags *models.SwitchProjectFlags,
+func (m *MockHandler) Switch(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.SwitchProjectFlags,
+	createNew bool,
 ) (models.Project, error) {
-	args := m.Called(ctx, flags)
+	args := m.Called(ctx, state, flags, createNew)
 	return args.Get(0).(models.Project), args.Error(1)
 }
 
-func (m *MockHandler) Update(ctx context.Context, flags *models.UpdateProjectFlags) error {
-	args := m.Called(ctx, flags)
+func (m *MockHandler) Update(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.UpdateProjectFlags,
+) error {
+	args := m.Called(ctx, state, flags)
 	return args.Error(0)
 }
 
-func (m *MockHandler) Delete(ctx context.Context) error {
-	args := m.Called(ctx)
+func (m *MockHandler) Delete(
+	ctx context.Context,
+	state *models.CommandState,
+) error {
+	args := m.Called(ctx, state)
 	return args.Error(0)
 }
 

--- a/cmd/world/project_refactor/switch.go
+++ b/cmd/world/project_refactor/switch.go
@@ -2,12 +2,126 @@ package project
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
+	"github.com/rotisserie/eris"
+	cmdsetup "pkg.world.dev/world-cli/cmd/internal/controllers/cmd_setup"
 	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/common/printer"
 )
 
-//nolint:revive // TODO: implement
-func (h *Handler) Switch(ctx context.Context, flags *models.SwitchProjectFlags,
+//nolint:gocognit,funlen // Belongs in a single function
+func (h *Handler) Switch(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.SwitchProjectFlags,
+	createNew bool,
 ) (models.Project, error) {
-	return models.Project{}, nil
+	if h.configService.GetConfig().CurrRepoKnown {
+		printer.Errorf("Cannot switch Project, current git working directory belongs to project: %s.",
+			h.configService.GetConfig().CurrProjectName)
+		return models.Project{}, ErrCannotCreateSwitchProject
+	}
+
+	// Get projects from selected organization
+	projects, err := h.apiClient.GetProjects(ctx, h.configService.GetConfig().OrganizationID)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to get projects")
+	}
+
+	if len(projects) == 0 {
+		if createNew {
+			proj, err := h.Create(ctx, state, models.CreateProjectFlags{})
+			if err != nil {
+				return models.Project{}, eris.Wrap(err, "Failed to create project")
+			}
+			return proj, nil
+		}
+		printNoProjectsInOrganization()
+		return models.Project{}, nil
+	}
+
+	// If slug is provided, select the project by slug
+	if flags.Slug != "" {
+		return h.switchBySlug(ctx, projects, flags.Slug)
+	}
+
+	// Display projects as a numbered list
+	printer.NewLine(1)
+	printer.Headerln("   Available Projects   ")
+	for i, proj := range projects {
+		printer.Infof("  %d. %s\n     └─ Slug: %s\n", i+1, proj.Name, proj.Slug)
+	}
+
+	inRepoRoot := false
+	prompt := "Enter project number ('q' to quit)"
+	if createNew {
+		_, _, err = h.PreCreateUpdateValidation()
+		if err != nil { // if in repo root, we can create a new project
+			inRepoRoot = true
+			prompt = "Enter project number ('c' to create new, 'q' to quit)"
+		}
+	}
+
+	for {
+		printer.NewLine(1)
+		input, err := h.inputService.Prompt(ctx, prompt, "")
+		if err != nil {
+			return models.Project{}, eris.Wrap(err, "Failed to prompt")
+		}
+		input = strings.TrimSpace(input)
+		if input == "q" {
+			return models.Project{}, nil
+		}
+
+		if input == "c" && inRepoRoot {
+			proj, err := h.Create(ctx, state, models.CreateProjectFlags{})
+			if err != nil {
+				return models.Project{}, eris.Wrap(err, "Failed to create project")
+			}
+			return proj, nil
+		}
+
+		// Parse selection
+		num, err := strconv.Atoi(input)
+		if err != nil || num < 1 || num > len(projects) {
+			printer.Errorf("Please enter a number between 1 and %d\n", len(projects))
+			continue
+		}
+
+		selectedProject := projects[num-1]
+
+		err = h.saveToConfig(&selectedProject)
+		if err != nil {
+			return models.Project{}, eris.Wrap(err, "selectProject")
+		}
+
+		printer.NewLine(1)
+		printer.Successf("Switched to project: %s\n", selectedProject.Name)
+		return selectedProject, nil
+	}
+}
+
+func (h *Handler) switchBySlug(ctx context.Context, projects []models.Project, slug string) (models.Project, error) {
+	for _, project := range projects {
+		if project.Slug == slug {
+			err := h.saveToConfig(&project)
+			if err != nil {
+				return models.Project{}, eris.Wrap(err, "selectProjectBySlug")
+			}
+			err = h.showProjectList(ctx)
+			if err != nil {
+				return models.Project{}, eris.Wrap(err, "Failed to show project list")
+			}
+			return project, nil
+		}
+	}
+	err := h.showProjectList(ctx)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to show project list")
+	}
+	printer.NewLine(1)
+	printer.Errorln("Project not found in organization under the slug: " + slug)
+	return models.Project{}, cmdsetup.ErrProjectSelectionCanceled
 }

--- a/cmd/world/project_refactor/types.go
+++ b/cmd/world/project_refactor/types.go
@@ -1,9 +1,41 @@
 package project
 
-import "pkg.world.dev/world-cli/cmd/internal/interfaces"
+import (
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
+	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/services/config"
+	"pkg.world.dev/world-cli/cmd/internal/services/input"
+)
+
+var nilUUID = "00000000-0000-0000-0000-000000000000"
 
 // Interface guard.
 var _ interfaces.ProjectHandler = (*Handler)(nil)
 
 type Handler struct {
+	repoClient    repo.ClientInterface
+	configService config.ServiceInterface
+	apiClient     api.ClientInterface
+	inputService  input.ServiceInterface
+}
+
+// notificationConfig holds common notification configuration fields.
+type notificationConfig struct {
+	name      string // "Discord" or "Slack"
+	tokenName string // What to call the token ("bot token" or "token")
+}
+
+func NewHandler(
+	repoClient repo.ClientInterface,
+	configService config.ServiceInterface,
+	apiClient api.ClientInterface,
+	inputService input.ServiceInterface,
+) interfaces.ProjectHandler {
+	return &Handler{
+		repoClient:    repoClient,
+		configService: configService,
+		apiClient:     apiClient,
+		inputService:  inputService,
+	}
 }

--- a/cmd/world/project_refactor/update.go
+++ b/cmd/world/project_refactor/update.go
@@ -7,7 +7,11 @@ import (
 )
 
 //nolint:revive // TODO: implement
-func (h *Handler) Update(ctx context.Context, flags *models.UpdateProjectFlags) error {
+func (h *Handler) Update(
+	ctx context.Context,
+	state *models.CommandState,
+	flags models.UpdateProjectFlags,
+) error {
 	// TODO: implement
 	return nil
 }

--- a/cmd/world/project_refactor/utils.go
+++ b/cmd/world/project_refactor/utils.go
@@ -1,0 +1,161 @@
+package project
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-cli/cmd/internal/clients/api"
+	"pkg.world.dev/world-cli/cmd/internal/clients/repo"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+	"pkg.world.dev/world-cli/cmd/internal/utils"
+	"pkg.world.dev/world-cli/common/printer"
+)
+
+// Get list of projects in selected organization.
+func (h *Handler) getListOfProjects(ctx context.Context) ([]models.Project, error) {
+	selectedOrg, err := h.apiClient.GetOrganizationByID(ctx, h.configService.GetConfig().OrganizationID)
+	if err != nil && !eris.Is(err, api.ErrNoOrganizationID) {
+		return nil, eris.Wrap(err, "Failed to get organization")
+	}
+
+	if selectedOrg.ID == "" {
+		printNoSelectedOrganization()
+		return nil, nil
+	}
+
+	projects, err := h.apiClient.GetProjects(ctx, selectedOrg.ID)
+	if err != nil {
+		return nil, eris.Wrap(err, "Failed to get projects")
+	}
+
+	return projects, nil
+}
+
+// Show list of projects in selected organization.
+func (h *Handler) showProjectList(ctx context.Context) error {
+	projects, err := h.getListOfProjects(ctx)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get projects")
+	}
+
+	if len(projects) == 0 {
+		printNoProjectsInOrganization()
+		return nil
+	}
+
+	selectedProject, err := h.getSelectedProject(ctx)
+	if err != nil {
+		return eris.Wrap(err, "Failed to get selected project")
+	}
+
+	printer.NewLine(1)
+	printer.Headerln("   Project Information   ")
+	if selectedProject.Name == "" {
+		printer.Errorln("No project selected")
+		printer.NewLine(1)
+		printer.Infoln("Use 'world forge project switch' to choose a project")
+	} else {
+		for _, prj := range projects {
+			if prj.ID == selectedProject.ID {
+				printer.Infof("• %s (%s) [SELECTED]\n", prj.Name, prj.Slug)
+			} else {
+				printer.Infof("  %s (%s)\n", prj.Name, prj.Slug)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Get selected project.
+func (h *Handler) getSelectedProject(ctx context.Context) (models.Project, error) {
+	selectedOrg, err := h.apiClient.GetOrganizationByID(ctx, h.configService.GetConfig().OrganizationID)
+	if err != nil && !eris.Is(err, api.ErrNoOrganizationID) {
+		return models.Project{}, eris.Wrap(err, "Failed to get organization")
+	}
+
+	if selectedOrg.ID == "" {
+		printNoSelectedOrganization()
+		return models.Project{}, nil
+	}
+
+	if h.configService.GetConfig().ProjectID == "" {
+		projects, err := h.getListOfProjects(ctx)
+		if err != nil {
+			return models.Project{}, eris.Wrap(err, "Failed to get projects")
+		}
+		if len(projects) == 0 {
+			printNoProjectsInOrganization()
+		}
+		return models.Project{}, nil
+	}
+
+	// Send request
+	project, err := h.apiClient.GetProjectByID(ctx, h.configService.GetConfig().ProjectID)
+	if err != nil {
+		return models.Project{}, eris.Wrap(err, "Failed to get project")
+	}
+
+	// Parse response
+	return project, nil
+}
+
+// PreCreateUpdateValidation returns the repo path and URL, and an error.
+func (h *Handler) PreCreateUpdateValidation() (string, string, error) {
+	repoPath, repoURL, err := h.repoClient.FindGitPathAndURL()
+	if err != nil && !strings.Contains(err.Error(), repo.ErrNotInGitRepository.Error()) {
+		return repoPath, repoURL, eris.Wrap(err, "Failed to find git path and URL")
+	} else if repoURL == "" { // Path is ok as empty, This means it's in repo root.
+		printer.Errorln(" Not in a git repository")
+		return repoPath, repoURL, repo.ErrNotInGitRepository
+	}
+
+	inRoot, err := utils.IsInWorldCardinalRoot()
+	if err != nil {
+		return repoPath, repoURL, eris.Wrap(err, "Failed to check if in World project root")
+	} else if !inRoot {
+		printer.Errorln(" Not in a World project root")
+		return repoPath, repoURL, utils.ErrNotInWorldCardinalRoot
+	}
+
+	return repoPath, repoURL, nil
+}
+
+// Get list of projects in selected organization.
+func (h *Handler) getListOfAvailableRegionsForNewProject(ctx context.Context) ([]string, error) {
+	selectedOrg, err := h.apiClient.GetOrganizationByID(ctx, h.configService.GetConfig().OrganizationID)
+	if err != nil && !eris.Is(err, api.ErrNoOrganizationID) {
+		return nil, eris.Wrap(err, "Failed to get organization")
+	}
+	if selectedOrg.ID == "" {
+		printNoSelectedOrganization()
+		return nil, nil
+	}
+	return h.apiClient.GetListRegions(ctx, selectedOrg.ID, nilUUID)
+}
+
+func printNoProjectsInOrganization() {
+	printer.NewLine(1)
+	printer.Headerln("   No Projects Found   ")
+	printer.Infoln("You don't have any projects in this organization yet.")
+	printRequiredStepsToCreateProject()
+}
+
+func printNoSelectedOrganization() {
+	printer.NewLine(1)
+	printer.Headerln("   No Organization Selected   ")
+	printer.Infoln("You don't have any organization selected.")
+	printer.Info("Use ")
+	printer.Notification("'world organization switch'")
+	printer.Infoln(" to select one!")
+}
+
+func (h *Handler) saveToConfig(project *models.Project) error {
+	h.configService.GetConfig().ProjectID = project.ID
+	err := h.configService.Save()
+	if err != nil {
+		return eris.Wrap(err, "Failed to save project configuration")
+	}
+	return nil
+}


### PR DESCRIPTION


feat: Implement organization and project creation APIs

## Overview

This PR implements the API client methods needed for organization and project creation, along with supporting utilities for slug validation and formatting. It adds error handling for organization and project operations and refactors the handler interfaces to support the new functionality.

## Brief Changelog

- Added organization creation API methods and handlers
- Implemented project creation API methods and handlers
- Added utility functions for slug validation and creation
- Added validation utilities for names, URLs, and repository paths
- Implemented region selection for projects
- Added error handling for organization and project operations
- Updated handler interfaces to support new functionality

## Testing and Verifying

This change can be verified by:
- Creating a new organization through the CLI
- Creating a new project with various configuration options
- Switching between organizations and projects
- Validating that slugs are properly formatted and validated

<!-- greptile_comment -->

## Greptile Summary

Major refactoring of organization and project management commands in the World CLI, introducing improved API client methods, validation, and command setup structure.

- Added comprehensive input validation in `cmd/pkg/utils/validation.go` for names, URLs, and repository paths with proper error handling
- Implemented organization and project creation in API client (`cmd/pkg/clients/api/api.go`) with slug validation and region management
- Standardized handler interfaces in `cmd/pkg/services/cmd_setup/types.go` to use `CommandState` and `context.Context` instead of `CommandContext`
- Implemented interactive project creation flow in `cmd/world/project_refactor/create.go` with support for repository config and notifications
- Added robust slug handling utilities in `cmd/pkg/utils/slug.go` for sanitizing and generating slugs from names



<!-- /greptile_comment -->