### PR TITLE
refactor(AvatarURL): Remove from org & project

### DIFF
--- a/cmd/internal/clients/api/mock.go
+++ b/cmd/internal/clients/api/mock.go
@@ -26,8 +26,8 @@ func (m *MockClient) GetUser(ctx context.Context) (models.User, error) {
 }
 
 // UpdateUser mocks updating user information.
-func (m *MockClient) UpdateUser(ctx context.Context, name, email, avatarURL string) error {
-	args := m.Called(ctx, name, email, avatarURL)
+func (m *MockClient) UpdateUser(ctx context.Context, name, email string) error {
+	args := m.Called(ctx, name, email)
 	return args.Error(0)
 }
 
@@ -88,9 +88,9 @@ func (m *MockClient) GetProjectByID(ctx context.Context, orgID, projID string) (
 // CreateOrganization mocks creating an organization.
 func (m *MockClient) CreateOrganization(
 	ctx context.Context,
-	name, slug, avatarURL string,
+	name, slug string,
 ) (models.Organization, error) {
-	args := m.Called(ctx, name, slug, avatarURL)
+	args := m.Called(ctx, name, slug)
 	return args.Get(0).(models.Organization), args.Error(1)
 }
 

--- a/cmd/internal/clients/api/organization.go
+++ b/cmd/internal/clients/api/organization.go
@@ -40,11 +40,10 @@ func (c *Client) GetOrganizationByID(ctx context.Context, id string) (models.Org
 }
 
 // CreateOrganization creates a new organization.
-func (c *Client) CreateOrganization(ctx context.Context, name, slug, avatarURL string) (models.Organization, error) {
+func (c *Client) CreateOrganization(ctx context.Context, name, slug string) (models.Organization, error) {
 	payload := map[string]string{
-		"name":       name,
-		"slug":       slug,
-		"avatar_url": avatarURL,
+		"name": name,
+		"slug": slug,
 	}
 
 	body, err := c.sendRequest(ctx, post, "/api/organization", payload)

--- a/cmd/internal/clients/api/project.go
+++ b/cmd/internal/clients/api/project.go
@@ -75,7 +75,6 @@ func (c *Client) CreateProject(ctx context.Context, orgID string, project models
 		"repo_path":  project.RepoPath,
 		"org_id":     orgID,
 		"config":     project.Config,
-		"avatar_url": project.AvatarURL,
 	}
 
 	endpoint := fmt.Sprintf("/api/organization/%s/project", orgID)
@@ -108,7 +107,6 @@ func (c *Client) UpdateProject(
 		"repo_token": project.RepoToken,
 		"repo_path":  project.RepoPath,
 		"config":     project.Config,
-		"avatar_url": project.AvatarURL,
 	})
 	if err != nil {
 		return models.Project{}, eris.Wrap(err, "Failed to update project")

--- a/cmd/internal/clients/api/types.go
+++ b/cmd/internal/clients/api/types.go
@@ -57,7 +57,7 @@ type ClientInterface interface {
 	// GetUser retrieves the current authenticated user's information
 	GetUser(ctx context.Context) (models.User, error)
 	// UpdateUser updates the current user's profile information
-	UpdateUser(ctx context.Context, name, email, avatarURL string) error
+	UpdateUser(ctx context.Context, name, email string) error
 	// InviteUserToOrganization invites a user to join an organization with a specific role
 	InviteUserToOrganization(ctx context.Context, orgID, userEmail, role string) error
 	// UpdateUserRoleInOrganization updates a user's role within an organization
@@ -76,7 +76,7 @@ type ClientInterface interface {
 	// GetOrganizationByID retrieves a specific organization by its ID
 	GetOrganizationByID(ctx context.Context, id string) (models.Organization, error)
 	// CreateOrganization creates a new organization
-	CreateOrganization(ctx context.Context, name, slug, avatarURL string) (models.Organization, error)
+	CreateOrganization(ctx context.Context, name, slug string) (models.Organization, error)
 
 	// ========================================
 	// Project Management Methods

--- a/cmd/internal/clients/api/user.go
+++ b/cmd/internal/clients/api/user.go
@@ -8,9 +8,8 @@ import (
 )
 
 var (
-	ErrNoUserEmail     = eris.New("user email is required")
-	ErrNoUserName      = eris.New("user name is required")
-	ErrNoUserAvatarURL = eris.New("user avatar URL is required")
+	ErrNoUserEmail = eris.New("user email is required")
+	ErrNoUserName  = eris.New("user name is required")
 )
 
 // ========================================
@@ -27,21 +26,17 @@ func (c *Client) GetUser(ctx context.Context) (models.User, error) {
 }
 
 // UpdateUser updates the current user information.
-func (c *Client) UpdateUser(ctx context.Context, name, email, avatarURL string) error {
+func (c *Client) UpdateUser(ctx context.Context, name, email string) error {
 	if email == "" {
 		return ErrNoUserEmail
 	}
 	if name == "" {
 		return ErrNoUserName
 	}
-	if avatarURL == "" {
-		return ErrNoUserAvatarURL
-	}
 
 	payload := models.User{
-		Name:      name,
-		Email:     email,
-		AvatarURL: avatarURL,
+		Name:  name,
+		Email: email,
 	}
 
 	_, err := c.sendRequest(ctx, put, "/api/user", payload)

--- a/cmd/internal/models/organization.go
+++ b/cmd/internal/models/organization.go
@@ -10,13 +10,11 @@ type Organization struct {
 	Deleted          bool   `json:"deleted"`
 	DeletedTime      string `json:"deleted_time"`
 	BaseShardAddress string `json:"base_shard_address"`
-	AvatarURL        string `json:"avatar_url"`
 }
 
 type CreateOrganizationFlags struct {
-	Name      string
-	Slug      string
-	AvatarURL string
+	Name string
+	Slug string
 }
 
 type SwitchOrganizationFlags struct {

--- a/cmd/internal/models/project.go
+++ b/cmd/internal/models/project.go
@@ -15,7 +15,6 @@ type Project struct {
 	RepoPath     string        `json:"repo_path"`
 	DeploySecret string        `json:"deploy_secret,omitempty"`
 	Config       ProjectConfig `json:"config"`
-	AvatarURL    string        `json:"avatar_url"`
 
 	Update bool `json:"-"`
 }
@@ -39,9 +38,8 @@ type ProjectConfigSlack struct {
 }
 
 type CreateProjectFlags struct {
-	Name      string
-	Slug      string
-	AvatarURL string
+	Name string
+	Slug string
 }
 
 type SwitchProjectFlags struct {
@@ -49,7 +47,6 @@ type SwitchProjectFlags struct {
 }
 
 type UpdateProjectFlags struct {
-	Name      string
-	Slug      string
-	AvatarURL string
+	Name string
+	Slug string
 }

--- a/cmd/internal/models/user.go
+++ b/cmd/internal/models/user.go
@@ -1,10 +1,9 @@
 package models
 
 type User struct {
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name"`
-	Email     string `json:"email"`
-	AvatarURL string `json:"avatar_url"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 type InviteUserToOrganizationFlags struct {
@@ -18,6 +17,5 @@ type ChangeUserRoleInOrganizationFlags struct {
 }
 
 type UpdateUserFlags struct {
-	Name      string
-	AvatarURL string
+	Name string
 }

--- a/cmd/world/cloud/cloud_internal_test.go
+++ b/cmd/world/cloud/cloud_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"pkg.world.dev/world-cli/cmd/internal/clients/api"
@@ -703,7 +702,7 @@ func (s *CloudTestSuite) TestDeployCmd_Run() {
 
 	// Test that the command exists and has expected fields
 	s.NotNil(cmd)
-	assert.False(s.T(), cmd.Force)
+	s.False(cmd.Force)
 }
 
 func (s *CloudTestSuite) TestStatusCmd_Run() {

--- a/cmd/world/organization/create.go
+++ b/cmd/world/organization/create.go
@@ -15,7 +15,7 @@ const MaxOrgNameLen = 50
 
 //nolint:gocognit,funlen // Belongs in a single function
 func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFlags) (models.Organization, error) {
-	var orgName, orgSlug, orgAvatarURL string
+	var orgName, orgSlug string
 	var err error
 
 	for {
@@ -62,40 +62,11 @@ func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFla
 			break
 		}
 
-		// Get and validate organization avatar URL
-		for {
-			orgAvatarURL, err = h.inputService.Prompt(
-				ctx,
-				"Enter organization avatar URL (Empty Valid)",
-				flags.AvatarURL,
-			)
-			if err != nil {
-				return models.Organization{}, eris.Wrap(err, "Failed to get organization avatar URL")
-			}
-
-			if orgAvatarURL == "" {
-				break
-			}
-
-			if err := utils.IsValidURL(orgAvatarURL); err != nil {
-				printer.Errorln(err.Error())
-				printer.NewLine(1)
-				continue
-			}
-
-			break
-		}
-
 		// Show confirmation
 		printer.NewLine(1)
 		printer.Headerln("  Organization Details  ")
 		printer.Infof("Name: %s\n", orgName)
 		printer.Infof("Slug: %s\n", orgSlug)
-		if orgAvatarURL != "" {
-			printer.Infof("Avatar URL: %s\n", orgAvatarURL)
-		} else {
-			printer.Infoln("Avatar URL: None")
-		}
 
 		// Get confirmation
 		printer.NewLine(1)
@@ -104,7 +75,7 @@ func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFla
 			return models.Organization{}, eris.Wrap(err, "Failed to get confirmation")
 		}
 		if confirm {
-			org, err := h.apiClient.CreateOrganization(ctx, orgName, orgSlug, orgAvatarURL)
+			org, err := h.apiClient.CreateOrganization(ctx, orgName, orgSlug)
 			if err != nil {
 				if strings.Contains(err.Error(), api.ErrOrganizationSlugAlreadyExists.Error()) {
 					printer.Errorf(

--- a/cmd/world/organization/organization.go
+++ b/cmd/world/organization/organization.go
@@ -21,7 +21,6 @@ type CreateCmd struct {
 	Dependencies cmdsetup.Dependencies `kong:"-"`
 	Name         string                `         flag:"" help:"The name of the organization"`
 	Slug         string                `         flag:"" help:"The slug of the organization"`
-	AvatarURL    string                `         flag:"" help:"The avatar URL of the organization" type:"url"`
 }
 
 func (c *CreateCmd) Run() error {
@@ -32,9 +31,8 @@ func (c *CreateCmd) Run() error {
 	}
 
 	flags := models.CreateOrganizationFlags{
-		Name:      c.Name,
-		Slug:      c.Slug,
-		AvatarURL: c.AvatarURL,
+		Name: c.Name,
+		Slug: c.Slug,
 	}
 
 	return cmdsetup.WithSetup(c.Context, c.Dependencies, req, func(_ models.CommandState) error {

--- a/cmd/world/organization/organization_test.go
+++ b/cmd/world/organization/organization_test.go
@@ -40,10 +40,9 @@ func (s *OrganizationTestSuite) createTestHandler() (
 // Test fixtures.
 func (s *OrganizationTestSuite) createTestOrganization() models.Organization {
 	return models.Organization{
-		ID:        "org-123",
-		Name:      "Test Organization",
-		Slug:      "test_org",
-		AvatarURL: "https://example.com/avatar.png",
+		ID:   "org-123",
+		Name: "Test Organization",
+		Slug: "test_org",
 	}
 }
 
@@ -63,9 +62,8 @@ func (s *OrganizationTestSuite) TestHandler_Create_Success() {
 	ctx := context.Background()
 	testOrg := s.createTestOrganization()
 	flags := models.CreateOrganizationFlags{
-		Name:      "Test Organization",
-		Slug:      "test-org",
-		AvatarURL: "https://example.com/avatar.png",
+		Name: "Test Organization",
+		Slug: "test-org",
 	}
 
 	// Mock input interactions
@@ -73,12 +71,10 @@ func (s *OrganizationTestSuite) TestHandler_Create_Success() {
 		Return("Test Organization", nil)
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "test_org").
 		Return("test_org", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("https://example.com/avatar.png", nil)
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
 
 	// Mock API call
-	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "test_org", "https://example.com/avatar.png").
+	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "test_org").
 		Return(testOrg, nil)
 
 	// Mock config operations
@@ -108,7 +104,6 @@ func (s *OrganizationTestSuite) TestHandler_Create_InvalidName() {
 	mockInputService.On("Prompt", ctx, "Enter organization name", "").Return("Good Organization", nil).Once()
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "goodorganizatio").
 		Return("goodorganizatio", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil)
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
 
 	testOrg := models.Organization{
@@ -117,7 +112,7 @@ func (s *OrganizationTestSuite) TestHandler_Create_InvalidName() {
 		Slug: "goodorganizatio",
 	}
 
-	mockAPIClient.On("CreateOrganization", ctx, "Good Organization", "goodorganizatio", "").Return(testOrg, nil)
+	mockAPIClient.On("CreateOrganization", ctx, "Good Organization", "goodorganizatio").Return(testOrg, nil)
 	mockConfigService.On("GetConfig").Return(s.createTestConfig())
 	mockConfigService.On("Save").Return(nil)
 
@@ -146,7 +141,6 @@ func (s *OrganizationTestSuite) TestHandler_Create_UserDeclinesThenAccepts() {
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "testorganizatio").
 		Return("testorganizatio", nil).
 		Once()
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil).Once()
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").
 		Return(false, nil).
 		Once()
@@ -158,7 +152,6 @@ func (s *OrganizationTestSuite) TestHandler_Create_UserDeclinesThenAccepts() {
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "finalorganizati").
 		Return("finalorganizati", nil).
 		Once()
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil).Once()
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").
 		Return(true, nil).
 		Once()
@@ -168,7 +161,7 @@ func (s *OrganizationTestSuite) TestHandler_Create_UserDeclinesThenAccepts() {
 		Name: "Final Organization",
 		Slug: "finalorganizati",
 	}
-	mockAPIClient.On("CreateOrganization", ctx, "Final Organization", "finalorganizati", "").Return(finalOrg, nil)
+	mockAPIClient.On("CreateOrganization", ctx, "Final Organization", "finalorganizati").Return(finalOrg, nil)
 	mockConfigService.On("GetConfig").Return(s.createTestConfig())
 	mockConfigService.On("Save").Return(nil)
 
@@ -196,12 +189,11 @@ func (s *OrganizationTestSuite) TestHandler_Create_SlugAlreadyExists() {
 		Return("Test Organization", nil)
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "test_org").
 		Return("test_org", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil)
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
 
 	// API call fails with slug already exists error - function returns error immediately
 	slugExistsErr := errors.New("organization slug already exists")
-	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "test_org", "").
+	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "test_org").
 		Return(models.Organization{}, slugExistsErr)
 
 	// No config operations expected since the method returns error immediately
@@ -437,7 +429,6 @@ func (s *OrganizationTestSuite) TestHandler_PromptForSwitch_CreateNew() {
 	// Mock inputs for create flow
 	mockInputService.On("Prompt", ctx, "Enter organization name", "").Return("New Organization", nil)
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "neworganization").Return("neworganization", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil)
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
 
 	newOrg := models.Organization{
@@ -447,7 +438,7 @@ func (s *OrganizationTestSuite) TestHandler_PromptForSwitch_CreateNew() {
 	}
 
 	// Mock API calls
-	mockAPIClient.On("CreateOrganization", ctx, "New Organization", "neworganization", "").Return(newOrg, nil)
+	mockAPIClient.On("CreateOrganization", ctx, "New Organization", "neworganization").Return(newOrg, nil)
 
 	// Mock config service
 	mockConfigService.On("GetConfig").Return(s.createTestConfig())
@@ -543,11 +534,10 @@ func (s *OrganizationTestSuite) TestHandler_Create_SaveError() {
 	mockInputService.On("Prompt", ctx, "Enter organization name", "Test Organization").
 		Return("Test Organization", nil)
 	mockInputService.On("Prompt", ctx, "Enter organization slug", "testorganizatio").Return("testorganizatio", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").Return("", nil)
 	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
 
 	// Mock API call
-	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "testorganizatio", "").Return(testOrg, nil)
+	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "testorganizatio").Return(testOrg, nil)
 
 	// Mock config operations - save fails
 	mockConfigService.On("GetConfig").Return(s.createTestConfig())
@@ -559,47 +549,6 @@ func (s *OrganizationTestSuite) TestHandler_Create_SaveError() {
 	s.Require().Error(err)
 	s.Contains(err.Error(), "Failed to save organization")
 	s.Equal(models.Organization{}, result)
-	mockInputService.AssertExpectations(s.T())
-	mockAPIClient.AssertExpectations(s.T())
-	mockConfigService.AssertExpectations(s.T())
-}
-
-func (s *OrganizationTestSuite) TestHandler_Create_EmptyAvatarURL() {
-	s.T().Parallel()
-
-	handler, _, mockInputService, mockAPIClient, mockConfigService := s.createTestHandler()
-	ctx := context.Background()
-	testOrg := models.Organization{
-		ID:        "org-123",
-		Name:      "Test Organization",
-		Slug:      "test_org",
-		AvatarURL: "",
-	}
-	flags := models.CreateOrganizationFlags{
-		Name: "Test Organization",
-		Slug: "test-org",
-	}
-
-	// Mock input interactions
-	mockInputService.On("Prompt", ctx, "Enter organization name", "Test Organization").
-		Return("Test Organization", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization slug", "test_org").
-		Return("test_org", nil)
-	mockInputService.On("Prompt", ctx, "Enter organization avatar URL (Empty Valid)", "").
-		Return("", nil)
-	mockInputService.On("Confirm", ctx, "Create organization with these details? (Y/n)", "n").Return(true, nil)
-
-	// Mock API call
-	mockAPIClient.On("CreateOrganization", ctx, "Test Organization", "test_org", "").Return(testOrg, nil)
-
-	// Mock config operations
-	mockConfigService.On("GetConfig").Return(s.createTestConfig())
-	mockConfigService.On("Save").Return(nil)
-
-	result, err := handler.Create(ctx, flags)
-
-	s.Require().NoError(err)
-	s.Equal(testOrg, result)
 	mockInputService.AssertExpectations(s.T())
 	mockAPIClient.AssertExpectations(s.T())
 	mockConfigService.AssertExpectations(s.T())

--- a/cmd/world/project/create.go
+++ b/cmd/world/project/create.go
@@ -46,12 +46,11 @@ func (h *Handler) Create(
 	printer.Headerln("   Project Creation   ")
 
 	p := models.Project{
-		Name:      flags.Name,
-		Slug:      flags.Slug,
-		AvatarURL: flags.AvatarURL,
-		RepoPath:  repoPath,
-		RepoURL:   repoURL,
-		Update:    false,
+		Name:     flags.Name,
+		Slug:     flags.Slug,
+		RepoPath: repoPath,
+		RepoURL:  repoURL,
+		Update:   false,
 	}
 	err = h.getSetupInput(ctx, &p, regions)
 	if err != nil {
@@ -132,11 +131,6 @@ func (h *Handler) getSetupInput(ctx context.Context, project *models.Project, re
 	err = h.inputSlack(ctx, project)
 	if err != nil {
 		return eris.Wrap(err, "Failed to input slack")
-	}
-
-	err = h.inputAvatarURL(ctx, project)
-	if err != nil {
-		return eris.Wrap(err, "Failed to input avatar URL")
 	}
 
 	return nil
@@ -486,36 +480,6 @@ func (h *Handler) inputSlack(ctx context.Context, project *models.Project) error
 	return nil
 }
 
-func (h *Handler) inputAvatarURL(ctx context.Context, project *models.Project) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			avatarURL, err := h.inputService.Prompt(ctx, "Enter avatar URL (Empty Valid)", project.AvatarURL)
-			if err != nil {
-				return eris.Wrap(err, "Failed to get avatar URL")
-			}
-
-			if avatarURL == "" {
-				// No avatar URL provided
-				project.AvatarURL = ""
-				return nil
-			}
-
-			if err := utils.IsValidURL(avatarURL); err != nil {
-				printer.Errorln(err.Error())
-				printer.NewLine(1)
-				project.AvatarURL = ""
-				continue
-			}
-
-			project.AvatarURL = avatarURL
-			return nil
-		}
-	}
-}
-
 func displayProjectDetails(project *models.Project) {
 	printer.NewLine(1)
 	printer.Infoln("Project Details:")
@@ -544,7 +508,6 @@ func displayProjectDetails(project *models.Project) {
 	} else {
 		printer.Infoln("  - Enabled: No")
 	}
-	printer.Infof("• Avatar URL: %s\n", project.AvatarURL)
 }
 
 func printRequiredStepsToCreateProject() {

--- a/cmd/world/project/project.go
+++ b/cmd/world/project/project.go
@@ -23,7 +23,6 @@ type CreateCmd struct {
 	Dependencies cmdsetup.Dependencies `kong:"-"`
 	Name         string                `         flag:"" help:"The name of the project"`
 	Slug         string                `         flag:"" help:"The slug of the project"`
-	AvatarURL    string                `         flag:"" help:"The avatar URL of the project" type:"url"`
 }
 
 func (c *CreateCmd) Run() error {
@@ -34,9 +33,8 @@ func (c *CreateCmd) Run() error {
 	}
 
 	flags := models.CreateProjectFlags{
-		Name:      c.Name,
-		Slug:      c.Slug,
-		AvatarURL: c.AvatarURL,
+		Name: c.Name,
+		Slug: c.Slug,
 	}
 
 	return cmdsetup.WithSetup(c.Context, c.Dependencies, req, func(_ models.CommandState) error {
@@ -84,9 +82,8 @@ func (c *UpdateCmd) Run() error {
 	}
 
 	flags := models.UpdateProjectFlags{
-		Name:      c.Name,
-		Slug:      c.Slug,
-		AvatarURL: c.AvatarURL,
+		Name: c.Name,
+		Slug: c.Slug,
 	}
 
 	return cmdsetup.WithSetup(c.Context, c.Dependencies, req, func(state models.CommandState) error {

--- a/cmd/world/project/project_test.go
+++ b/cmd/world/project/project_test.go
@@ -82,7 +82,6 @@ func (s *ProjectTestSuite) createTestProject() models.Project {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "https://example.com/avatar.png",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "token123",
@@ -138,9 +137,8 @@ func (s *ProjectTestSuite) TestHandler_Create_Success() {
 	testProject := s.createTestProject()
 	testOrg := s.createTestOrganization()
 	flags := models.CreateProjectFlags{
-		Name:      "Test Project",
-		Slug:      "test_project",
-		AvatarURL: "https://example.com/avatar.png",
+		Name: "Test Project",
+		Slug: "test_project",
 	}
 
 	// Mock config service
@@ -170,8 +168,6 @@ func (s *ProjectTestSuite) TestHandler_Create_Success() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("https://example.com/avatar.png", nil)
 
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
@@ -182,7 +178,6 @@ func (s *ProjectTestSuite) TestHandler_Create_Success() {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "https://example.com/avatar.png",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "", // Empty because repo validation succeeded without token
@@ -729,8 +724,6 @@ func (s *ProjectTestSuite) TestHandler_Create_SlugAlreadyExists() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
@@ -745,7 +738,6 @@ func (s *ProjectTestSuite) TestHandler_Create_SlugAlreadyExists() {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -792,9 +784,8 @@ func (s *ProjectTestSuite) TestHandler_Update_Success() {
 	ctx := context.Background()
 	testProject := s.createTestProject()
 	flags := models.UpdateProjectFlags{
-		Name:      "Updated Project",
-		Slug:      "updated_project",
-		AvatarURL: "https://example.com/new_avatar.png",
+		Name: "Updated Project",
+		Slug: "updated_project",
 	}
 
 	// Mock PreCreateUpdateValidation
@@ -821,8 +812,6 @@ func (s *ProjectTestSuite) TestHandler_Update_Success() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/new_avatar.png").
-		Return("https://example.com/new_avatar.png", nil)
 
 	// Mock repo validation - first tries public (empty token), then prompts for token
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").
@@ -838,7 +827,6 @@ func (s *ProjectTestSuite) TestHandler_Update_Success() {
 	updatedProject := testProject
 	updatedProject.Name = "Updated Project"
 	updatedProject.Slug = "updated_project"
-	updatedProject.AvatarURL = "https://example.com/new_avatar.png"
 	updatedProject.Update = true
 	updatedProject.Config.Region = []string{"us-east-1"}
 
@@ -874,9 +862,8 @@ func (s *ProjectTestSuite) TestHandler_Update_SlugAlreadyExists() {
 	ctx := context.Background()
 	testProject := s.createTestProject()
 	flags := models.UpdateProjectFlags{
-		Name:      "Updated Project",
-		Slug:      "existing_slug",
-		AvatarURL: "https://example.com/avatar.png", // Set avatar URL to match the mock expectation
+		Name: "Updated Project",
+		Slug: "existing_slug",
 	}
 
 	// Mock PreCreateUpdateValidation
@@ -903,8 +890,6 @@ func (s *ProjectTestSuite) TestHandler_Update_SlugAlreadyExists() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("https://example.com/avatar.png", nil)
 
 	// Mock repo validation - first tries public (empty token), then prompts for token
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").
@@ -983,8 +968,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_EnableCreation_NoProjects() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
@@ -999,7 +982,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_EnableCreation_NoProjects() {
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1009,7 +991,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_EnableCreation_NoProjects() {
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1288,8 +1269,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_CreateOption_InRepoRoot() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
@@ -1304,7 +1283,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_CreateOption_InRepoRoot() {
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1314,7 +1292,6 @@ func (s *ProjectTestSuite) TestHandler_Switch_CreateOption_InRepoRoot() {
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1390,8 +1367,6 @@ func (s *ProjectTestSuite) TestHandler_HandleSwitch_NoProjects_CreateConfirmed()
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
@@ -1406,7 +1381,6 @@ func (s *ProjectTestSuite) TestHandler_HandleSwitch_NoProjects_CreateConfirmed()
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1416,7 +1390,6 @@ func (s *ProjectTestSuite) TestHandler_HandleSwitch_NoProjects_CreateConfirmed()
 		Name:      "New Project",
 		Slug:      "new_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1494,8 +1467,6 @@ func (s *ProjectTestSuite) TestHandler_Create_InvalidURL() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation - first for invalid URL (with https:// prepended), then for valid URL
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://invalid-url", "").
@@ -1519,7 +1490,6 @@ func (s *ProjectTestSuite) TestHandler_Create_InvalidURL() {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1607,9 +1577,6 @@ func (s *ProjectTestSuite) TestHandler_Create_WithNotifications() {
 	mockInputService.On("Prompt", ctx, "Enter Slack channel ID", "").
 		Return("slack-channel-123", nil)
 
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
-
 	// Mock repo validation
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
 	mockRepoClient.On("ValidateRepoPath", ctx, "https://github.com/test/repo", "", "cardinal").Return(nil)
@@ -1622,7 +1589,6 @@ func (s *ProjectTestSuite) TestHandler_Create_WithNotifications() {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "",
@@ -1650,101 +1616,6 @@ func (s *ProjectTestSuite) TestHandler_Create_WithNotifications() {
 	testProject.Config.Slack.Token = "slack-token-123"
 	testProject.Config.Slack.Channel = "slack-channel-123"
 
-	mockAPIClient.On("CreateProject", ctx, "org-123", expectedProject).Return(testProject, nil)
-
-	result, err := handler.Create(ctx, flags)
-
-	s.Require().NoError(err)
-	s.Equal(testProject, result)
-	mockRepoClient.AssertExpectations(s.T())
-	mockConfigService.AssertExpectations(s.T())
-	mockAPIClient.AssertExpectations(s.T())
-	mockInputService.AssertExpectations(s.T())
-}
-
-func (s *ProjectTestSuite) TestHandler_Create_InvalidAvatarURL() {
-	// Remove s.T().Parallel() to avoid race conditions with directory changes
-
-	// Setup World project directory structure and change to it
-	tmpDir := s.setupWorldProjectDir()
-	originalDir, err := os.Getwd()
-	s.Require().NoError(err)
-	s.T().Cleanup(func() {
-		os.Chdir(originalDir)
-	})
-	err = os.Chdir(tmpDir)
-	s.Require().NoError(err)
-
-	handler, mockRepoClient, mockConfigService, mockAPIClient, mockInputService := s.createTestHandler()
-	ctx := context.Background()
-	flags := models.CreateProjectFlags{
-		Name: "Test Project",
-	}
-
-	// Mock config service
-	cfg := s.createTestConfig()
-	cfg.CurrRepoKnown = false
-	mockConfigService.On("GetConfig").Return(cfg)
-	mockConfigService.On("Save").Return(nil)
-
-	// Mock PreCreateUpdateValidation
-	mockRepoClient.On("FindGitPathAndURL").Return("cardinal", "https://github.com/test/repo", nil)
-
-	// Mock API calls
-	mockAPIClient.On("GetListRegions", ctx, "org-123", "00000000-0000-0000-0000-000000000000").
-		Return([]string{"us-east-1"}, nil)
-	mockAPIClient.On("GetOrganizationByID", ctx, "org-123").Return(s.createTestOrganization(), nil)
-
-	// Mock input interactions
-	mockInputService.On("Prompt", ctx, "Enter project name", "Test Project").
-		Return("Test Project", nil)
-	mockInputService.On("Prompt", ctx, "Slug", "test_project").
-		Return("test_project", nil)
-	mockInputService.On("Prompt", ctx, "Enter Repository URL", "https://github.com/test/repo").
-		Return("https://github.com/test/repo", nil)
-	mockInputService.On("Prompt", ctx, "Enter path to Cardinal within Repo (Empty Valid)", "cardinal").
-		Return("cardinal", nil)
-	mockInputService.On("Confirm", ctx, "Do you want to set up Discord notifications? (y/n)", "n").
-		Return(false, nil)
-	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
-		Return(false, nil)
-
-	// Invalid avatar URL first, then valid empty
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("invalid-url", nil).Once()
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil).Once()
-
-	// Mock repo validation
-	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").Return(nil)
-	mockRepoClient.On("ValidateRepoPath", ctx, "https://github.com/test/repo", "", "cardinal").Return(nil)
-
-	// Mock API calls
-	mockAPIClient.On("CheckProjectSlugIsTaken", ctx, "org-123", "00000000-0000-0000-0000-000000000000", "test_project").
-		Return(nil)
-
-	expectedProject := models.Project{
-		Name:      "Test Project",
-		Slug:      "test_project",
-		OrgID:     "org-123",
-		AvatarURL: "",
-		RepoURL:   "https://github.com/test/repo",
-		RepoPath:  "cardinal",
-		RepoToken: "",
-		Update:    false,
-		Config: models.ProjectConfig{
-			Region: []string{"us-east-1"},
-			Discord: models.ProjectConfigDiscord{
-				Enabled: false,
-			},
-			Slack: models.ProjectConfigSlack{
-				Enabled: false,
-			},
-		},
-	}
-
-	testProject := s.createTestProject()
-	testProject.AvatarURL = ""
 	mockAPIClient.On("CreateProject", ctx, "org-123", expectedProject).Return(testProject, nil)
 
 	result, err := handler.Create(ctx, flags)
@@ -1803,8 +1674,6 @@ func (s *ProjectTestSuite) TestHandler_Create_PublicTokenSelection() {
 		Return(false, nil)
 	mockInputService.On("Confirm", ctx, "Do you want to set up Slack notifications? (y/n)", "n").
 		Return(false, nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "").
-		Return("", nil)
 
 	// Mock repo validation - first fails (private), user selects "public", second validation succeeds
 	mockRepoClient.On("ValidateRepoToken", ctx, "https://github.com/test/repo", "").
@@ -1823,7 +1692,6 @@ func (s *ProjectTestSuite) TestHandler_Create_PublicTokenSelection() {
 		Name:      "Test Project",
 		Slug:      "test_project",
 		OrgID:     "org-123",
-		AvatarURL: "",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
 		RepoToken: "", // Empty because "public" was selected

--- a/cmd/world/project/update.go
+++ b/cmd/world/project/update.go
@@ -36,7 +36,6 @@ func (h *Handler) Update(
 	project.Update = true
 	project.Name = flags.Name
 	project.Slug = flags.Slug
-	project.AvatarURL = flags.AvatarURL
 	project.RepoPath = repoPath
 	project.RepoURL = repoURL
 

--- a/cmd/world/root/login.go
+++ b/cmd/world/root/login.go
@@ -128,7 +128,7 @@ func (h *Handler) handleArgusIDPostLogin(ctx context.Context) error {
 
 	// Update user email if it's different from the JWT token
 	if user.Email != h.configService.GetConfig().Credential.Email {
-		err = h.apiClient.UpdateUser(ctx, user.Name, user.Email, user.AvatarURL)
+		err = h.apiClient.UpdateUser(ctx, user.Name, user.Email)
 		if err != nil {
 			return eris.Wrap(err, "Failed to update user email")
 		}

--- a/cmd/world/root/root_test.go
+++ b/cmd/world/root/root_test.go
@@ -101,10 +101,9 @@ func (s *RootTestSuite) TestLogin_Success() {
 	}
 
 	user := models.User{
-		ID:        "12345",
-		Name:      "John Doe",
-		Email:     "john.updated@example.com", // Different from JWT email to trigger UpdateUser
-		AvatarURL: "https://example.com/avatar.jpg",
+		ID:    "12345",
+		Name:  "John Doe",
+		Email: "john.updated@example.com", // Different from JWT email to trigger UpdateUser
 	}
 
 	setupState := models.CommandState{
@@ -126,7 +125,7 @@ func (s *RootTestSuite) TestLogin_Success() {
 	mockAPIClient.On("SetAuthToken", mock.AnythingOfType("string")).Return()
 	mockAPIClient.On("GetUser", mock.Anything).Return(user, nil)
 	mockAPIClient.On(
-		"UpdateUser", mock.Anything, "John Doe", "john.updated@example.com", "https://example.com/avatar.jpg").
+		"UpdateUser", mock.Anything, "John Doe", "john.updated@example.com").
 		Return(nil)
 
 	// Mock config operations
@@ -284,10 +283,9 @@ func (s *RootTestSuite) TestLogin_SetupCommandStateFails() {
 	}
 
 	user := models.User{
-		ID:        "12345",
-		Name:      "John Doe",
-		Email:     "john@example.com",
-		AvatarURL: "https://example.com/avatar.jpg",
+		ID:    "12345",
+		Name:  "John Doe",
+		Email: "john@example.com",
 	}
 
 	// Mock API calls
@@ -296,7 +294,7 @@ func (s *RootTestSuite) TestLogin_SetupCommandStateFails() {
 	mockAPIClient.On("GetLoginToken", mock.Anything, loginLink.CallBackURL).Return(loginToken, nil)
 	mockAPIClient.On("SetAuthToken", mock.AnythingOfType("string")).Return()
 	mockAPIClient.On("GetUser", mock.Anything).Return(user, nil)
-	mockAPIClient.On("UpdateUser", mock.Anything, user.Name, user.Email, user.AvatarURL).Return(nil)
+	mockAPIClient.On("UpdateUser", mock.Anything, user.Name, user.Email).Return(nil)
 
 	// Mock config operations
 	configObj := &config.Config{

--- a/cmd/world/user/update.go
+++ b/cmd/world/user/update.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-cli/cmd/internal/models"
-	"pkg.world.dev/world-cli/cmd/internal/utils"
 	"pkg.world.dev/world-cli/common/printer"
 )
 
@@ -28,16 +27,7 @@ func (h *Handler) Update(ctx context.Context, flags models.UpdateUserFlags) erro
 		return eris.Wrap(err, "Failed to input user name")
 	}
 
-	// prompt for avatar url
-	if flags.AvatarURL == "" {
-		flags.AvatarURL = currentUser.AvatarURL
-	}
-	flags.AvatarURL, err = h.inputUserAvatarURL(ctx, flags.AvatarURL)
-	if err != nil {
-		return eris.Wrap(err, "Failed to input user avatar URL")
-	}
-
-	err = h.apiClient.UpdateUser(ctx, flags.Name, currentUser.Email, flags.AvatarURL)
+	err = h.apiClient.UpdateUser(ctx, flags.Name, currentUser.Email)
 	if err != nil {
 		return eris.Wrap(err, "Failed to update user")
 	}
@@ -65,29 +55,6 @@ func (h *Handler) inputUserName(ctx context.Context, currentUserName string) (st
 				continue
 			}
 			return name, nil
-		}
-	}
-}
-
-func (h *Handler) inputUserAvatarURL(ctx context.Context, currentUserAvatarURL string) (string, error) {
-	for {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-			avatarURL, err := h.inputService.Prompt(ctx, "Enter avatar URL (Empty Valid)", currentUserAvatarURL)
-			if err != nil {
-				return "", err
-			}
-			if avatarURL == "" {
-				return avatarURL, nil
-			}
-			if err := utils.IsValidURL(avatarURL); err != nil {
-				printer.Errorln(err.Error())
-				printer.NewLine(1)
-				continue
-			}
-			return avatarURL, nil
 		}
 	}
 }

--- a/cmd/world/user/user.go
+++ b/cmd/world/user/user.go
@@ -70,7 +70,6 @@ type UpdateCmd struct {
 	Context      context.Context       `kong:"-"`
 	Dependencies cmdsetup.Dependencies `kong:"-"`
 	Name         string                `         flag:"" help:"The new name of the user"`
-	AvatarURL    string                `         flag:"" help:"The new avatar URL of the user" type:"url"`
 }
 
 func (c *UpdateCmd) Run() error {
@@ -81,8 +80,7 @@ func (c *UpdateCmd) Run() error {
 	}
 
 	flags := models.UpdateUserFlags{
-		Name:      c.Name,
-		AvatarURL: c.AvatarURL,
+		Name: c.Name,
 	}
 
 	return cmdsetup.WithSetup(c.Context, c.Dependencies, req, func(_ models.CommandState) error {

--- a/cmd/world/user/user_test.go
+++ b/cmd/world/user/user_test.go
@@ -41,10 +41,9 @@ func (s *UserTestSuite) createTestOrganization() models.Organization {
 
 func (s *UserTestSuite) createTestUser() models.User {
 	return models.User{
-		ID:        "user-123",
-		Name:      "Test User",
-		Email:     "test@example.com",
-		AvatarURL: "https://example.com/avatar.png",
+		ID:    "user-123",
+		Name:  "Test User",
+		Email: "test@example.com",
 	}
 }
 
@@ -294,8 +293,7 @@ func (s *UserTestSuite) TestHandler_Update_Success() {
 	ctx := context.Background()
 	currentUser := s.createTestUser()
 	flags := models.UpdateUserFlags{
-		Name:      "Updated User",
-		AvatarURL: "https://example.com/new-avatar.png",
+		Name: "Updated User",
 	}
 
 	// Mock getting current user
@@ -305,11 +303,9 @@ func (s *UserTestSuite) TestHandler_Update_Success() {
 	// Mock input interactions
 	mockInputService.On("Prompt", ctx, "Enter name", "Updated User").
 		Return("Updated User", nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/new-avatar.png").
-		Return("https://example.com/new-avatar.png", nil)
 
 	// Mock API call
-	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com", "https://example.com/new-avatar.png").
+	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com").
 		Return(nil)
 
 	err := handler.Update(ctx, flags)
@@ -326,8 +322,7 @@ func (s *UserTestSuite) TestHandler_Update_EmptyName() {
 	ctx := context.Background()
 	currentUser := s.createTestUser()
 	flags := models.UpdateUserFlags{
-		Name:      "",
-		AvatarURL: "",
+		Name: "",
 	}
 
 	// Mock getting current user
@@ -339,45 +334,9 @@ func (s *UserTestSuite) TestHandler_Update_EmptyName() {
 		Return("", nil).Once()
 	mockInputService.On("Prompt", ctx, "Enter name", "Test User").
 		Return("Valid User", nil).Once()
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("", nil)
 
 	// Mock API call
-	mockAPIClient.On("UpdateUser", ctx, "Valid User", "test@example.com", "").
-		Return(nil)
-
-	err := handler.Update(ctx, flags)
-
-	s.Require().NoError(err)
-	mockAPIClient.AssertExpectations(s.T())
-	mockInputService.AssertExpectations(s.T())
-}
-
-func (s *UserTestSuite) TestHandler_Update_InvalidAvatarURL() {
-	s.T().Parallel()
-
-	handler, mockAPIClient, mockInputService := s.createTestHandler()
-	ctx := context.Background()
-	currentUser := s.createTestUser()
-	flags := models.UpdateUserFlags{
-		Name:      "Updated User",
-		AvatarURL: "",
-	}
-
-	// Mock getting current user
-	mockAPIClient.On("GetUser", ctx).
-		Return(currentUser, nil)
-
-	// Mock input interactions - user enters invalid URL first, then valid URL
-	mockInputService.On("Prompt", ctx, "Enter name", "Updated User").
-		Return("Updated User", nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("invalid-url", nil).Once()
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("https://example.com/valid-avatar.png", nil).Once()
-
-	// Mock API call
-	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com", "https://example.com/valid-avatar.png").
+	mockAPIClient.On("UpdateUser", ctx, "Valid User", "test@example.com").
 		Return(nil)
 
 	err := handler.Update(ctx, flags)
@@ -441,8 +400,7 @@ func (s *UserTestSuite) TestHandler_Update_APIError() {
 	ctx := context.Background()
 	currentUser := s.createTestUser()
 	flags := models.UpdateUserFlags{
-		Name:      "Updated User",
-		AvatarURL: "",
+		Name: "Updated User",
 	}
 
 	// Mock getting current user
@@ -452,12 +410,10 @@ func (s *UserTestSuite) TestHandler_Update_APIError() {
 	// Mock input interactions
 	mockInputService.On("Prompt", ctx, "Enter name", "Updated User").
 		Return("Updated User", nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("", nil)
 
 	// Mock API error
 	apiErr := errors.New("update user error")
-	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com", "").
+	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com").
 		Return(apiErr)
 
 	err := handler.Update(ctx, flags)
@@ -487,38 +443,6 @@ func (s *UserTestSuite) TestHandler_Update_ContextCanceled() {
 
 	s.Require().Error(err)
 	s.Contains(err.Error(), "context canceled")
-	mockAPIClient.AssertExpectations(s.T())
-	mockInputService.AssertExpectations(s.T())
-}
-
-func (s *UserTestSuite) TestHandler_Update_EmptyAvatarURL() {
-	s.T().Parallel()
-
-	handler, mockAPIClient, mockInputService := s.createTestHandler()
-	ctx := context.Background()
-	currentUser := s.createTestUser()
-	flags := models.UpdateUserFlags{
-		Name:      "Updated User",
-		AvatarURL: "",
-	}
-
-	// Mock getting current user
-	mockAPIClient.On("GetUser", ctx).
-		Return(currentUser, nil)
-
-	// Mock input interactions
-	mockInputService.On("Prompt", ctx, "Enter name", "Updated User").
-		Return("Updated User", nil)
-	mockInputService.On("Prompt", ctx, "Enter avatar URL (Empty Valid)", "https://example.com/avatar.png").
-		Return("", nil)
-
-	// Mock API call with empty avatar URL
-	mockAPIClient.On("UpdateUser", ctx, "Updated User", "test@example.com", "").
-		Return(nil)
-
-	err := handler.Update(ctx, flags)
-
-	s.Require().NoError(err)
 	mockAPIClient.AssertExpectations(s.T())
 	mockInputService.AssertExpectations(s.T())
 }


### PR DESCRIPTION
# Remove avatar URL from organization and project models

## Overview

This PR removes the `avatar_url` field from organization and project models, as well as from related API endpoints and commands. The avatar functionality is being handled differently in the UI, making this field unnecessary in the CLI and API.

## Brief Changelog

- Removed `avatar_url` field from organization and project models
- Updated API client methods to no longer accept or return avatar URLs
- Removed avatar URL prompts and validation from organization and project creation flows
- Updated mock client implementations to match the new interfaces
- Removed avatar URL flags from CLI commands
- Updated tests to reflect these changes

## Testing and Verifying

This change is covered by existing tests, which have been updated to reflect the removal of the avatar URL field. The tests verify that organizations and projects can still be created and updated without the avatar URL field.

<!-- greptile_comment -->

## Greptile Summary

Removes avatar URL functionality from organization and project models as it's now handled in the UI layer instead of CLI/API. This streamlines the codebase by:

- Removed `avatar_url` field from organization/project models in `cmd/internal/models/`
- Updated API client methods and interfaces to remove avatar URL parameters in `cmd/internal/clients/api/`
- Removed avatar URL input prompts and validation from org/project creation flows in `cmd/world/organization/` and `cmd/world/project/`
- **Note**: Potential oversight where `AvatarURL` remains in `UpdateCmd` struct but not in `UpdateProjectFlags` in `cmd/world/project/project.go`



<!-- /greptile_comment -->