### PR TITLE
fix: Repo error handling msg

### DIFF
--- a/cmd/internal/controllers/cmd_setup/cmd_setup_test.go
+++ b/cmd/internal/controllers/cmd_setup/cmd_setup_test.go
@@ -547,7 +547,7 @@ func TestSetupCommandState_NeedProjectData_NoProjects_CreateNew(t *testing.T) {
 	mockAPI.On("GetUser", ctx).Return(user, nil)
 	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
 	mockAPI.On("GetProjects", ctx, "org-123").Return([]models.Project{}, nil)
-	mockProjectHandler.On("PreCreateUpdateValidation").Return("", "", nil)
+	mockProjectHandler.On("PreCreateUpdateValidation", true).Return("", "", nil)
 	mockInput.On("Prompt", ctx, "Would you like to create a new project? (Y/n)", "Y").Return("Y", nil)
 	mockProjectHandler.On("Create", ctx, models.CreateProjectFlags{}).
 		Return(newProject, nil)
@@ -601,7 +601,7 @@ func TestSetupCommandState_NeedProjectData_OneProject_UseExisting(t *testing.T) 
 	mockAPI.On("GetUser", ctx).Return(user, nil)
 	mockAPI.On("GetOrganizationsInvitedTo", ctx).Return([]models.Organization{}, nil)
 	mockAPI.On("GetProjects", ctx, "org-123").Return([]models.Project{existingProject}, nil)
-	mockProjectHandler.On("PreCreateUpdateValidation").Return("", "", repo.ErrNotInGitRepository)
+	mockProjectHandler.On("PreCreateUpdateValidation", false).Return("", "", repo.ErrNotInGitRepository)
 	mockInput.On("Prompt", ctx, "Select project: Existing Project [existing-project]? (Y/n)", "Y").Return("Y", nil)
 	mockConfig.On("Save").Return(nil)
 

--- a/cmd/internal/controllers/cmd_setup/organization.go
+++ b/cmd/internal/controllers/cmd_setup/organization.go
@@ -133,7 +133,7 @@ func (c *Controller) handleNeedExistingOrgData(
 }
 
 func (c *Controller) handleNeedExistingOrganizationCaseNoOrgs() error {
-	// TODO: printNoOrganizations()
+	c.organizationHandler.PrintNoOrganizations()
 	return ErrOrganizationSelectionCanceled
 }
 

--- a/cmd/internal/controllers/cmd_setup/project.go
+++ b/cmd/internal/controllers/cmd_setup/project.go
@@ -42,9 +42,9 @@ func (c *Controller) handleNeedProjectCaseNoProjects(
 ) error {
 	for {
 		// Must be in a valid directory to create a project
-		_, _, err := c.projectHandler.PreCreateUpdateValidation()
+		_, _, err := c.projectHandler.PreCreateUpdateValidation(true)
 		if err != nil {
-			// TODO: printNoProjectsInOrganization()
+			c.projectHandler.PrintNoProjectsInOrganization()
 			return ErrProjectCreationCanceled
 		}
 
@@ -80,7 +80,7 @@ func (c *Controller) handleNeedProjectCaseOneProject(
 
 	inRepoRoot := true
 	prompt := fmt.Sprintf("Select project: %s [%s]? (Y/n/c to create new)", projects[0].Name, projects[0].Slug)
-	_, _, err := c.projectHandler.PreCreateUpdateValidation()
+	_, _, err := c.projectHandler.PreCreateUpdateValidation(false)
 	if err != nil {
 		inRepoRoot = false
 		prompt = fmt.Sprintf("Select project: %s [%s]? (Y/n)", projects[0].Name, projects[0].Slug)
@@ -157,7 +157,7 @@ func (c *Controller) handleNeedExistingProjectData(
 }
 
 func (c *Controller) handleNeedExistingProjectCaseNoProjects() error {
-	// TODO: printNoProjectsInOrganization()
+	c.projectHandler.PrintNoProjectsInOrganization()
 	return ErrProjectSelectionCanceled
 }
 

--- a/cmd/internal/interfaces/organization.go
+++ b/cmd/internal/interfaces/organization.go
@@ -20,4 +20,7 @@ type OrganizationHandler interface {
 		orgs []models.Organization,
 		enableCreation bool,
 	) (models.Organization, error)
+
+	// Utils
+	PrintNoOrganizations()
 }

--- a/cmd/internal/interfaces/project.go
+++ b/cmd/internal/interfaces/project.go
@@ -17,5 +17,7 @@ type ProjectHandler interface {
 	Update(ctx context.Context, project models.Project, flags models.UpdateProjectFlags) error
 	Delete(ctx context.Context, project models.Project) error
 
-	PreCreateUpdateValidation() (string, string, error)
+	// Utils
+	PreCreateUpdateValidation(printError bool) (string, string, error)
+	PrintNoProjectsInOrganization()
 }

--- a/cmd/world/organization/mock.go
+++ b/cmd/world/organization/mock.go
@@ -30,3 +30,7 @@ func (m *MockHandler) PromptForSwitch(ctx context.Context, orgs []models.Organiz
 	args := m.Called(ctx, orgs, enableCreation)
 	return args.Get(0).(models.Organization), args.Error(1)
 }
+
+func (m *MockHandler) PrintNoOrganizations() {
+	m.Called()
+}

--- a/cmd/world/organization/switch.go
+++ b/cmd/world/organization/switch.go
@@ -38,7 +38,7 @@ func (h *Handler) Switch(ctx context.Context, flags models.SwitchOrganizationFla
 	}
 
 	if len(orgs) == 0 {
-		printNoOrganizations()
+		h.PrintNoOrganizations()
 		return models.Organization{}, nil
 	}
 

--- a/cmd/world/organization/utils.go
+++ b/cmd/world/organization/utils.go
@@ -15,7 +15,7 @@ func (h *Handler) saveOrganization(org models.Organization) error {
 	return nil
 }
 
-func printNoOrganizations() {
+func (h *Handler) PrintNoOrganizations() {
 	printer.NewLine(1)
 	printer.Headerln("   No Organizations Found   ")
 	printer.Info("1. Use ")

--- a/cmd/world/project/create.go
+++ b/cmd/world/project/create.go
@@ -31,7 +31,7 @@ func (h *Handler) Create(
 		return models.Project{}, ErrCannotCreateSwitchProject
 	}
 
-	repoPath, repoURL, err := h.PreCreateUpdateValidation()
+	repoPath, repoURL, err := h.PreCreateUpdateValidation(true)
 	if err != nil {
 		printRequiredStepsToCreateProject()
 		return models.Project{}, eris.Wrap(err, "Failed to validate project creation")

--- a/cmd/world/project/mock.go
+++ b/cmd/world/project/mock.go
@@ -54,7 +54,11 @@ func (m *MockHandler) Delete(
 	return args.Error(0)
 }
 
-func (m *MockHandler) PreCreateUpdateValidation() (string, string, error) {
-	args := m.Called()
+func (m *MockHandler) PreCreateUpdateValidation(printError bool) (string, string, error) {
+	args := m.Called(printError)
 	return args.Get(0).(string), args.Get(1).(string), args.Error(2)
+}
+
+func (m *MockHandler) PrintNoProjectsInOrganization() {
+	m.Called()
 }

--- a/cmd/world/project/project_test.go
+++ b/cmd/world/project/project_test.go
@@ -656,7 +656,7 @@ func (s *ProjectTestSuite) TestHandler_PreCreateUpdateValidation_Success() {
 	// Mock successful validation
 	mockRepoClient.On("FindGitPathAndURL").Return("cardinal", "https://github.com/test/repo", nil)
 
-	repoPath, repoURL, err := handler.PreCreateUpdateValidation()
+	repoPath, repoURL, err := handler.PreCreateUpdateValidation(false)
 
 	// Should succeed because we're in a proper World project directory
 	s.Equal("cardinal", repoPath)
@@ -674,7 +674,7 @@ func (s *ProjectTestSuite) TestHandler_PreCreateUpdateValidation_NotInRepo() {
 	validationErr := errors.New("not in git repository")
 	mockRepoClient.On("FindGitPathAndURL").Return("", "", validationErr)
 
-	repoPath, repoURL, err := handler.PreCreateUpdateValidation()
+	repoPath, repoURL, err := handler.PreCreateUpdateValidation(false)
 
 	s.Require().Error(err)
 	s.Empty(repoPath)
@@ -1228,7 +1228,7 @@ func (s *ProjectTestSuite) TestHandler_PreCreateUpdateValidation_NotInWorldRoot(
 	// Mock successful git validation but not in World root
 	mockRepoClient.On("FindGitPathAndURL").Return("cardinal", "https://github.com/test/repo", nil)
 
-	repoPath, repoURL, err := handler.PreCreateUpdateValidation()
+	repoPath, repoURL, err := handler.PreCreateUpdateValidation(false)
 
 	// Should fail because not in World Cardinal root (no world.toml/cardinal dir setup)
 	s.Require().Error(err)

--- a/cmd/world/project/switch.go
+++ b/cmd/world/project/switch.go
@@ -37,7 +37,7 @@ func (h *Handler) Switch(
 			}
 			return proj, nil
 		}
-		printNoProjectsInOrganization()
+		h.PrintNoProjectsInOrganization()
 		return models.Project{}, nil
 	}
 
@@ -56,7 +56,7 @@ func (h *Handler) Switch(
 	inRepoRoot := false
 	prompt := "Enter project number ('q' to quit)"
 	if enableCreation {
-		_, _, err = h.PreCreateUpdateValidation()
+		_, _, err = h.PreCreateUpdateValidation(false)
 		if err == nil { // if in repo root, we can create a new project
 			inRepoRoot = true
 			prompt = "Enter project number ('c' to create new, 'q' to quit)"
@@ -168,7 +168,7 @@ func (h *Handler) handleMultipleProjects(ctx context.Context, projects []models.
 
 // handleNoProjects handles the case when there are no projects.
 func (h *Handler) handleNoProjects(ctx context.Context) error {
-	_, _, err := h.PreCreateUpdateValidation()
+	_, _, err := h.PreCreateUpdateValidation(true)
 	if err != nil {
 		printRequiredStepsToCreateProject()
 		return nil //nolint:nilerr // error here is representing a boolean

--- a/cmd/world/project/update.go
+++ b/cmd/world/project/update.go
@@ -21,7 +21,7 @@ func (h *Handler) Update(
 
 	printer.Infof("Updating Project: %s [%s]\n", project.Name, project.Slug)
 
-	repoPath, repoURL, err := h.PreCreateUpdateValidation()
+	repoPath, repoURL, err := h.PreCreateUpdateValidation(true)
 	if err != nil {
 		printRequiredStepsToCreateProject()
 		return eris.Wrap(err, "Failed to validate project update")


### PR DESCRIPTION
# fix: Improve project validation and error handling


## Overview

This PR enhances the project validation process by adding a parameter to control error message display and implementing missing error handling for cases when no projects exist in an organization.

## Brief Changelog

- Added `printError` boolean parameter to `PreCreateUpdateValidation` to control when error messages are displayed
- Implemented the previously TODOed `PrintNoProjectsInOrganization` method
- Updated all calls to `PreCreateUpdateValidation` to include the new parameter
- Fixed error handling in project creation and selection flows

## Testing and Verifying

This change is already covered by existing tests, which have been updated to accommodate the new parameter in the validation method.

<!-- greptile_comment -->

## Greptile Summary

Enhanced project validation and error handling in world-cli by adding configurable error message display and implementing missing error cases.

- Added `printError` parameter to `PreCreateUpdateValidation` in `cmd/world/project/*.go` files to control error message visibility
- Implemented `PrintNoProjectsInOrganization` method to handle empty project list scenarios
- Updated validation calls across project-related operations (create, update, switch) with new parameter
- Added test coverage for new error handling functionality in `cmd/world/project/project_test.go`



<!-- /greptile_comment -->