### PR TITLE
fix: input defaults when missing flags on commands

### DIFF
--- a/cmd/world/project/delete.go
+++ b/cmd/world/project/delete.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-cli/cmd/internal/models"
@@ -28,7 +29,8 @@ func (h *Handler) Delete(
 	printer.Infoln("• All associated resources")
 	printer.NewLine(1)
 
-	confirmation, err := h.inputService.Prompt(ctx, "Type 'Yes' to confirm deletion of project: ", project.Name)
+	prompt := fmt.Sprintf("Type 'Yes' to confirm deletion of '%s (%s)'", project.Name, project.Slug)
+	confirmation, err := h.inputService.Prompt(ctx, prompt, "no")
 	if err != nil {
 		return eris.Wrap(err, "Failed to prompt for confirmation")
 	}

--- a/cmd/world/project/project_test.go
+++ b/cmd/world/project/project_test.go
@@ -309,7 +309,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_Success() {
 	testProject := s.createTestProject()
 
 	// Mock input confirmation
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("Yes", nil)
 
 	// Mock API call
@@ -334,7 +334,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_UserDeclines() {
 	testProject := s.createTestProject()
 
 	// Mock input confirmation - user declines
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("no", nil)
 
 	err := handler.Delete(ctx, testProject)
@@ -351,7 +351,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_IncorrectConfirmation() {
 	testProject := s.createTestProject()
 
 	// Mock input confirmation - user types "yes" instead of "Yes"
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("yes", nil)
 
 	err := handler.Delete(ctx, testProject)
@@ -369,7 +369,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_InputError() {
 
 	// Mock input error
 	inputErr := errors.New("input error")
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("", inputErr)
 
 	err := handler.Delete(ctx, testProject)
@@ -387,7 +387,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_APIError() {
 	testProject := s.createTestProject()
 
 	// Mock input confirmation
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("Yes", nil)
 
 	// Mock API error
@@ -1182,7 +1182,7 @@ func (s *ProjectTestSuite) TestHandler_Delete_ConfigError() {
 	testProject := s.createTestProject()
 
 	// Mock input confirmation
-	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of project: ", "Test Project").
+	mockInputService.On("Prompt", ctx, "Type 'Yes' to confirm deletion of 'Test Project (test_project)'", "no").
 		Return("Yes", nil)
 
 	// Mock successful API call
@@ -1694,7 +1694,7 @@ func (s *ProjectTestSuite) TestHandler_Create_PublicTokenSelection() {
 		OrgID:     "org-123",
 		RepoURL:   "https://github.com/test/repo",
 		RepoPath:  "cardinal",
-		RepoToken: "", // Empty because "public" was selected
+		RepoToken: "",
 		Update:    false,
 		Config: models.ProjectConfig{
 			Region: []string{"us-east-1"},

--- a/cmd/world/project/update.go
+++ b/cmd/world/project/update.go
@@ -32,6 +32,13 @@ func (h *Handler) Update(
 		return eris.Wrap(err, "Failed to get available regions")
 	}
 
+	if flags.Name == "" {
+		flags.Name = project.Name
+	}
+	if flags.Slug == "" {
+		flags.Slug = project.Slug
+	}
+
 	// set update to true
 	project.Update = true
 	project.Name = flags.Name

--- a/cmd/world/user/invite.go
+++ b/cmd/world/user/invite.go
@@ -27,6 +27,10 @@ func (h *Handler) InviteToOrganization(
 		return eris.New("User email cannot be empty")
 	}
 
+	if flags.Role == "" {
+		flags.Role = roles[0]
+	}
+
 	userRole, err := h.inputService.Prompt(ctx, "Enter user role to invite", flags.Role)
 	if err != nil {
 		return eris.Wrap(err, "Failed to get user role")

--- a/cmd/world/user/role.go
+++ b/cmd/world/user/role.go
@@ -12,6 +12,12 @@ var (
 	ErrFailedToSetUserRoleInOrg = eris.New("Failed to set user role in organization")
 )
 
+var roles = []string{
+	"member",
+	"admin",
+	"owner",
+}
+
 func (h *Handler) ChangeRoleInOrganization(
 	ctx context.Context,
 	organization models.Organization,
@@ -26,6 +32,10 @@ func (h *Handler) ChangeRoleInOrganization(
 
 	if userEmail == "" {
 		return eris.New("User email cannot be empty")
+	}
+
+	if flags.Role == "" {
+		flags.Role = roles[0]
 	}
 
 	userRole, err := h.inputService.Prompt(ctx, "Enter user role to update", flags.Role)


### PR DESCRIPTION
# Improve project deletion confirmation and default values for user roles and project updates

## Overview

This PR enhances the user experience by improving the project deletion confirmation prompt and adding default values for user roles and project updates.

## Brief Changelog

- Improved project deletion confirmation prompt to include both project name and slug
- Added default value of "no" for project deletion confirmation
- Set default values for project name and slug during updates
- Added default role selection for user invitations and role changes
- Extracted role options into a shared variable

## Testing and Verifying

This change is already covered by existing tests, which have been updated to reflect the new prompt format and default values.

<!-- greptile_comment -->

## Greptile Summary

Enhanced CLI user experience by improving input handling and default values across project and user management commands.

- Added safer project deletion with expanded confirmation prompt showing both name and slug in `cmd/world/project/delete.go`, defaulting to 'no'
- Implemented smart defaults for project updates in `cmd/world/project/update.go`, using existing values when flags are empty
- Consolidated role management in `cmd/world/user/role.go` with shared role options and default 'member' role
- Added automatic role defaulting to user invitation flow in `cmd/world/user/invite.go`
- Updated test cases in `cmd/world/project/project_test.go` to reflect new confirmation prompts



<!-- /greptile_comment -->