### PR TITLE
chore: org code cleanup

### DIFF
--- a/cmd/world/organization/create.go
+++ b/cmd/world/organization/create.go
@@ -14,7 +14,7 @@ import (
 
 const MaxOrgNameLen = 50
 
-//nolint:gocognit,funlen // Belongs in a single function
+//nolint:gocognit // Belongs in a single function
 func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFlags) (models.Organization, error) {
 	var orgName, orgSlug string
 	var err error
@@ -30,8 +30,6 @@ func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFla
 			}
 			err = validate.Name(orgName, MaxOrgNameLen)
 			if err != nil {
-				printer.Errorf("%s\n", err)
-				printer.NewLine(1)
 				continue
 			}
 			break
@@ -78,6 +76,7 @@ func (h *Handler) Create(ctx context.Context, flags models.CreateOrganizationFla
 		if confirm {
 			org, err := h.apiClient.CreateOrganization(ctx, orgName, orgSlug)
 			if err != nil {
+				// Check if the error is because the slug already exists.
 				if strings.Contains(err.Error(), api.ErrOrganizationSlugAlreadyExists.Error()) {
 					printer.Errorf(
 						"An Organization already exists with slug: %s, please choose a different slug.\n",

--- a/cmd/world/organization/switch.go
+++ b/cmd/world/organization/switch.go
@@ -23,15 +23,6 @@ func (h *Handler) Switch(ctx context.Context, flags models.SwitchOrganizationFla
 		return models.Organization{}, ErrCannotSwitchOrganization
 	}
 
-	// If slug is provided, select organization from slug
-	if flags.Slug != "" {
-		org, err := h.switchOrganizationFromSlug(ctx, flags.Slug)
-		if err != nil {
-			return models.Organization{}, eris.Wrap(err, "Failed command switch organization from slug")
-		}
-		return org, nil
-	}
-
 	orgs, err := h.apiClient.GetOrganizations(ctx)
 	if err != nil {
 		return models.Organization{}, eris.Wrap(err, "Failed to get organizations")
@@ -40,6 +31,15 @@ func (h *Handler) Switch(ctx context.Context, flags models.SwitchOrganizationFla
 	if len(orgs) == 0 {
 		h.PrintNoOrganizations()
 		return models.Organization{}, nil
+	}
+
+	// If slug is provided, select organization from slug
+	if flags.Slug != "" {
+		org, err := h.switchOrganizationFromSlug(ctx, flags.Slug, orgs)
+		if err != nil {
+			return models.Organization{}, eris.Wrap(err, "Failed command switch organization from slug")
+		}
+		return org, nil
 	}
 
 	selectedOrg, err := h.PromptForSwitch(ctx, orgs, false)
@@ -55,23 +55,19 @@ func (h *Handler) Switch(ctx context.Context, flags models.SwitchOrganizationFla
 	return selectedOrg, nil
 }
 
-func (h *Handler) switchOrganizationFromSlug(ctx context.Context, slug string) (models.Organization, error) {
-	orgs, err := h.apiClient.GetOrganizations(ctx)
-	if err != nil {
-		return models.Organization{}, eris.Wrap(err, "Failed to get organizations")
-	}
-
+func (h *Handler) switchOrganizationFromSlug(
+	ctx context.Context,
+	slug string,
+	orgs []models.Organization,
+) (models.Organization, error) {
 	for _, org := range orgs {
 		if org.Slug == slug {
-			err = h.saveOrganization(org)
+			err := h.saveOrganization(org)
 			if err != nil {
 				return models.Organization{}, eris.Wrap(err, "Failed to save organization")
 			}
 
-			err = h.showOrganizationList(ctx)
-			if err != nil {
-				return models.Organization{}, err
-			}
+			h.showOrganizationList(org, orgs)
 
 			err = h.projectHandler.HandleSwitch(ctx, org)
 			if err != nil {
@@ -86,36 +82,6 @@ func (h *Handler) switchOrganizationFromSlug(ctx context.Context, slug string) (
 	return models.Organization{}, eris.Wrap(ErrOrganizationNotFoundWithSlug, slug)
 }
 
-func (h *Handler) showOrganizationList(ctx context.Context) error {
-	selectedOrg, err := h.apiClient.GetOrganizationByID(ctx, h.configService.GetConfig().OrganizationID)
-	if err != nil {
-		return eris.Wrap(err, "Failed to get organization")
-	}
-
-	organizations, err := h.apiClient.GetOrganizations(ctx)
-	if err != nil {
-		return eris.Wrap(err, "Failed to get organization list")
-	}
-
-	printer.NewLine(1)
-	printer.Headerln("  Organization Information  ")
-	if selectedOrg.Name == "" {
-		printer.Errorln("No organization selected")
-		printer.NewLine(1)
-		printer.Infoln("Use 'world organization switch' to choose an organization")
-	} else {
-		for _, org := range organizations {
-			if org.ID == selectedOrg.ID {
-				printer.Infof("• %s (%s) [SELECTED]\n", org.Name, org.Slug)
-			} else {
-				printer.Infof("  %s (%s)\n", org.Name, org.Slug)
-			}
-		}
-	}
-	return nil
-}
-
-//nolint:gocognit // Belongs in a single function
 func (h *Handler) PromptForSwitch(
 	ctx context.Context, orgs []models.Organization, enableCreation bool,
 ) (models.Organization, error) {
@@ -127,58 +93,48 @@ func (h *Handler) PromptForSwitch(
 	}
 
 	// Get user input
-	var input string
+	var input, prompt string
 	var err error
 	for {
-		select {
-		case <-ctx.Done():
-			return models.Organization{}, ctx.Err()
-		default:
-			printer.NewLine(1)
-			if enableCreation {
-				input, err = h.inputService.Prompt(
-					ctx,
-					"Enter organization number ('c' to create new or 'q' to quit)",
-					"",
-				)
-				if err != nil {
-					return models.Organization{}, eris.Wrap(err, "Failed to get organization number")
-				}
-			} else {
-				input, err = h.inputService.Prompt(ctx, "Enter organization number ('q' to quit)", "")
-				if err != nil {
-					return models.Organization{}, eris.Wrap(err, "Failed to get organization number")
-				}
-			}
-
-			if input == "q" {
-				return models.Organization{}, ErrOrganizationSelectionCanceled
-			}
-
-			if input == "c" && enableCreation {
-				org, err := h.Create(ctx, models.CreateOrganizationFlags{})
-				if err != nil {
-					return models.Organization{}, eris.Wrap(err, "Failed to create organization")
-				}
-				return org, nil
-			}
-
-			// Parse selection
-			num, err := strconv.Atoi(input)
-			if err != nil || num < 1 || num > len(orgs) {
-				printer.Errorf("Invalid selection. Please enter a number between 1 and %d\n", len(orgs))
-				continue
-			}
-
-			selectedOrg := orgs[num-1]
-
-			err = h.saveOrganization(selectedOrg)
-			if err != nil {
-				return models.Organization{}, eris.Wrap(err, "Failed to save organization")
-			}
-
-			printer.Successf("Selected organization: %s\n", selectedOrg.Name)
-			return selectedOrg, nil
+		printer.NewLine(1)
+		if enableCreation {
+			prompt = "Enter organization number ('c' to create new or 'q' to quit)"
+		} else {
+			prompt = "Enter organization number ('q' to quit)"
 		}
+
+		input, err = h.inputService.Prompt(ctx, prompt, "")
+		if err != nil {
+			return models.Organization{}, eris.Wrap(err, "Failed to get organization number")
+		}
+
+		if input == "q" {
+			return models.Organization{}, ErrOrganizationSelectionCanceled
+		}
+
+		if input == "c" && enableCreation {
+			org, err := h.Create(ctx, models.CreateOrganizationFlags{})
+			if err != nil {
+				return models.Organization{}, eris.Wrap(err, "Failed to create organization")
+			}
+			return org, nil
+		}
+
+		// Parse selection
+		num, err := strconv.Atoi(input)
+		if err != nil || num < 1 || num > len(orgs) {
+			printer.Errorf("Invalid selection. Please enter a number between 1 and %d\n", len(orgs))
+			continue
+		}
+
+		selectedOrg := orgs[num-1]
+
+		err = h.saveOrganization(selectedOrg)
+		if err != nil {
+			return models.Organization{}, eris.Wrap(err, "Failed to save organization")
+		}
+
+		printer.Successf("Selected organization: %s\n", selectedOrg.Name)
+		return selectedOrg, nil
 	}
 }

--- a/cmd/world/organization/utils.go
+++ b/cmd/world/organization/utils.go
@@ -15,6 +15,18 @@ func (h *Handler) saveOrganization(org models.Organization) error {
 	return nil
 }
 
+func (h *Handler) showOrganizationList(org models.Organization, orgs []models.Organization) {
+	printer.NewLine(1)
+	printer.Headerln("  Organization Information  ")
+	for _, organization := range orgs {
+		if organization.ID == org.ID {
+			printer.Infof("• %s (%s) [SELECTED]\n", organization.Name, organization.Slug)
+		} else {
+			printer.Infof("  %s (%s)\n", organization.Name, organization.Slug)
+		}
+	}
+}
+
 func (h *Handler) PrintNoOrganizations() {
 	printer.NewLine(1)
 	printer.Headerln("   No Organizations Found   ")

--- a/cmd/world/project/switch.go
+++ b/cmd/world/project/switch.go
@@ -142,7 +142,7 @@ func (h *Handler) HandleSwitch(ctx context.Context, org models.Organization) err
 	case numProjects == 1:
 		return h.handleSingleProject(ctx, projects[0], org)
 	case numProjects > 1:
-		return h.handleMultipleProjects(ctx, projects, org)
+		return h.handleMultipleProjects(ctx, org)
 	default:
 		return h.handleNoProjects(ctx, org)
 	}
@@ -161,16 +161,8 @@ func (h *Handler) handleSingleProject(
 // handleMultipleProjects handles the case when there are multiple projects.
 func (h *Handler) handleMultipleProjects(
 	ctx context.Context,
-	projects []models.Project,
 	org models.Organization,
 ) error {
-	for _, project := range projects {
-		if project.ID == h.configService.GetConfig().ProjectID {
-			h.showProjectList(ctx, project, org)
-			return nil
-		}
-	}
-
 	project, err := h.Switch(ctx, models.SwitchProjectFlags{}, org, false)
 	if err != nil {
 		return eris.Wrap(err, "Failed to select project")


### PR DESCRIPTION
# Refactor: Organization Command Improvements

## Overview

This PR refactors the organization command handling to improve code quality, fix bugs, and enhance test coverage. It reorganizes the organization switching logic, removes redundant API calls, and improves error handling.

## Brief Changelog

- Removed redundant API calls in the organization switching flow
- Moved organization list display functionality to a separate utility function
- Improved error handling in the organization creation process
- Reorganized the switch command to check for organizations before attempting to switch by slug
- Enhanced test coverage for context cancellation scenarios
- Moved the test suite runner to the top of the test file for better readability
- Removed unnecessary error messages during organization name validation

## Testing and Verifying

This change is covered by existing tests, with improvements to the test suite to better validate error handling and context cancellation scenarios.

<!-- greptile_comment -->

## Greptile Summary

Refactors organization command handling to improve code quality and efficiency, primarily focusing on the switch and create workflows.

- Optimized API calls by consolidating organization list fetching in `cmd/world/organization/switch.go`, preventing duplicate requests
- Added new `showOrganizationList` utility function in `cmd/world/organization/utils.go` to centralize organization display logic
- Enhanced error handling in organization creation process and removed redundant validation messages in `cmd/world/organization/create.go`
- Improved test coverage and organization in `cmd/world/organization/organization_test.go` with better context cancellation handling



<!-- /greptile_comment -->