### PR TITLE
refactor: cloud command remove 'prefix cloud' & cmd_setup test coverage

### DIFF
--- a/cmd/world/cloud/cloud.go
+++ b/cmd/world/cloud/cloud.go
@@ -7,12 +7,8 @@ import (
 	"pkg.world.dev/world-cli/cmd/internal/models"
 )
 
-var CmdPlugin struct {
-	Cloud *Cmd `cmd:""`
-}
-
 //nolint:lll // needed to put all the help text in the same line
-type Cmd struct {
+var CmdPlugin struct {
 	Deploy  *DeployCmd  `cmd:"" group:"Cloud Management Commands:" help:"Deploy your World Forge project to a TEST environment in the cloud"`
 	Status  *StatusCmd  `cmd:"" group:"Cloud Management Commands:" help:"Check the status of your deployed World Forge project"`
 	Promote *PromoteCmd `cmd:"" group:"Cloud Management Commands:" help:"Deploy your game project to a LIVE environment in the cloud"`


### PR DESCRIPTION
# refactor: Simplify cloud command structure

## Overview

This PR simplifies the command structure in the cloud package by removing an unnecessary nesting level. Instead of having a nested `Cloud` command inside `CmdPlugin`, the cloud commands are now directly accessible from the `CmdPlugin` struct.

## Brief Changelog

- Removed the nested `Cmd` struct and moved its fields directly into the `CmdPlugin` struct
- Preserved all command functionality and help text
- Maintained the existing command grouping

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage. The functionality remains unchanged, only the command structure is simplified.

<!-- greptile_comment -->

## Greptile Summary

Simplified command structure in cloud package by removing unnecessary nesting level, making commands directly accessible from `CmdPlugin` struct.

- Removed nested `Cloud` struct from `cmd/world/cloud/cloud.go`, flattening command hierarchy
- Command functionality, help text, and grouping remain unchanged
- Improved code organization by removing redundant abstraction layer
- Commands previously accessed via `CmdPlugin.Cloud.*` now accessed directly via `CmdPlugin.*`



<!-- /greptile_comment -->