### PR TITLE
refactor: cardinal struture migration

### DIFF
--- a/cmd/internal/controllers/cmd_setup/types.go
+++ b/cmd/internal/controllers/cmd_setup/types.go
@@ -25,6 +25,7 @@ type Dependencies struct {
 	RootHandler         interfaces.RootHandler
 	CloudHandler        interfaces.CloudHandler
 	EVMHandler          interfaces.EVMHandler
+	CardinalHandler     interfaces.CardinalHandler
 	SetupController     interfaces.CommandSetupController
 }
 

--- a/cmd/internal/interfaces/cardinal.go
+++ b/cmd/internal/interfaces/cardinal.go
@@ -1,0 +1,16 @@
+package interfaces
+
+import (
+	"context"
+
+	"pkg.world.dev/world-cli/cmd/internal/models"
+)
+
+type CardinalHandler interface {
+	Start(ctx context.Context, f models.StartCardinalFlags) error
+	Stop(ctx context.Context, f models.StopCardinalFlags) error
+	Restart(ctx context.Context, f models.RestartCardinalFlags) error
+	Dev(ctx context.Context, f models.DevCardinalFlags) error
+	Purge(ctx context.Context, f models.PurgeCardinalFlags) error
+	Build(ctx context.Context, f models.BuildCardinalFlags) error
+}

--- a/cmd/internal/models/cardinal.go
+++ b/cmd/internal/models/cardinal.go
@@ -1,0 +1,43 @@
+package models
+
+type StartCardinalFlags struct {
+	Config     string
+	Detach     bool
+	LogLevel   string
+	Debug      bool
+	Telemetry  bool
+	Editor     bool
+	EditorPort string
+}
+
+type StopCardinalFlags struct {
+	Config string
+}
+
+type RestartCardinalFlags struct {
+	Config string
+	Detach bool
+	Debug  bool
+}
+
+type DevCardinalFlags struct {
+	Config    string
+	Editor    bool
+	PrettyLog bool
+}
+
+type PurgeCardinalFlags struct {
+	Config string
+}
+
+type BuildCardinalFlags struct {
+	Config    string
+	LogLevel  string
+	Debug     bool
+	Telemetry bool
+	Push      string
+	Auth      string
+	User      string
+	Pass      string
+	RegToken  string
+}

--- a/cmd/world/cardinal/mocks.go
+++ b/cmd/world/cardinal/mocks.go
@@ -1,0 +1,45 @@
+package cardinal
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"pkg.world.dev/world-cli/cmd/internal/interfaces"
+	"pkg.world.dev/world-cli/cmd/internal/models"
+)
+
+var _ interfaces.CardinalHandler = (*MockHandler)(nil)
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Start(ctx context.Context, flags models.StartCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Stop(ctx context.Context, flags models.StopCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Restart(ctx context.Context, flags models.RestartCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Dev(ctx context.Context, flags models.DevCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Purge(ctx context.Context, flags models.PurgeCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *MockHandler) Build(ctx context.Context, flags models.BuildCardinalFlags) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}

--- a/cmd/world/cardinal/purge.go
+++ b/cmd/world/cardinal/purge.go
@@ -3,14 +3,15 @@ package cardinal
 import (
 	"context"
 
+	"pkg.world.dev/world-cli/cmd/internal/models"
 	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/docker"
 	"pkg.world.dev/world-cli/common/docker/service"
 	"pkg.world.dev/world-cli/common/printer"
 )
 
-func Purge(c *PurgeCmd) error {
-	cfg, err := config.GetConfig(&c.Parent.Config)
+func (h *Handler) Purge(ctx context.Context, f models.PurgeCardinalFlags) error {
+	cfg, err := config.GetConfig(&f.Config)
 	if err != nil {
 		return err
 	}
@@ -22,7 +23,6 @@ func Purge(c *PurgeCmd) error {
 	}
 	defer dockerClient.Close()
 
-	ctx := context.Background()
 	err = dockerClient.Purge(ctx, service.Nakama, service.Cardinal,
 		service.NakamaDB, service.Redis, service.Jaeger, service.Prometheus)
 	if err != nil {

--- a/cmd/world/cardinal/restart.go
+++ b/cmd/world/cardinal/restart.go
@@ -3,18 +3,19 @@ package cardinal
 import (
 	"context"
 
+	"pkg.world.dev/world-cli/cmd/internal/models"
 	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/docker"
 )
 
-func Restart(c *RestartCmd) error {
-	cfg, err := config.GetConfig(&c.Parent.Config)
+func (h *Handler) Restart(ctx context.Context, f models.RestartCardinalFlags) error {
+	cfg, err := config.GetConfig(&f.Config)
 	if err != nil {
 		return err
 	}
 	cfg.Build = true
-	cfg.Debug = c.Debug
-	cfg.Detach = c.Detach
+	cfg.Debug = f.Debug
+	cfg.Detach = f.Detach
 
 	// Create docker client
 	dockerClient, err := docker.NewClient(cfg)
@@ -23,7 +24,6 @@ func Restart(c *RestartCmd) error {
 	}
 	defer dockerClient.Close()
 
-	ctx := context.Background()
 	err = dockerClient.Restart(ctx, getServices(cfg)...)
 	if err != nil {
 		return err

--- a/cmd/world/cardinal/stop.go
+++ b/cmd/world/cardinal/stop.go
@@ -3,14 +3,15 @@ package cardinal
 import (
 	"context"
 
+	"pkg.world.dev/world-cli/cmd/internal/models"
 	"pkg.world.dev/world-cli/common/config"
 	"pkg.world.dev/world-cli/common/docker"
 	"pkg.world.dev/world-cli/common/docker/service"
 	"pkg.world.dev/world-cli/common/printer"
 )
 
-func Stop(c *StopCmd) error {
-	cfg, err := config.GetConfig(&c.Parent.Config)
+func (h *Handler) Stop(ctx context.Context, f models.StopCardinalFlags) error {
+	cfg, err := config.GetConfig(&f.Config)
 	if err != nil {
 		return err
 	}
@@ -22,7 +23,6 @@ func Stop(c *StopCmd) error {
 	}
 	defer dockerClient.Close()
 
-	ctx := context.Background()
 	err = dockerClient.Stop(ctx, service.Nakama, service.Cardinal,
 		service.NakamaDB, service.Redis, service.Jaeger, service.Prometheus)
 	if err != nil {

--- a/cmd/world/cardinal/types.go
+++ b/cmd/world/cardinal/types.go
@@ -1,0 +1,12 @@
+package cardinal
+
+import "pkg.world.dev/world-cli/cmd/internal/interfaces"
+
+var _ interfaces.CardinalHandler = &Handler{}
+
+type Handler struct {
+}
+
+func NewHandler() interfaces.CardinalHandler {
+	return &Handler{}
+}

--- a/cmd/world/main.go
+++ b/cmd/world/main.go
@@ -318,6 +318,8 @@ func initDependencies(env, version string) (cmdsetup.Dependencies, error) {
 
 	evmHandler := evm.NewHandler()
 
+	cardinalHandler := cardinal.NewHandler()
+
 	setupController := cmdsetup.NewController(
 		configService,
 		repoClient,
@@ -342,5 +344,6 @@ func initDependencies(env, version string) (cmdsetup.Dependencies, error) {
 		EVMHandler:          evmHandler,
 		SetupController:     setupController,
 		RootHandler:         rootHandler,
+		CardinalHandler:     cardinalHandler,
 	}, nil
 }


### PR DESCRIPTION
# refactor: Implement Cardinal Handler Interface


## Overview

This PR refactors the Cardinal command implementation to follow the handler pattern used throughout the codebase. It introduces a `CardinalHandler` interface and moves the implementation logic from direct function calls to methods on a handler struct.

## Brief Changelog

- Created a new `CardinalHandler` interface in `cmd/internal/interfaces/cardinal.go`
- Added flag models for Cardinal commands in `cmd/internal/models/cardinal.go`
- Implemented a `Handler` struct in the cardinal package that implements the interface
- Refactored all Cardinal commands to use the handler pattern
- Updated the dependency injection system to include the Cardinal handler
- Added mock implementation for testing

## Testing and Verifying

This change is already covered by existing tests. The existing tests have been updated to use the new handler pattern, ensuring that the refactored code maintains the same functionality.

<!-- greptile_comment -->

## Greptile Summary

Refactors Cardinal command implementation to use a handler pattern, improving consistency with the rest of the codebase by moving from direct function calls to a structured interface approach.

- Added new `CardinalHandler` interface in `cmd/internal/interfaces/cardinal.go` to standardize Cardinal operations
- Introduced flag models in `cmd/internal/models/cardinal.go` for type-safe command configuration
- Converted standalone functions (Start, Stop, Restart, etc.) to methods on `Handler` struct in `cmd/world/cardinal`
- Added proper context handling and dependency injection throughout Cardinal commands
- Enabled better testability by introducing mock implementations while maintaining existing functionality



<!-- /greptile_comment -->