### PR TITLE
feat: WE V2 build

### DIFF
--- a/cmd/world/cardinal/build.go
+++ b/cmd/world/cardinal/build.go
@@ -69,6 +69,12 @@ func (h *Handler) Build(ctx context.Context, f models.BuildCardinalFlags) error 
 	printer.Infoln("Building Cardinal game shard image...")
 	printer.Infoln("This may take a few minutes.")
 
+	// Set the namespace
+	if cfg.DockerEnv["CARDINAL_NAMESPACE"] == "" {
+		cfg.DockerEnv["CARDINAL_NAMESPACE"] = "defaultnamespace"
+	}
+	printer.Infof("Namespace: %s", cfg.DockerEnv["CARDINAL_NAMESPACE"])
+
 	group, groupCtx := errgroup.WithContext(ctx)
 
 	// Create docker client

--- a/cmd/world/cardinal/build.go
+++ b/cmd/world/cardinal/build.go
@@ -73,7 +73,7 @@ func (h *Handler) Build(ctx context.Context, f models.BuildCardinalFlags) error 
 	if cfg.DockerEnv["CARDINAL_NAMESPACE"] == "" {
 		cfg.DockerEnv["CARDINAL_NAMESPACE"] = "defaultnamespace"
 	}
-	printer.Infof("Namespace: %s", cfg.DockerEnv["CARDINAL_NAMESPACE"])
+	printer.Infof("Namespace: %s\n", cfg.DockerEnv["CARDINAL_NAMESPACE"])
 
 	group, groupCtx := errgroup.WithContext(ctx)
 

--- a/cmd/world/internal/controllers/cmd_setup/cmd_setup_test.go
+++ b/cmd/world/internal/controllers/cmd_setup/cmd_setup_test.go
@@ -59,7 +59,7 @@ func TestSetupCommandSuite(t *testing.T) {
 
 // TestLoginScenarios tests various login scenarios.
 func (s *SetupCommandSuite) TestLoginScenarios() {
-	s.T().Parallel()
+	// s.T().Parallel()
 
 	testCases := []struct {
 		name           string
@@ -161,7 +161,7 @@ func (s *SetupCommandSuite) TestLoginScenarios() {
 
 // TestHandleOrganizationInvitationsAcceptInvitation tests accepting organization invitations.
 func (s *SetupCommandSuite) TestHandleOrganizationInvitationsAcceptInvitation() {
-	s.T().Parallel()
+	// s.T().Parallel()
 	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := s.createTestController()
 	ctx := context.Background()
 
@@ -311,7 +311,7 @@ func (s *SetupCommandSuite) TestRepoLookupSuccess() {
 
 // TestRepoLookupNotLoggedIn tests repository lookup when user is not logged in.
 func (s *SetupCommandSuite) TestRepoLookupNotLoggedIn() {
-	s.T().Parallel()
+	// s.T().Parallel()
 	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := s.createTestController()
 	ctx := context.Background()
 
@@ -343,7 +343,7 @@ func (s *SetupCommandSuite) TestRepoLookupNotLoggedIn() {
 
 // TestNeedOrgDataNoOrgsCreateNew tests creating a new organization when none exist.
 func (s *SetupCommandSuite) TestNeedOrgDataNoOrgsCreateNew() {
-	s.T().Parallel()
+	// s.T().Parallel()
 	controller, mockAPI, mockConfig, mockInput, mockRepo, mockOrgHandler, mockProjectHandler := s.createTestController()
 	ctx := context.Background()
 
@@ -777,7 +777,7 @@ func (s *SetupCommandSuite) TestRepoLookupNewProjectDiscovered() {
 
 // TestOrganizationInvitationScenarios tests organization invitation handling.
 func (s *SetupCommandSuite) TestOrganizationInvitationScenarios() {
-	s.T().Parallel()
+	// s.T().Parallel()
 
 	testCases := []struct {
 		name         string
@@ -852,7 +852,7 @@ func (s *SetupCommandSuite) TestOrganizationInvitationScenarios() {
 
 // TestOrganizationDataScenarios tests organization data handling scenarios.
 func (s *SetupCommandSuite) TestOrganizationDataScenarios() {
-	s.T().Parallel()
+	// s.T().Parallel()
 
 	testCases := []struct {
 		name          string
@@ -1004,7 +1004,7 @@ func (s *SetupCommandSuite) TestOrganizationDataScenarios() {
 
 // TestProjectDataScenarios tests project data handling scenarios.
 func (s *SetupCommandSuite) TestProjectDataScenarios() {
-	s.T().Parallel()
+	// s.T().Parallel()
 
 	testCases := []struct {
 		name              string
@@ -1199,7 +1199,7 @@ func (s *SetupCommandSuite) TestProjectDataScenarios() {
 
 // TestExistingDataScenarios tests existing data handling scenarios.
 func (s *SetupCommandSuite) TestExistingDataScenarios() {
-	s.T().Parallel()
+	// s.T().Parallel()
 
 	testCases := []struct {
 		name              string

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -153,12 +153,17 @@ func (c *Client) buildImage(ctx context.Context, dockerService service.Service) 
 	tarReader := bytes.NewReader(buf.Bytes())
 
 	sourcePath := "."
+	githubToken := os.Getenv("ARGUS_WEV2_GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, eris.New("ARGUS_WEV2_GITHUB_TOKEN is not set")
+	}
 	buildOptions := build.ImageBuildOptions{
 		Dockerfile: "Dockerfile",
 		Tags:       []string{dockerService.Image},
 		Target:     dockerService.BuildTarget,
 		BuildArgs: map[string]*string{
-			"SOURCE_PATH": &sourcePath,
+			"SOURCE_PATH":  &sourcePath,
+			"GITHUB_TOKEN": &githubToken,
 		},
 	}
 

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -232,7 +232,7 @@ func (c *Client) addFileToTarWriter(baseDir string, tw *tar.Writer) error {
 	})
 }
 
-// addSSHKeysToTarWriter adds SSH keys to the tar archive if they exist
+// addSSHKeysToTarWriter adds SSH keys to the tar archive if they exist.
 func (c *Client) addSSHKeysToTarWriter(tw *tar.Writer) error {
 	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
 
@@ -249,7 +249,9 @@ func (c *Client) addSSHKeysToTarWriter(tw *tar.Writer) error {
 		}
 
 		// Skip directories and non-key files
-		if info.IsDir() || !strings.HasSuffix(info.Name(), ".pub") && !strings.HasSuffix(info.Name(), "id_rsa") && !strings.HasSuffix(info.Name(), "id_ed25519") {
+		if info.IsDir() ||
+			!strings.HasSuffix(info.Name(), ".pub") && !strings.HasSuffix(info.Name(), "id_rsa") &&
+				!strings.HasSuffix(info.Name(), "id_ed25519") {
 			return nil
 		}
 

--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -144,13 +144,22 @@ func (c *Client) buildImage(ctx context.Context, dockerService service.Service) 
 		return nil, eris.Wrap(err, "Failed to add source code to tar writer")
 	}
 
+	// Add SSH keys if they exist
+	if err := c.addSSHKeysToTarWriter(tw); err != nil {
+		return nil, eris.Wrap(err, "Failed to add SSH keys to tar writer")
+	}
+
 	// Read the tar archive
 	tarReader := bytes.NewReader(buf.Bytes())
 
+	sourcePath := "."
 	buildOptions := build.ImageBuildOptions{
 		Dockerfile: "Dockerfile",
 		Tags:       []string{dockerService.Image},
 		Target:     dockerService.BuildTarget,
+		BuildArgs: map[string]*string{
+			"SOURCE_PATH": &sourcePath,
+		},
 	}
 
 	if service.BuildkitSupport {
@@ -178,9 +187,10 @@ func (c *Client) addFileToTarWriter(baseDir string, tw *tar.Writer) error {
 		if err != nil {
 			return eris.Wrapf(err, "Failed to get relative path %s", path)
 		}
-		// Skip files that are not world.toml or inside the cardinal directory
-		if info.Name() != "world.toml" && !strings.HasPrefix(filepath.ToSlash(relPath), "cardinal/") {
-			return nil
+
+		// Skip .git directory and all files inside it
+		if info.Name() == ".git" {
+			return filepath.SkipDir
 		}
 
 		// Create a tar header for the file or directory
@@ -211,6 +221,62 @@ func (c *Client) addFileToTarWriter(baseDir string, tw *tar.Writer) error {
 
 		if _, err := io.Copy(tw, file); err != nil {
 			return eris.Wrap(err, "Failed to copy file to tar writer")
+		}
+
+		return nil
+	})
+}
+
+// addSSHKeysToTarWriter adds SSH keys to the tar archive if they exist
+func (c *Client) addSSHKeysToTarWriter(tw *tar.Writer) error {
+	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
+
+	// Check if SSH directory exists
+	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
+		// SSH directory doesn't exist, skip
+		return nil
+	}
+
+	// Add SSH keys to the tar archive
+	return filepath.Walk(sshDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return eris.Wrapf(err, "Failed to walk SSH directory %s", sshDir)
+		}
+
+		// Skip directories and non-key files
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".pub") && !strings.HasSuffix(info.Name(), "id_rsa") && !strings.HasSuffix(info.Name(), "id_ed25519") {
+			return nil
+		}
+
+		// Get relative path from SSH directory
+		relPath, err := filepath.Rel(sshDir, path)
+		if err != nil {
+			return eris.Wrapf(err, "Failed to get relative path %s", path)
+		}
+
+		// Create tar header
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return eris.Wrap(err, "Failed to create tar header")
+		}
+
+		// Set the name to be in the .ssh directory
+		header.Name = filepath.ToSlash(filepath.Join(".ssh", relPath))
+
+		// Write the header
+		if err := tw.WriteHeader(header); err != nil {
+			return eris.Wrap(err, "Failed to write header to tar writer")
+		}
+
+		// Write the file content
+		file, err := os.Open(path)
+		if err != nil {
+			return eris.Wrapf(err, "Failed to open SSH key file %s", path)
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(tw, file); err != nil {
+			return eris.Wrap(err, "Failed to copy SSH key to tar writer")
 		}
 
 		return nil

--- a/common/docker/client_internal_test.go
+++ b/common/docker/client_internal_test.go
@@ -211,6 +211,11 @@ func TestStartUndetach(t *testing.T) {
 func TestBuild(t *testing.T) {
 	t.Parallel()
 
+	// Skip test if GitHub token is not available
+	if os.Getenv("ARGUS_WEV2_GITHUB_TOKEN") == "" {
+		t.Skip("Skipping build test - ARGUS_WEV2_GITHUB_TOKEN not set")
+	}
+
 	namespace := getUniqueNamespace(t)
 
 	// Create a temporary directory

--- a/common/docker/client_util.go
+++ b/common/docker/client_util.go
@@ -32,7 +32,7 @@ func checkBuildkitSupport(cli *client.Client) bool {
 		return false
 	}
 
-	// Check if DOCKER_BUILDKIT environment variable is set to 1
+	// Always return true to enable BuildKit (or check environment variable)
 	buildKitEnv := os.Getenv("DOCKER_BUILDKIT")
-	return buildKitEnv == "1"
+	return buildKitEnv == "1" || buildKitEnv == ""
 }

--- a/common/docker/service/cardinal.Dockerfile
+++ b/common/docker/service/cardinal.Dockerfile
@@ -11,8 +11,9 @@ WORKDIR /go/src/app
 # Set Go environment variables for private repositories
 ENV GOPRIVATE=github.com/argus-labs/*,pkg.world.dev/*
 
-# Configure git to use HTTPS with GitHub token if provided, otherwise use SSH
-RUN git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+# Configure git to use HTTPS with GitHub token
+RUN --mount=type=secret,id=github_token \
+    git config --global url."https://$(cat /run/secrets/github_token):x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
 # Copy the entire source code
 COPY /${SOURCE_PATH} ./

--- a/common/docker/service/cardinal.Dockerfile
+++ b/common/docker/service/cardinal.Dockerfile
@@ -4,38 +4,24 @@
 FROM golang:1.24 AS build
 
 ARG SOURCE_PATH
+ARG GITHUB_TOKEN
 
 WORKDIR /go/src/app
 
 # Set Go environment variables for private repositories
 ENV GOPRIVATE=github.com/argus-labs/*,pkg.world.dev/*
-ENV GOSUMDB=off
-ENV GOPROXY=direct
 
-# Configure git to use SSH for GitHub (if SSH keys are available)
-RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
-
-# Start SSH agent and add SSH key if available
-RUN mkdir -p /root/.ssh && \
-    ssh-keyscan github.com >> /root/.ssh/known_hosts && \
-    chmod 600 /root/.ssh/known_hosts
-
-# Copy SSH keys if they exist
-COPY .ssh/ /root/.ssh/
-RUN chmod 600 /root/.ssh/* && \
-    chmod 644 /root/.ssh/*.pub
-
-# Copy go.mod and go.sum files first to leverage Docker layer caching
-COPY /${SOURCE_PATH}/go.mod /${SOURCE_PATH}/go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Set the GOCACHE environment variable to /root/.cache/go-build to speed up build
-ENV GOCACHE=/root/.cache/go-build
+# Configure git to use HTTPS with GitHub token if provided, otherwise use SSH
+RUN git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
 # Copy the entire source code
 COPY /${SOURCE_PATH} ./
+
+# Download dependencies
+RUN go mod tidy
+
+# Set the GOCACHE environment variable to /root/.cache/go-build to speed up build
+ENV GOCACHE=/root/.cache/go-build
 
 # Build the binary
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/app

--- a/common/docker/service/cardinal.go
+++ b/common/docker/service/cardinal.go
@@ -3,7 +3,6 @@ package service
 import (
 	_ "embed"
 	"fmt"
-	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
@@ -11,8 +10,20 @@ import (
 )
 
 const (
-	// mountCache is the Docker mount command to cache the go build cache.
-	mountCacheScript = `--mount=type=cache,target="/root/.cache/go-build"`
+// mountCache is the Docker mount command to cache the go build cache.
+// mountCacheScript = `--mount=type=cache,target="/root/.cache/go-build"`
+// mountSecret is the Docker mount command for GitHub token secret.
+// mountSecretScript = `--mount=type=secret,id=github_token`
+// gitConfigWithSecret is the git config command that uses the secret mount.
+//
+//	gitConfigWithSecret = `RUN --mount=type=secret,id=github_token \
+//	  git config --global \
+//	  url."https://$(cat /run/secrets/github_token):x-oauth-basic@github.com/".insteadOf "https://github.com/"`
+//
+// gitConfigWithEnv is the git config command that uses environment variable.
+//
+//	gitConfigWithEnv = `RUN git config --global \
+//	  url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"`
 )
 
 //nolint:gochecknoglobals // dockerfileContent is embedded at compile time and is read-only
@@ -36,7 +47,11 @@ func Cardinal(cfg *config.Config) Service {
 
 	dockerfile := dockerfileContent
 	if !BuildkitSupport {
-		dockerfile = strings.ReplaceAll(dockerfile, mountCacheScript, "")
+		// dockerfile = strings.ReplaceAll(dockerfile, mountCacheScript, "")
+		// dockerfile = strings.ReplaceAll(dockerfile, gitConfigWithSecret, gitConfigWithEnv)
+		// (not recommended) uncomment the lines above and comment out the panic if you want to support insecure builds
+		// without BuildKit. Insecure because this embeds the GitHub token value in the image layers
+		panic("BuildKit is required to build the Cardinal image. Please enable BuildKit in your Docker configuration.")
 	}
 
 	// Set env variables


### PR DESCRIPTION
Closes: DEVP-221

This is a workaround to be able to build WEv2 projects from World CLI using the `world build` command. It uses a new ARGUS_WEV2_GITHUB_TOKEN environment variable to be able to pull from the go-ecs private repo for dependencies, which is not a long term solution. 

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

<!-- greptile_comment -->

## Greptile Summary

Implements a temporary workaround for building WE V2 projects via World CLI by adding GitHub token authentication and modifying build processes.

- Modified `common/docker/client_image.go` to support private repo access by adding SSH keys and GitHub token handling
- Updated `common/docker/service/cardinal.Dockerfile` to use GitHub token auth and removed debug build stage
- Changed `cmd/world/cardinal/build.go` to create default config when none exists, with infinite build timeout
- Disabled parallel test execution in `cmd_setup_test.go` to prevent race conditions
- Security concern: SSH keys are being copied into Docker build context, which requires careful handling



<!-- /greptile_comment -->