### PR TITLE
fix: linter error

### DIFF
--- a/common/docker/client_image.go
+++ b/common/docker/client_image.go
@@ -440,8 +440,8 @@ func (c *Client) parseNonBuildkitResp(decoder *json.Decoder, stop *bool) (string
 
 	// Check for error details
 	if errorDetail, ok := event["errorDetail"]; ok {
-		if errorDetailMap, ok := errorDetail.(map[string]interface{}); ok { //nolint:govet
-			if message, ok := errorDetailMap["message"]; ok && message != "" { //nolint:govet
+		if errorDetailMap, ok2 := errorDetail.(map[string]interface{}); ok2 {
+			if message, ok3 := errorDetailMap["message"]; ok3 && message != "" {
 				return "", eris.New(message.(string))
 			}
 		}


### PR DESCRIPTION
Fix linter error

<!-- greptile_comment -->

## Greptile Summary

Updates variable naming in `common/docker/client_image.go` to fix linter errors by renaming duplicate 'ok' variables in type assertions within the parseNonBuildkitResp function.

- Improved code clarity by using distinct variable names (ok2, ok3) instead of reusing 'ok' for multiple type assertions in error handling flow
- Change maintains existing functionality while addressing linter warnings for Docker build output processing



<!-- /greptile_comment -->